### PR TITLE
Borro label irrelevante

### DIFF
--- a/src/components/viewpage/share/LinkShare.tsx
+++ b/src/components/viewpage/share/LinkShare.tsx
@@ -39,7 +39,6 @@ export class LinkShare extends React.Component<ILinkShareProps, ILinkShareState>
                         </span>
                     </span>
                 </CopyToClipboard>
-                <span className="legend">Guarda este link para automatizar la búsqueda</span>
                 <ReactTooltip effect="solid" getContent={this.copyMessage}/>
             </span>
         )


### PR DESCRIPTION
fix #58 

Borro el label que dice "Guarde el enlace para compartir" ya que no tiene sentido.