### PR TITLE
Borro label como primer ítem de los resultados

### DIFF
--- a/src/components/common/searchbox/SearchBox.tsx
+++ b/src/components/common/searchbox/SearchBox.tsx
@@ -98,19 +98,9 @@ class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
     }
 
     private renderItem(item: SearchResult, isHighlighted: boolean) {
-        if (this.state.autoCompleteItems[0].id === item.id) {
-            return (
-                <div>
-                    <div style={{marginBottom: '10px'}}>Datasets más relevantes a tu búsqueda:</div>
-
-                    <AutoCompleteItem key={item.id} item={item} isHighlighted={isHighlighted} />
-                </div>
-            )
-        } else {
-            return (
-                <AutoCompleteItem key={item.id} item={item} isHighlighted={isHighlighted} />
-            );
-        }
+        return (
+            <AutoCompleteItem key={item.id} item={item} isHighlighted={isHighlighted} />
+        );
     }
 }
 


### PR DESCRIPTION
fix #100

Antes al buscar, salía como primer ítem un label que decía "Resultados de la búsqueda". Ahora eso ya no está ya que lo agregué por un mal entendido.
Lo borré tanto de la home como de la vista de ids.