### PR TITLE
Agrego label 'Publicador:' a serie card

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1279,7 +1279,7 @@ footer .series-card .card-title,
 header .series-card .card-section,
 section .series-card .card-section,
 aside .series-card .card-section,
-footer .series-card .card-section {
+footer .series-card .card-section, .card-source {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1292,14 +1292,14 @@ footer .series-card .card-section,
 header .series-card .card-count,
 section .series-card .card-count,
 aside .series-card .card-count,
-footer .series-card .card-count {
+footer .series-card .card-count, .card-source {
   display: block;
   font-size: 12px;
 }
 header .series-card .card-section,
 section .series-card .card-section,
 aside .series-card .card-section,
-footer .series-card .card-section {
+footer .series-card .card-section, .card-source {
   color: #999999;
 }
 header .series-card .card-count,
@@ -3716,3 +3716,13 @@ FLEX:
 }
 
 /* Fin contenido react-datepicker.css */
+
+span.card-section {
+  white-space: normal !important;
+  -webkit-line-clamp: 2 !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  display: -webkit-box !important;
+  /* -webkit-line-clamp: 3 !important; */
+  -webkit-box-orient: vertical !important;
+}

--- a/src/components/style/Card/CardSource.tsx
+++ b/src/components/style/Card/CardSource.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export default (props: React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>) =>
+
+    <span className="card-source" {...props}/>

--- a/src/components/style/Card/Serie/SerieCard.tsx
+++ b/src/components/style/Card/Serie/SerieCard.tsx
@@ -7,6 +7,7 @@ import CardSubtitle from '../CardSubtitle';
 import CardTitle from '../CardTitle';
 
 import { ISerie } from '../../../../api/Serie';
+import CardSource from "../CardSource";
 
 
 export interface ISerieCardProps extends ICardProps {
@@ -18,9 +19,8 @@ export default (props: ISerieCardProps) =>
 
     <Card title={props.serie.title} {...props}>
         <CardTitle>{props.serie.title}</CardTitle>
-        <CardSubtitle>{props.serie.publisher.name}</CardSubtitle>
+        <CardSubtitle>Publicador: {props.serie.publisher.name}</CardSubtitle>
         <CardBody>{props.serie.description}</CardBody>
-
-        <CardSubtitle>Fuente: {props.serie.datasetSource}</CardSubtitle>
+        <CardSource>Fuente: {props.serie.datasetSource}</CardSource>
         <CardFooter>{props.serie.id}</CardFooter>
     </Card>


### PR DESCRIPTION
closes #85

Agregué el label "Publicador:" el cual se puede ver en cada tarjeta, ya sea la Home o la vista de resultados de una búsqueda en el panel derecho.

Si se superan las 2 líneas, se completa con puntos suspensivos.

![serie](https://user-images.githubusercontent.com/11604761/43540285-b2a345c4-959d-11e8-93e7-71f059bde37b.png)
