### PR TITLE
Gráfico: borro opciones de descargar csv y xls porque no andan

### DIFF
--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -38,6 +38,14 @@ export class Graphic extends React.Component<IGraphicProps, any> {
                 zoomType: 'x'
             },
 
+            exporting: {
+                buttons: {
+                    contextButton: {
+                        menuItems: ['printChart', 'downloadPNG','downloadJPEG', 'downloadPDF', 'downloadSVG']
+                    },
+                }
+            },
+
             title: {
                 text: '',
             },


### PR DESCRIPTION
closes #106

Borré las opciones de exportar el gráfico como csv y xls porque no andan. Las demás quedaron igual.