### PR TITLE
Cambio la posición del botón de zoom

### DIFF
--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -35,6 +35,10 @@ export class Graphic extends React.Component<IGraphicProps, any> {
 
             chart: {
                 height: 550,
+                resetZoomButton: {
+                    position: { x: -50, y: 10 },
+                    relativeTo: 'chart'
+                },
                 zoomType: 'x'
             },
 


### PR DESCRIPTION
closes #87

Corrí el botón de _reset zoom_ un poco más al costado para que no tape el menu hamburguesa de exportación.