### PR TITLE
Fix: start_date y end_date se envían bien al server

### DIFF
--- a/src/api/QueryParams.ts
+++ b/src/api/QueryParams.ts
@@ -40,10 +40,10 @@ export default class QueryParams {
     public asJson(): {} {
         return {
             collapse: this.getCollapse(),
-            endDate: this.endDate,
+            end_date: this.endDate,
             ids: this.getIds(),
             representation_mode: this.getRepresentationMode(),
-            startDate: this.startDate
+            start_date: this.startDate
         }
     }
 


### PR DESCRIPTION
closes #164

Los parámetros `start_date` y `end_date` se enviaban en camelcase. Ahora se envían bien.