### PR TITLE
Fix para cuando recibimos más datos de los pedidos

### DIFF
--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -45,7 +45,7 @@ export class ApiClient {
     }
 
     private needToFetchMoreData(result: any[], limit: number): boolean {
-        return result.length === limit;
+        return result.length >= limit;
     }
 
     private increaseOffset(options: IApiClientOpt) {


### PR DESCRIPTION
closes #163

A veces recibimos más datos de los pedidos. El chequeo para saber si hay que ir a buscar más datos al server (si es que tenemos más datos por mostrar) compara preguntando si la cantidad recibida es igual al límite. Es decir, si pedí 10 datos y recibí 10, es probable que hayan más. 
Si por algún motivo recibimos más datos (el explorer es ajeno a esto), el chequeo da _false_ y no se vuelven a pedir más datos, y de este modo, no logramos mostrar todo.
El fix fue preguntar si los datos recibimos son iguales _o más_ que los pedidos. Si es así, vamos a buscar la segunda página.