### PR TITLE
Fix parametro 'theme'

### DIFF
--- a/src/api/ITSAPIResponse.ts
+++ b/src/api/ITSAPIResponse.ts
@@ -35,13 +35,19 @@ export interface ICatalog {
     identifier: string;
 }
 
+export interface IDataSetTheme {
+    id: string;
+    descripcion: string;
+    label: string;
+}
+
 export interface IDataSet {
     publisher: IPublisher;
     title: string;
     source: string;
     identifier: string;
     landingPage: string;
-    theme: string[];
+    theme: IDataSetTheme[];
     accrualPeriodicity: string;
 }
 

--- a/src/api/Serie.ts
+++ b/src/api/Serie.ts
@@ -1,5 +1,5 @@
 import DataPoint, { IDataPoint } from './DataPoint';
-import {IExtraMeta, IPublisher, ITSAPIResponse, ITSMeta} from './ITSAPIResponse'
+import {IDataSetTheme, IExtraMeta, IPublisher, ITSAPIResponse, ITSMeta} from './ITSAPIResponse'
 import {PeriodicityParser} from "./utils/periodicityParser";
 
 
@@ -17,7 +17,7 @@ export interface ISerie {
     landingPage: string,
     issued: string,
     modified: string,
-    themes: string[],
+    themes: IDataSetTheme[],
     frequency?: string,
 }
 

--- a/src/components/style/Details/SerieDetails.tsx
+++ b/src/components/style/Details/SerieDetails.tsx
@@ -29,7 +29,7 @@ export default (props: ISerieDetailsProp) =>
             <div className="col-md-12">
                 <dl className="dl-horizontal">
                     <dt>Temas</dt>
-                    <dd>{props.serie.themes.join(', ')}</dd>
+                    <dd>{props.serie.themes.map((theme) => theme.label)}</dd>
                 </dl>
                 <dl className="dl-horizontal">
                     <dt>Frecuencia de actualización</dt>

--- a/src/components/style/Details/SerieDetails.tsx
+++ b/src/components/style/Details/SerieDetails.tsx
@@ -29,7 +29,7 @@ export default (props: ISerieDetailsProp) =>
             <div className="col-md-12">
                 <dl className="dl-horizontal">
                     <dt>Temas</dt>
-                    <dd>{props.serie.themes.map((theme) => theme.label)}</dd>
+                    <dd>{props.serie.themes.map((theme) => theme.label).join(', ')}</dd>
                 </dl>
                 <dl className="dl-horizontal">
                     <dt>Frecuencia de actualización</dt>

--- a/src/tests/api/mockApi.ts
+++ b/src/tests/api/mockApi.ts
@@ -90,7 +90,7 @@ function toSerie(id: string): ISerie {
         landingPage: `${id} landingPage`,
         modified: `2018-01-01`,
         startDate: 'start',
-        themes: [`${id} theme`],
+        themes: [{id: `${id} theme`, label: `${id} theme`, descripcion: `${id} theme`}],
     };
 
     return self;

--- a/src/tests/support/factories/series_api.ts
+++ b/src/tests/support/factories/series_api.ts
@@ -43,7 +43,7 @@ export function generateITSAPIResponse(tsIDs: string[] = ["1.1", "1.2"]): ITSAPI
                         name: `${tsID} dataset publisher name`
                     },
                     source: `${tsID} dataset source`,
-                    theme: [`${tsID} dataset theme`],
+                    theme: [{id: `${tsID} theme`, label: `${tsID} theme`, descripcion: `${tsID} theme`}],
                     title: `${tsID} dataset title`,
                 },
                 distribution: {


### PR DESCRIPTION
closes #181

Al parecer cambió la respuesta de la API y en la vista al usuario se mostraba `[Object Object]`. Ahora se muestra el valor correcto de vuelta.