### PR TITLE
Reset zoom reinicia el gráfico con 1 sólo click

### DIFF
--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -268,6 +268,7 @@ export class ViewPage extends React.Component<IViewPageProps, any> {
         params.delete('start_date');
         params.delete('end_date');
         this.setQueryParams(params);
+        this.props.dispatch(setDate({ start: '', end: '' }));
     }
 
 }


### PR DESCRIPTION
Closes #176

Ya no hay que clickear 2 veces en _reset zoom_ para que el gráfico muestre la serie completa.