### PR TITLE
195 add loading msg

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1,3 +1,131 @@
+.loading-spinner {
+  background-color: transparent;
+  display: inline-block;
+  margin: 0 auto;
+  left: 50%;
+}
+
+.sk-circle {
+  width: 40px;
+  height: 40px;
+  position: relative;
+}
+.sk-circle .sk-child {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+.sk-circle .sk-child:before {
+  content: '';
+  display: block;
+  margin: 0 auto;
+  width: 15%;
+  height: 15%;
+  background-color: #333;
+  border-radius: 100%;
+  -webkit-animation: sk-circleBounceDelay 1.2s infinite ease-in-out both;
+  animation: sk-circleBounceDelay 1.2s infinite ease-in-out both;
+}
+.sk-circle .sk-circle2 {
+  -webkit-transform: rotate(30deg);
+  -ms-transform: rotate(30deg);
+  transform: rotate(30deg); }
+.sk-circle .sk-circle3 {
+  -webkit-transform: rotate(60deg);
+  -ms-transform: rotate(60deg);
+  transform: rotate(60deg); }
+.sk-circle .sk-circle4 {
+  -webkit-transform: rotate(90deg);
+  -ms-transform: rotate(90deg);
+  transform: rotate(90deg); }
+.sk-circle .sk-circle5 {
+  -webkit-transform: rotate(120deg);
+  -ms-transform: rotate(120deg);
+  transform: rotate(120deg); }
+.sk-circle .sk-circle6 {
+  -webkit-transform: rotate(150deg);
+  -ms-transform: rotate(150deg);
+  transform: rotate(150deg); }
+.sk-circle .sk-circle7 {
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg); }
+.sk-circle .sk-circle8 {
+  -webkit-transform: rotate(210deg);
+  -ms-transform: rotate(210deg);
+  transform: rotate(210deg); }
+.sk-circle .sk-circle9 {
+  -webkit-transform: rotate(240deg);
+  -ms-transform: rotate(240deg);
+  transform: rotate(240deg); }
+.sk-circle .sk-circle10 {
+  -webkit-transform: rotate(270deg);
+  -ms-transform: rotate(270deg);
+  transform: rotate(270deg); }
+.sk-circle .sk-circle11 {
+  -webkit-transform: rotate(300deg);
+  -ms-transform: rotate(300deg);
+  transform: rotate(300deg); }
+.sk-circle .sk-circle12 {
+  -webkit-transform: rotate(330deg);
+  -ms-transform: rotate(330deg);
+  transform: rotate(330deg); }
+.sk-circle .sk-circle2:before {
+  -webkit-animation-delay: -1.1s;
+  animation-delay: -1.1s; }
+.sk-circle .sk-circle3:before {
+  -webkit-animation-delay: -1s;
+  animation-delay: -1s; }
+.sk-circle .sk-circle4:before {
+  -webkit-animation-delay: -0.9s;
+  animation-delay: -0.9s; }
+.sk-circle .sk-circle5:before {
+  -webkit-animation-delay: -0.8s;
+  animation-delay: -0.8s; }
+.sk-circle .sk-circle6:before {
+  -webkit-animation-delay: -0.7s;
+  animation-delay: -0.7s; }
+.sk-circle .sk-circle7:before {
+  -webkit-animation-delay: -0.6s;
+  animation-delay: -0.6s; }
+.sk-circle .sk-circle8:before {
+  -webkit-animation-delay: -0.5s;
+  animation-delay: -0.5s; }
+.sk-circle .sk-circle9:before {
+  -webkit-animation-delay: -0.4s;
+  animation-delay: -0.4s; }
+.sk-circle .sk-circle10:before {
+  -webkit-animation-delay: -0.3s;
+  animation-delay: -0.3s; }
+.sk-circle .sk-circle11:before {
+  -webkit-animation-delay: -0.2s;
+  animation-delay: -0.2s; }
+.sk-circle .sk-circle12:before {
+  -webkit-animation-delay: -0.1s;
+  animation-delay: -0.1s; }
+
+@-webkit-keyframes sk-circleBounceDelay {
+  0%, 80%, 100% {
+    -webkit-transform: scale(0);
+    transform: scale(0);
+  } 40% {
+      -webkit-transform: scale(1);
+      transform: scale(1);
+    }
+}
+
+@keyframes sk-circleBounceDelay {
+  0%, 80%, 100% {
+    -webkit-transform: scale(0);
+    transform: scale(0);
+  } 40% {
+      -webkit-transform: scale(1);
+      transform: scale(1);
+    }
+}
+
 .highcharts-range-selector:focus {
   top: 75px !important;
   width: 95px !important;

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+
+export default (props: any) =>
+    <div className="sk-circle loading-spinner">
+        <div className="sk-circle1 sk-child" />
+        <div className="sk-circle2 sk-child" />
+        <div className="sk-circle3 sk-child" />
+        <div className="sk-circle4 sk-child" />
+        <div className="sk-circle5 sk-child" />
+        <div className="sk-circle6 sk-child" />
+        <div className="sk-circle7 sk-child" />
+        <div className="sk-circle8 sk-child" />
+        <div className="sk-circle9 sk-child" />
+        <div className="sk-circle10 sk-child" />
+        <div className="sk-circle11 sk-child" />
+        <div className="sk-circle12 sk-child" />
+    </div>

--- a/src/components/common/searchbox/SearchBox.tsx
+++ b/src/components/common/searchbox/SearchBox.tsx
@@ -106,7 +106,7 @@ class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
 
     private renderSearch(item: SearchResult, isHighlighted: boolean) {
         if (this.state.searchTerm !== "" && this.state.loading) {
-            return <LoadingSpinner />
+            return <div key={this.state.searchTerm}><LoadingSpinner /></div>
         } else {
             const onClick = () => this.props.onSearch(this.state.searchTerm);
             return (<div id={item.id} key={item.id} onClick={onClick} className={isHighlighted ? 'highlight-item pointer' : 'pointer'}>{item.title}</div>)

--- a/src/components/common/searchbox/SearchBox.tsx
+++ b/src/components/common/searchbox/SearchBox.tsx
@@ -4,13 +4,13 @@ const debounce = require('debounce');
 import * as React from 'react';
 
 import { ISearchResponse } from "../../../api/ITSAPIResponse";
+import SearchResult from '../../../api/SearchResult';
+import { ISerieApi } from '../../../api/SerieApi';
 import AutoComplete from '../../style/Common/AutoComplete';
 import AutoCompleteItem from '../../style/Common/AutoCompleteItem';
 import SearchIcon from '../../style/Common/SearchIcon';
 import HeroFormSearch from '../../style/Hero/HeroFormSearch';
-
-import SearchResult from '../../../api/SearchResult';
-import { ISerieApi } from '../../../api/SerieApi';
+import LoadingSpinner from "../LoadingSpinner";
 
 
 interface ISearchBoxProps {
@@ -22,19 +22,19 @@ interface ISearchBoxProps {
 }
 
 interface ISearchBoxState {
-
     searchTerm: string;
     autoCompleteItems: SearchResult[];
+    loading: boolean;
 }
 
 class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
-
 
     constructor(props: ISearchBoxProps) {
         super(props);
 
         this.state = {
             autoCompleteItems: [],
+            loading: false,
             searchTerm: this.props.searchTerm || "",
         };
 
@@ -46,7 +46,6 @@ class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
     }
 
     public componentDidUpdate(prevProps: ISearchBoxProps) {
-
         if (this.props.searchTerm && (this.props.searchTerm !== prevProps.searchTerm)) {
             this.setState({
                 searchTerm: this.props.searchTerm
@@ -59,14 +58,14 @@ class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
             this.props.seriesApi
                 .searchSeries(searchTerm, {offset: 0, limit: 10})
                 .then((response: ISearchResponse) => {
-                    this.setState({ autoCompleteItems:  response.result})
+                    this.setState({ autoCompleteItems:  response.result, loading: false })
                 });
         }
     }
 
     public onSearchTermChange(event: any) {
         const searchTerm: string = event.target.value;
-        this.setState({ searchTerm });
+        this.setState({ searchTerm, loading: true });
 
         this.updateAutoCompleteItems(searchTerm);
     }
@@ -106,9 +105,12 @@ class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
     }
 
     private renderSearch(item: SearchResult, isHighlighted: boolean) {
-        const onClick = () => this.props.onSearch(this.state.searchTerm);
-
-        return (<div id={item.id} key={item.id} onClick={onClick} className={isHighlighted ? 'highlight-item pointer' : 'pointer'}>{item.title}</div>)
+        if (this.state.searchTerm !== "" && this.state.loading) {
+            return <LoadingSpinner />
+        } else {
+            const onClick = () => this.props.onSearch(this.state.searchTerm);
+            return (<div id={item.id} key={item.id} onClick={onClick} className={isHighlighted ? 'highlight-item pointer' : 'pointer'}>{item.title}</div>)
+        }
     }
 
     private renderItemResult(item: SearchResult, isHighlighted: boolean) {

--- a/src/components/common/searcher/Searcher.tsx
+++ b/src/components/common/searcher/Searcher.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import {ISearchResponse} from "../../../api/ITSAPIResponse";
 import SearchResult from "../../../api/SearchResult";
 import {ISearchOptions, ISerieApi} from "../../../api/SerieApi";
+import LoadingSpinner from "../LoadingSpinner";
 import InitialSearcher from "./InitialSearcher";
 import SearcherResults from "./SearcherResults";
 
@@ -26,6 +27,7 @@ interface ISearcherState {
     currentPage: number;
     result: SearchResult[];
     searched: boolean;
+    loading: boolean;
 }
 
 export default class Searcher extends React.Component<ISearcherProps, ISearcherState> {
@@ -36,6 +38,7 @@ export default class Searcher extends React.Component<ISearcherProps, ISearcherS
         this.state = {
             count: 0,
             currentPage: 0,
+            loading: false,
             result: [],
             searched: false
         };
@@ -97,17 +100,21 @@ export default class Searcher extends React.Component<ISearcherProps, ISearcherS
                         </SearcherResults>
         }
 
+        if (this.state.loading) { component = <LoadingSpinner />; }
+
         return component;
     }
 
     private performSearch(q: string, options?: ISearchOptions) {
+        this.setState({loading: true});
         this.props.seriesApi.searchSeries(q, options)
             .then((responseResult: ISearchResponse) => {
                 this.setState({
                     count: responseResult.count,
+                    loading: false,
                     result: responseResult.result,
                     searched: true
-                });
+                })
             }).catch(alert);
     }
 


### PR DESCRIPTION
Closes #195 

Agregué un spinner en los inputs de búsqueda para indicar que se está procesando.
Con @abenassi quedamos en mostrar un mensaje "Cargando..." pero creo que eso fue solo un ejemplo. Al agregar un spinner me parece que aproveché los espacios de la pantalla.
Adjunto un gif de cómo funciona (se ve un poco lento en el gif pero es sólamente el gif, en real time anda bien).

Aclaración: En la pantalla principal donde aparece "Series destacadas" no lo agregué porque ahí no hay demora en la búsqueda de datos. Esa pantalla se muestra cuando ya se cargaron los datos, por lo tanto mostrar un spinner ahí no tiene sentido, ya que no debería haber demora en la búsqueda de datos. La demora va a ser la misma que demore en cargar el propio html.

![peek 2018-09-17 14-50](https://user-images.githubusercontent.com/11604761/45640480-2c38b580-ba89-11e8-9d7a-9345a765e195.gif)
