### PR TITLE
201 search all metadata

### DIFF
--- a/src/api/SerieApi.ts
+++ b/src/api/SerieApi.ts
@@ -96,6 +96,7 @@ export default class SerieApi implements ISerieApi {
         const dataset_source = searchOptions && searchOptions.datasetSource ? searchOptions.datasetSource : undefined;
         // tslint:disable-next-line:variable-name
         const dataset_theme = searchOptions && searchOptions.datasetTheme ? searchOptions.datasetTheme : undefined;
+        const query = q ? q : null;
 
         const options = {
             qs: {
@@ -103,7 +104,7 @@ export default class SerieApi implements ISerieApi {
                 dataset_source,
                 dataset_theme,
                 limit,
-                q,
+                q: query,
                 start,
             },
             uri: this.apiClient.endpoint('search'),

--- a/src/components/common/searchbox/SearchBox.tsx
+++ b/src/components/common/searchbox/SearchBox.tsx
@@ -105,7 +105,7 @@ class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
 
     private renderSearch(item: SearchResult, isHighlighted: boolean) {
         if (this.state.searchTerm !== "" && this.state.loading) {
-            return <div key={this.state.searchTerm || 'all-values'}><LoadingSpinner /></div>
+            return <div key={this.state.searchTerm}><LoadingSpinner /></div>
         } else {
             const onClick = () => this.props.onSearch(this.state.searchTerm);
             return (<div id={item.id} key={item.id} onClick={onClick} className={isHighlighted ? 'highlight-item pointer' : 'pointer'}>{item.title}</div>)

--- a/src/components/common/searchbox/SearchBox.tsx
+++ b/src/components/common/searchbox/SearchBox.tsx
@@ -14,7 +14,6 @@ import LoadingSpinner from "../LoadingSpinner";
 
 
 interface ISearchBoxProps {
-
     onSelect: (serieId: string) => void;
     onSearch: (searchTerm: string) => void;
     searchTerm?: string;
@@ -35,7 +34,7 @@ class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
         this.state = {
             autoCompleteItems: [],
             loading: false,
-            searchTerm: this.props.searchTerm || "",
+            searchTerm: this.props.searchTerm || ''
         };
 
         this.onSearchTermChange = this.onSearchTermChange.bind(this);
@@ -46,9 +45,9 @@ class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
     }
 
     public componentDidUpdate(prevProps: ISearchBoxProps) {
-        if (this.props.searchTerm && (this.props.searchTerm !== prevProps.searchTerm)) {
+        if (this.props.searchTerm !== prevProps.searchTerm) {
             this.setState({
-                searchTerm: this.props.searchTerm
+                searchTerm: this.props.searchTerm || ''
             });
         }
     }
@@ -106,7 +105,7 @@ class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
 
     private renderSearch(item: SearchResult, isHighlighted: boolean) {
         if (this.state.searchTerm !== "" && this.state.loading) {
-            return <div key={this.state.searchTerm}><LoadingSpinner /></div>
+            return <div key={this.state.searchTerm || 'all-values'}><LoadingSpinner /></div>
         } else {
             const onClick = () => this.props.onSearch(this.state.searchTerm);
             return (<div id={item.id} key={item.id} onClick={onClick} className={isHighlighted ? 'highlight-item pointer' : 'pointer'}>{item.title}</div>)

--- a/src/components/common/searcher/Searcher.tsx
+++ b/src/components/common/searcher/Searcher.tsx
@@ -52,10 +52,6 @@ export default class Searcher extends React.Component<ISearcherProps, ISearcherS
         }
     }
 
-    public componentDidMount() {
-        this.performSearch(this.props.q, this.searchOptions());
-    }
-
     public componentDidUpdate(prevProps: ISearcherProps) {
         window.scrollTo(0, 0);
 

--- a/src/components/common/searcher/Searcher.tsx
+++ b/src/components/common/searcher/Searcher.tsx
@@ -9,7 +9,6 @@ import SearcherResults from "./SearcherResults";
 
 
 export interface ISearchParams {
-
     datasetSource: string;
     datasetTheme: string;
     limit: number;
@@ -54,11 +53,6 @@ export default class Searcher extends React.Component<ISearcherProps, ISearcherS
     }
 
     public componentDidMount() {
-
-        if (!this.props.q) {
-            return;
-        }
-
         this.performSearch(this.props.q, this.searchOptions());
     }
 
@@ -69,13 +63,7 @@ export default class Searcher extends React.Component<ISearcherProps, ISearcherS
             this.setState({ currentPage: 0 });
         }
 
-        if (this.props.q &&
-            (prevProps.q !== this.props.q ||
-                prevProps.datasetTheme !== this.props.datasetTheme ||
-                prevProps.datasetSource !== this.props.datasetSource ||
-                prevProps.offset !== this.props.offset ||
-                prevProps.limit !== this.props.limit
-            )) {
+        if (queryChanged(prevProps, this.props)) {
             this.performSearch(this.props.q, this.searchOptions());
         }
     }
@@ -132,4 +120,13 @@ export default class Searcher extends React.Component<ISearcherProps, ISearcherS
     private clearResults() {
         this.setState({result: []});
     }
+}
+
+
+function queryChanged(prevQuery: ISearcherProps, newQuery: ISearcherProps): boolean {
+    return prevQuery.q              !== newQuery.q ||
+            prevQuery.datasetTheme  !== newQuery.datasetTheme ||
+            prevQuery.datasetSource !== newQuery.datasetSource ||
+            prevQuery.offset        !== newQuery.offset ||
+            prevQuery.limit         !== newQuery.limit
 }

--- a/src/components/searchpage/SearchPage.tsx
+++ b/src/components/searchpage/SearchPage.tsx
@@ -45,7 +45,6 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
     }
 
     public componentDidMount() {
-
         this.unListen = this.props.history.listen(location => {
             this.updateSearchParams(location)
         });
@@ -70,20 +69,12 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
     public getUriSearchParams(location: Location): ISearchParams | undefined {
         const search: string = location.search; // could be '?foo=bar'
         const params: URLSearchParams = URLSearchParams(search);
-        const q: string | null = params.get('q');
-
-        if (!q) {
-            return;
-        }
-
+        const q: string = params.get('q') || '';
         const offsetString: string | null = params.get('offset');
         const limitString: string | null = params.get('limit');
-
         const offset = offsetString ? parseInt(offsetString, 10) : initialState.searchParams.offset;
         const limit: number = limitString ? parseInt(limitString, 10) : initialState.searchParams.limit;
-
         const datasetSource = params.get('dataset_source') || "";
-
         const datasetTheme = params.get('dataset_theme') || "";
 
         return ({
@@ -108,11 +99,11 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
     }
 
     public sourceRemoved(event: React.MouseEvent<HTMLButtonElement>): void {
-        event.stopPropagation()
+        event.stopPropagation();
 
         let oldSearchParams: ISearchParams | undefined;
 
-        oldSearchParams = this.getUriSearchParams(this.props.location)
+        oldSearchParams = this.getUriSearchParams(this.props.location);
 
         if (oldSearchParams) {
             this.updateUriParams(oldSearchParams.q, "", oldSearchParams.datasetTheme, oldSearchParams.offset, oldSearchParams.limit);
@@ -123,7 +114,7 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
 
         let oldSearchParams: ISearchParams | undefined;
 
-        oldSearchParams = this.getUriSearchParams(this.props.location)
+        oldSearchParams = this.getUriSearchParams(this.props.location);
 
         if (oldSearchParams) {
             this.updateUriParams(oldSearchParams.q, newDatasetSource, oldSearchParams.datasetTheme, oldSearchParams.offset, oldSearchParams.limit);
@@ -135,7 +126,7 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
 
         let oldSearchParams: ISearchParams | undefined;
 
-        oldSearchParams = this.getUriSearchParams(this.props.location)
+        oldSearchParams = this.getUriSearchParams(this.props.location);
 
         if (oldSearchParams) {
             this.updateUriParams(oldSearchParams.q, oldSearchParams.datasetSource, "", oldSearchParams.offset, oldSearchParams.limit);
@@ -185,18 +176,13 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
 
     public render() {
         return (
-
             <section id="listado">
-
                 <SeriesHero compact={true} searchBox={<SearchBox seriesApi={this.props.seriesApi} onSearch={this.searchTermPicked} onSelect={this.redirectToViewPage} />} />
-
                 <div id="listado-list">
                     <Container>
                         <Row>
                             <div className="col-sm-4">
-
                                 <SeriesFilters selector={Selector} seriesApi={this.props.seriesApi} onSourcePicked={this.sourcePicked} onThemePicked={this.themePicked} />
-
                             </div>
                             <div className="col-sm-8">
                                 <div id="list" className="pd-v-lg">
@@ -205,15 +191,13 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
                                         {this.searchTags()}
                                     </div>
 
-                                    <Searcher
-                                        datasetSource={this.props.datasetSource}
-                                        datasetTheme={this.props.datasetTheme}
-                                        limit={this.props.limit}
-                                        offset={this.props.offset}
-                                        q={this.props.q}
-                                        seriesApi={this.props.seriesApi}
-                                        renderSearchResults={renderSearchResults} />
-
+                                    <Searcher datasetSource={this.props.datasetSource}
+                                              datasetTheme={this.props.datasetTheme}
+                                              limit={this.props.limit}
+                                              offset={this.props.offset}
+                                              q={this.props.q}
+                                              seriesApi={this.props.seriesApi}
+                                              renderSearchResults={renderSearchResults} />
                                 </div>
                             </div>
                         </Row>

--- a/src/tests/components/common/searcher/Searcher.test.tsx
+++ b/src/tests/components/common/searcher/Searcher.test.tsx
@@ -13,7 +13,6 @@ configure({ adapter: new Adapter() });
 
 
 describe('SeriesPicker', () => {
-
     let mockSeriesApi: ISerieApi;
     let q: string;
     let offset: number;
@@ -24,7 +23,6 @@ describe('SeriesPicker', () => {
     let renderSearchResults: any;
 
     beforeEach(() => {
-
         mockSeriesApi = new MockApi(0);
         mockSeriesApi.searchSeries = jest.fn().mockImplementation(mockSeriesApi.searchSeries);
         mockSeriesApi.fetchSeries = jest.fn().mockImplementation(mockSeriesApi.fetchSeries);
@@ -38,22 +36,19 @@ describe('SeriesPicker', () => {
         renderSearchResults = jest.fn();
     });
 
-    it('searchs upon render', () => {
-
+    it('does not search upon render', () => {
         mount(<Searcher datasetTheme={datasetTheme} datasetSource={datasetSource} seriesApi={mockSeriesApi} q={q} offset={offset} limit={limit} renderSearchResults={renderSearchResults} />);
 
-        expect(mockSeriesApi.searchSeries).toBeCalledWith(q, { datasetTheme, datasetSource, offset, limit });
+        expect(mockSeriesApi.searchSeries).not.toBeCalledWith(q, { datasetTheme, datasetSource, offset, limit });
     });
 
     it('do not queries api if q is falsy', () => {
-
         mount(<Searcher datasetTheme={datasetTheme} datasetSource={datasetSource} seriesApi={mockSeriesApi} q={""} offset={offset} limit={limit} renderSearchResults={renderSearchResults} />);
 
         expect(mockSeriesApi.searchSeries).not.toBeCalled();
     });
 
     describe('search behaviour when props change', () => {
-
         let node: any;
 
         beforeEach(() => {
@@ -68,23 +63,21 @@ describe('SeriesPicker', () => {
         });
 
         it('do not search if props dont change', () => {
-
             ReactDOM.render(
                 <Searcher datasetTheme={datasetTheme} datasetSource={datasetSource} seriesApi={mockSeriesApi} q={q} offset={offset} limit={limit} renderSearchResults={renderSearchResults} />,
                 node);
 
-            expect(mockSeriesApi.searchSeries).toHaveBeenCalledTimes(1);
+            expect(mockSeriesApi.searchSeries).toHaveBeenCalledTimes(0);
         });
 
         it('searchs again if props change', () => {
-
             q = "exportaciones";
 
             ReactDOM.render(
                 <Searcher datasetTheme={datasetTheme} datasetSource={datasetSource} seriesApi={mockSeriesApi} q={q} offset={offset} limit={limit} renderSearchResults={renderSearchResults} />,
                 node);
 
-            expect(mockSeriesApi.searchSeries).toHaveBeenCalledTimes(2);
+            expect(mockSeriesApi.searchSeries).toHaveBeenCalledTimes(1);
         });
     });
 });


### PR DESCRIPTION
Closes #201 

Ahora podemos buscar todos los metadatos. La forma es no enviar el parámetro `q`.