### PR TITLE
Ahora podemos borrar la única búsqueda

### DIFF
--- a/src/components/searchpage/SearchPage.tsx
+++ b/src/components/searchpage/SearchPage.tsx
@@ -42,6 +42,7 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
         this.themeRemoved = this.themeRemoved.bind(this);
         this.sourceRemoved = this.sourceRemoved.bind(this);
         this.redirectToViewPage = this.redirectToViewPage.bind(this);
+        this.searchTagPicked = this.searchTagPicked.bind(this);
     }
 
     public componentDidMount() {
@@ -53,9 +54,7 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
     }
 
     public updateSearchParams(location: Location) {
-        let searchParams: ISearchParams | undefined;
-
-        searchParams = this.getUriSearchParams(location);
+        const searchParams: ISearchParams | undefined = this.getUriSearchParams(location);
 
         if (searchParams) {
             this.props.dispatch(setSearchParams(searchParams));
@@ -101,9 +100,7 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
     public sourceRemoved(event: React.MouseEvent<HTMLButtonElement>): void {
         event.stopPropagation();
 
-        let oldSearchParams: ISearchParams | undefined;
-
-        oldSearchParams = this.getUriSearchParams(this.props.location);
+        const oldSearchParams: ISearchParams | undefined = this.getUriSearchParams(this.props.location);
 
         if (oldSearchParams) {
             this.updateUriParams(oldSearchParams.q, "", oldSearchParams.datasetTheme, oldSearchParams.offset, oldSearchParams.limit);
@@ -111,10 +108,7 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
     }
 
     public sourcePicked(newDatasetSource: string): void {
-
-        let oldSearchParams: ISearchParams | undefined;
-
-        oldSearchParams = this.getUriSearchParams(this.props.location);
+        const oldSearchParams: ISearchParams | undefined = this.getUriSearchParams(this.props.location);
 
         if (oldSearchParams) {
             this.updateUriParams(oldSearchParams.q, newDatasetSource, oldSearchParams.datasetTheme, oldSearchParams.offset, oldSearchParams.limit);
@@ -124,9 +118,7 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
     public themeRemoved(event: React.MouseEvent<HTMLButtonElement>): void {
         event.stopPropagation();
 
-        let oldSearchParams: ISearchParams | undefined;
-
-        oldSearchParams = this.getUriSearchParams(this.props.location);
+        const oldSearchParams: ISearchParams | undefined = this.getUriSearchParams(this.props.location);
 
         if (oldSearchParams) {
             this.updateUriParams(oldSearchParams.q, oldSearchParams.datasetSource, "", oldSearchParams.offset, oldSearchParams.limit);
@@ -134,10 +126,7 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
     }
 
     public themePicked(newTheme: string): void {
-
-        let oldSearchParams: ISearchParams | undefined;
-
-        oldSearchParams = this.getUriSearchParams(this.props.location)
+        const oldSearchParams: ISearchParams | undefined = this.getUriSearchParams(this.props.location)
 
         if (oldSearchParams) {
             this.updateUriParams(oldSearchParams.q, oldSearchParams.datasetSource, newTheme, oldSearchParams.offset, oldSearchParams.limit);
@@ -145,25 +134,28 @@ class SearchPage extends React.Component<ISearchPageProps & ISearchParams, any> 
     }
 
     public searchTermPicked(newSearchTerm: string): void {
-        let oldSearchParams: ISearchParams | undefined;
-
-        oldSearchParams = this.getUriSearchParams(this.props.location);
+        const oldSearchParams: ISearchParams | undefined = this.getUriSearchParams(this.props.location);
 
         if (oldSearchParams) {
             this.updateUriParams(newSearchTerm, oldSearchParams.datasetSource, oldSearchParams.datasetTheme, oldSearchParams.offset, oldSearchParams.limit);
         }
     }
 
+    public searchTagPicked(event: React.MouseEvent<HTMLButtonElement>): void {
+        const oldSearchParams: ISearchParams | undefined = this.getUriSearchParams(this.props.location);
+
+        if (oldSearchParams) {
+            this.updateUriParams("", oldSearchParams.datasetSource, oldSearchParams.datasetTheme, oldSearchParams.offset, oldSearchParams.limit);
+        }
+    }
+
     public searchTags(): JSX.Element[] {
         let tags: JSX.Element[] = [];
-        let searchParams: ISearchParams | undefined;
+        const searchParams: ISearchParams | undefined = this.getUriSearchParams(this.props.location);
 
-        searchParams = this.getUriSearchParams(this.props.location);
-        if (!searchParams) {
-            return tags;
-        }
+        if (!searchParams) { return tags }
 
-        tags = searchParams.q ? tags.concat(<Tag key={searchParams.q}>{searchParams.q}</Tag>) : tags;
+        tags = searchParams.q ? tags.concat(<Tag key={searchParams.q} onClose={this.searchTagPicked}>{searchParams.q}</Tag>) : tags;
         tags = searchParams.datasetTheme ? tags.concat(<Tag key={searchParams.datasetTheme} onClose={this.themeRemoved}>{searchParams.datasetTheme}</Tag>) : tags;
         tags = searchParams.datasetSource ? tags.concat(<Tag key={searchParams.datasetSource} onClose={this.sourceRemoved}>{searchParams.datasetSource}</Tag>) : tags;
 


### PR DESCRIPTION
Closes #86

Agrego la posibilidad de borrar el único término buscado. Al borrarlo, se borra el parámetro `q` y traemos todos los resultados de los metadatos.