### PR TITLE
Agregar más de una serie agrega una nueva escala

### DIFF
--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -70,7 +70,7 @@ export class Graphic extends React.Component<IGraphicProps, any> {
             chart: {
                 height: '43%',
                 resetZoomButton: {
-                    position: { x: -350, y: 5 },
+                    position: { x: -700, y: 5 },
                     relativeTo: 'chart'
                 },
                 width: 1150,
@@ -142,11 +142,7 @@ export class Graphic extends React.Component<IGraphicProps, any> {
                 }
             },
 
-            yAxis: {
-                title: {
-                    text: 'Valores'
-                }
-            },
+            yAxis: generateYAxisBySeries(this.props.series),
 
             series: this.seriesValues(),
         });
@@ -164,10 +160,10 @@ export class Graphic extends React.Component<IGraphicProps, any> {
     }
 
     public seriesValues(): IHCSeries[] {
-        return this.props.series.map((serie) => this.hcSerieFromISerie(serie, {}));
+        return this.props.series.map((serie, index) => this.hcSerieFromISerie(serie, {}, index));
     }
 
-    public hcSerieFromISerie(serie: ISerie, hcConfig: IHConfig): IHCSeries {
+    public hcSerieFromISerie(serie: ISerie, hcConfig: IHConfig, yAxis: number): IHCSeries {
         const data = serie.data.map(datapoint => [timestamp(datapoint.date), datapoint.value]);
         return {
             ...this.defaultHCSeriesConfig(),
@@ -175,6 +171,7 @@ export class Graphic extends React.Component<IGraphicProps, any> {
             color: this.props.colorFor ? this.props.colorFor(serie).code : this.defaultHCSeriesConfig().color,
             data,
             name: serie.title,
+            yAxis
         }
 
     }
@@ -228,4 +225,15 @@ function dateFormatByPeriodicity(component: Graphic) {
     const frequency = component.props.series.length > 0 ? component.props.series[0].frequency || 'day' : 'day';
 
     return DATE_FORMAT_BY_PERIODICITY[frequency];
+}
+
+function generateYAxisBySeries(series: ISerie[]): any[] {
+    return series.map((serie, index) => {
+        return {
+            opposite: (index > 0),
+            title: {
+                text: serie.units
+            }
+        }
+    });
 }

--- a/src/components/viewpage/graphic/highcharts.ts
+++ b/src/components/viewpage/graphic/highcharts.ts
@@ -23,6 +23,7 @@ export interface IHCSeries {
     color: string;
     lineWidth: number;
     dashStyle: string;
+    yAxis: number
 }
 
 export interface IHConfig {


### PR DESCRIPTION
Closes #112

Ahora cuando agregamos más de una serie, se van agregando nuevas escalas.
Moví el botón de _reset zoom_ a un lugar donde no se vea pisado por otros elementos del DOM ya que agregar nuevas escalas mueve los elementos en la pantalla.

Las nuevas series generan una nueva escala. Tenemos la posibilidad de realizar un cálculo para ver si conviene o no generar una nueva escala, ya que en algunos casos la diferencia es chica. Pero este cálculo yo creo que es demasiado pesado para realizar, ya que los datos de las series pueden ser muchisimos, y calcular implica recorrer uno por uno evaluando si es o no más chico que el anterior. Creo que no tiene sentido cargar el navegador con algo así.
Lo que propongo es agregar un botón que le permita al usuario ver o no ver las series con sus respectivas escalas. Es decir, tendríamos un botón que habilita o deshabilita este nuevo feature.

Si les convence la idea lo implemento.