### PR TITLE
Highlighting omite tildes o mayusculas

### DIFF
--- a/src/components/common/searcher/HighlightWords.tsx
+++ b/src/components/common/searcher/HighlightWords.tsx
@@ -11,4 +11,14 @@ export default (props: IHighlightWordsProps) =>
     <Highlighter highlightClassName="item-highlight"
                  searchWords={props.words}
                  autoEscape={true}
-                 textToHighlight={props.text} />
+                 textToHighlight={props.text}  sanitize={sanitizer}/>
+
+
+function sanitizer(text: string): string {
+    return text.toLocaleLowerCase()
+               .replace(/á/g, "a")
+               .replace(/é/g, "e")
+               .replace(/í/g, "i")
+               .replace(/ó/g, "o")
+               .replace(/ú/g, "u");
+}


### PR DESCRIPTION
Closes #202

El highlight del texto ahora matchea con las palabras que tienen tilde.