### PR TITLE
205 datepicker avoid rerender

### DIFF
--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -55,6 +55,12 @@ export class ViewPage extends React.Component<IViewPageProps, any> {
         }
     }
 
+    public shouldComponentUpdate(nextProps: IViewPageProps) {
+        return this.props.series.every((serie1: ISerie) => {
+            return nextProps.series.every((serie2: ISerie) => serie1.id !== serie2.id)
+        });
+    }
+
     public viewSeries(ids: string[]) {
         const params = this.getQueryParams();
         params.set('ids', ids.join(','));

--- a/src/components/viewpage/graphic/GraphicAndShare.tsx
+++ b/src/components/viewpage/graphic/GraphicAndShare.tsx
@@ -57,7 +57,7 @@ export default class GraphicAndShare extends React.Component<IGraphicAndSharePro
 
         const minDataIndex = this.firstSerieData().findIndex((data) => data.date >= this.props.date.start);
         let maxDataIndex = this.firstSerieData().findIndex((data) => data.date >= this.props.date.end);
-        if (maxDataIndex === 0) { maxDataIndex = this.firstSerieData().length - 1}
+        if (maxDataIndex <= 0) { maxDataIndex = this.firstSerieData().length - 1}
 
         const min = new Date(this.firstSerieData()[minDataIndex].date).getTime();
         const max = new Date(this.firstSerieData()[maxDataIndex].date).getTime();


### PR DESCRIPTION
Closes #205 

Ahora los cambios de fecha no disparan un re-render lo cual producía que el scroll de la pantalla vuelva al top.
