### PR TITLE
No requerir enter al buscar series desde DetallePanel

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1,3 +1,19 @@
+.dp-results {
+  animation-name: fadeInOpacity;
+  animation-iteration-count: 1;
+  animation-timing-function: ease-in;
+  animation-duration: .1s;
+}
+
+@keyframes fadeInOpacity {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
 .app-loading {
   margin-top: 25%;
 }

--- a/src/components/common/searchbox/SearchBox.tsx
+++ b/src/components/common/searchbox/SearchBox.tsx
@@ -18,6 +18,7 @@ interface ISearchBoxProps {
     onSearch: (searchTerm?: string) => void;
     searchTerm?: string;
     seriesApi: ISerieApi;
+    enterRequired?: boolean;
 }
 
 interface ISearchBoxState {
@@ -65,8 +66,9 @@ class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState> {
     public onSearchTermChange(event: any) {
         const searchTerm: string = event.target.value;
         this.setState({ searchTerm, loading: true });
+        if (this.props.enterRequired === false && searchTerm.length > 2) { this.props.onSearch(searchTerm); return } // search without press Enter
 
-        this.updateAutoCompleteItems(searchTerm);
+        this.updateAutoCompleteItems(searchTerm); // search and show the preview items
     }
 
     public triggerSearch(event: any) {

--- a/src/components/common/searcher/FullSearcher.tsx
+++ b/src/components/common/searcher/FullSearcher.tsx
@@ -52,8 +52,12 @@ export default class FullSearcher extends React.Component<IFullSearcherProps, IS
     public render() {
         return (
             <div className="Searcher">
-                <SearchBox seriesApi={this.props.seriesApi} searchTerm={this.props.q} onSearch={this.onSearchTermPicked} onSelect={this.onSearchTermPicked}/>
-                <Searcher {...this.searcherProps()}/>
+                <SearchBox seriesApi={this.props.seriesApi}
+                           searchTerm={this.props.q}
+                           onSearch={this.onSearchTermPicked}
+                           onSelect={this.onSearchTermPicked}
+                           enterRequired={false} />
+                <Searcher {...this.searcherProps()} />
             </div>
         );
     }


### PR DESCRIPTION
Closes #231 

Cuando buscamos series desde el panel derecho de la View Page, no hace falta apretar enter. Con escribis +2 caracteres ya empieza a buscar.
