### PR TITLE
En la Main Page se buscan solo los metadatos

### DIFF
--- a/src/api/QueryParams.ts
+++ b/src/api/QueryParams.ts
@@ -16,6 +16,7 @@ export default class QueryParams {
     private startDate: string;
     private endDate: string;
     private representationMode: string;
+    private metadata: string;
 
     constructor(ids: string[]) {
         this.ids = ids;
@@ -35,6 +36,10 @@ export default class QueryParams {
 
     public getRepresentationMode(): string {
         return this.representationMode;
+    }
+
+    public getMetadata(): string {
+        return this.metadata;
     }
 
     public setCollapse(collapse: string) {
@@ -57,11 +62,14 @@ export default class QueryParams {
         this.collapseAggregation = collapseAggregation;
     }
 
+    public setMetadata(metadata: string) {
+        this.metadata = metadata;
+    }
+
     public extractParams(params: any) {
         this.setCollapse(params.get('collapse') || '');
         this.setCollapseAggregation(params.get('collapse_aggregation') || '');
         this.setRepresentationMode(params.get('representation_mode') || '');
-
     }
 
     public asJson(): {} {
@@ -70,6 +78,7 @@ export default class QueryParams {
             collapse_aggregation: this.getCollapseAggregation(),
             end_date: this.endDate,
             ids: this.getIds(),
+            metadata: this.getMetadata(),
             representation_mode: this.getRepresentationMode(),
             start_date: this.startDate
         }

--- a/src/api/Serie.ts
+++ b/src/api/Serie.ts
@@ -78,11 +78,8 @@ export default class Serie implements ISerie {
     }
 
     get data(): DataPoint[] {
-        return this.tsResponse.data
-            .map((datapoint: any[]) => {
-                return new DataPoint(datapoint, this.responseIndex)
-            }
-            );
+        const data = this.tsResponse.data || [];
+        return data.map((datapoint: any[]) => new DataPoint(datapoint, this.responseIndex));
     }
 
     get accrualPeriodicity() {

--- a/src/api/Serie.ts
+++ b/src/api/Serie.ts
@@ -78,8 +78,7 @@ export default class Serie implements ISerie {
     }
 
     get data(): DataPoint[] {
-        const data = this.tsResponse.data || [];
-        return data.map((datapoint: any[]) => new DataPoint(datapoint, this.responseIndex));
+        return this.tsResponse.data.map((datapoint: any[]) => new DataPoint(datapoint, this.responseIndex));
     }
 
     get accrualPeriodicity() {

--- a/src/api/SerieApi.ts
+++ b/src/api/SerieApi.ts
@@ -53,7 +53,7 @@ export default class SerieApi implements ISerieApi {
     public fetchSeries(params: QueryParams, metadata: string = METADATA.FULL): Promise<Serie[]> {
         const options = this.getSeriesParams(params, metadata);
 
-        return this.performGetWithRetry(options);
+        return this.performGetAllWithRetry(options);
     }
 
     public fetchMetadata(params: QueryParams): Promise<Serie[]> {

--- a/src/api/SerieApi.ts
+++ b/src/api/SerieApi.ts
@@ -24,8 +24,8 @@ type DatasetTheme = string;
 type DatasetSource = string;
 
 export interface ISerieApi {
-
     fetchSeries: ((params: QueryParams) => Promise<ISerie[]>);
+    fetchMetadata: ((params: QueryParams) => Promise<ISerie[]>);
     searchSeries: ((q: string | null, searchOptions?: ISearchOptions) => Promise<ISearchResponse>);
     fetchSources: () => Promise<DatasetSource[]>;
     fetchThemes: () => Promise<DatasetTheme[]>;
@@ -51,31 +51,19 @@ export default class SerieApi implements ISerieApi {
     }
 
     public fetchSeries(params: QueryParams, metadata: string = METADATA.FULL): Promise<Serie[]> {
-        const options = {
-            qs: {
-                limit: 1000,
-                metadata,
-                start: 0
-            },
-            uri: this.apiClient.endpoint('series'),
-        };
+        const options = this.getSeriesParams(params, metadata);
 
-        Object.assign(options.qs, params.asQuery());
+        return this.performGetWithRetry(options);
+    }
+
+    public fetchMetadata(params: QueryParams): Promise<Serie[]> {
+        const options = this.getSeriesParams(params, METADATA.ONLY);
 
         return this.performGetWithRetry(options);
     }
 
     public downloadDataURL(params: QueryParams, metadata: string = METADATA.FULL): string {
-        const options = {
-            qs: {
-                limit: 1000,
-                metadata,
-                start: 0
-            },
-            uri: this.apiClient.endpoint('series'),
-        };
-
-        Object.assign(options.qs, params.asQuery());
+        const options = this.getSeriesParams(params, metadata);
 
         let url = '?';
         Object.keys(options.qs).forEach((key) => {
@@ -129,24 +117,36 @@ export default class SerieApi implements ISerieApi {
         return this.apiClient.get<ITSAPIResponse>(options).then((tsResponse: ITSAPIResponse) => tsResponse.data);
     }
 
-    private performGet(options: IApiClientOpt): Promise<Serie[]> {
+    private getSeriesParams(params: QueryParams, metadata: string = METADATA.FULL) {
+        const options = {
+            qs: {
+                limit: 1000,
+                metadata,
+                start: 0
+            },
+            uri: this.apiClient.endpoint('series'),
+        };
+
+        Object.assign(options.qs, params.asQuery());
+        return options;
+    }
+
+    private performGetWithRetry(options: IApiClientOpt): Promise<Serie[]> {
+        return this.apiClient
+                    .get(options)
+                    .then((tsResponse: ITSAPIResponse) => tsResponseToSeries(options.qs.ids.split(","), tsResponse))
+                    .catch((error: any) => retryFailedRequest(error, options, this.performGetWithRetry.bind(this)));
+    }
+
+    private performGetAll(options: IApiClientOpt): Promise<Serie[]> {
         return this.apiClient
                    .getAll(options, [])
                    .then((tsResponse: ITSAPIResponse) => tsResponseToSeries(options.qs.ids.split(","), tsResponse));
     }
 
-    private performGetWithRetry(options: IApiClientOpt): Promise<Serie[]> {
-        return this.performGet(options)
-                   .catch((error: any) => {
-                       if (error.response.data.failed_series) {
-                           const failedIds: string[] = error.response.data.failed_series;
-                           options.qs.ids = options.qs.ids.split(',').filter((id: string) => failedIds.indexOf(sanitizedSerieId(id)) === -1).join(',');
-
-                           return this.performGetWithRetry(options);
-                       } else {
-                           throw error.response;
-                       }
-                   });
+    private performGetAllWithRetry(options: IApiClientOpt): Promise<Serie[]> {
+        return this.performGetAll(options)
+                   .catch((error: any) => retryFailedRequest(error, options, this.performGetAllWithRetry.bind(this)));
     }
 
 }
@@ -185,4 +185,15 @@ function addPlaceHolders(apiResponse: ITSAPIResponse): ITSAPIResponse {
 // removes serie id transformations
 function sanitizedSerieId(id: string): string {
     return id.split(':')[0];
+}
+
+function retryFailedRequest(error: any, options: IApiClientOpt, performGetFn: (options: IApiClientOpt) => Promise<Serie[]>) {
+    if (error.response.data.failed_series) {
+        const failedIds: string[] = error.response.data.failed_series;
+        options.qs.ids = options.qs.ids.split(',').filter((id: string) => failedIds.indexOf(sanitizedSerieId(id)) === -1).join(',');
+
+        return performGetFn(options);
+    } else {
+        throw error.response;
+    }
 }

--- a/src/components/mainpage/MainPage.tsx
+++ b/src/components/mainpage/MainPage.tsx
@@ -54,7 +54,7 @@ export class MainPage extends React.Component<IMainPageProps, any> {
 
     private fetchFeaturedSeries() {
         const params = new QueryParams(this.props.featured);
-        this.props.seriesApi.fetchSeries(params).then(featuredSeries => {
+        this.props.seriesApi.fetchMetadata(params).then(featuredSeries => {
             this.setState({featuredLoaded: true, featuredSeries});
         })
     }

--- a/src/tests/api/mockApi.ts
+++ b/src/tests/api/mockApi.ts
@@ -36,32 +36,37 @@ class MockApi implements ISerieApi {
         })
     }
 
-    public searchSeries(q: string, options?: ISearchOptions): Promise<ISearchResponse> {
+    public fetchMetadata(params: QueryParams): Promise<ISerie[]> {
+        return new Promise((resolve, reject) => {
+            setTimeout(resolve, this.delay, params.getIds().split(',').map(toSerie))
+        })
+    }
 
+    public searchSeries(q: string, options?: ISearchOptions): Promise<ISearchResponse> {
         if (options && options.datasetSource) {
             return new Promise((resolve, reject) => {
                 setTimeout(resolve, this.delay, {count:1, result: [toSerie("serie01")]});
             });
         }
+
         if (options && options.datasetTheme) {
             return new Promise((resolve, reject) => {
                 setTimeout(resolve, this.delay, {count:1, result: [toSerie("serie02")]});
             });
         }
+
         return new Promise((resolve, reject) => {
             setTimeout(resolve, this.delay, {count:1, result: [toSerie("serie01"), toSerie("serie02")]});
         });
     }
 
     public fetchSources(): Promise<string[]> {
-
         return new Promise((resolve, reject) => {
             setTimeout(resolve, this.delay, this.sources);
         });
     }
 
     public fetchThemes(): Promise<string[]> {
-
         return new Promise((resolve, reject) => {
             setTimeout(resolve, this.delay, this.themes);
         });
@@ -73,7 +78,6 @@ class MockApi implements ISerieApi {
 }
 
 function toSerie(id: string): ISerie {
-
     const self = {
         accrualPeriodicity: `${id} accrualPeriodicity`,
         bake: () => self,

--- a/src/tests/components/mainpage/MainPage.test.tsx
+++ b/src/tests/components/mainpage/MainPage.test.tsx
@@ -10,12 +10,16 @@ import MockApi from '../../api/mockApi';
 configure({ adapter: new Adapter() });
 
 it('renders without crashing', () => {
-
   const seriesApi = new MockApi(0);
+  seriesApi.fetchMetadata = jest.fn(seriesApi.fetchMetadata);
+  seriesApi.fetchSeries = jest.fn(seriesApi.fetchSeries);
+
   const wrapper = mount(
     <MemoryRouter>
       <MainPage featured={[]} seriesApi={seriesApi} />
     </MemoryRouter>);
 
   expect(wrapper.find(MainPage).find('h1').text()).toBe('Series de tiempo');
+  expect(seriesApi.fetchMetadata).toBeCalled();
+  expect(seriesApi.fetchSeries).not.toBeCalled();
 });


### PR DESCRIPTION
Closes #252

En la MainPage se estaban buscando todos los datos para mostrar sólo las "tarjetas" con metadatos. 
Agrego una implementación que en dicha pantalla sólo busca los metadatos, lo cual hace que sea más performante.