### PR TITLE
282 better tooltip

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1,3 +1,22 @@
+.highcharts-tooltip .tooltip-content {
+  width: 200px;
+  white-space: normal !important;
+  display: -webkit-box !important;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  -webkit-line-clamp: 3;
+}
+
+.highcharts-tooltip td {
+  vertical-align: top;
+}
+
+.tooltip-value {
+  text-align: right;
+  vertical-align:top;
+  font-weight: bold;
+}
+
 .graphic-complements {
   margin-top: -25px;
 }

--- a/src/api/SerieConfig.ts
+++ b/src/api/SerieConfig.ts
@@ -1,3 +1,4 @@
+import {IDataPoint} from "./DataPoint";
 import {ISerie} from "./Serie";
 import {i18nFrequency} from "./utils/periodicityManager";
 
@@ -6,7 +7,6 @@ export default class SerieConfig {
     private serie: ISerie;
     private percentChange: boolean;
     private percentChangeAYearAgo: boolean;
-    private formatUnits: boolean;
 
     public constructor(serie: ISerie) {
         this.serie = serie;
@@ -32,16 +32,16 @@ export default class SerieConfig {
         this.percentChangeAYearAgo = percentChangeAYearAgo;
     }
 
-    public setMustFormatUnits(format: boolean) {
-        this.formatUnits = format;
-    }
-
     public mustFormatUnits(formatUnits: boolean):boolean {
-        return formatUnits && (this.formatUnits || this.getPercentChange() || this.getPercentChangeAYearAgo());
+        return formatUnits && (this.canFormatSerie() || this.getPercentChange() || this.getPercentChangeAYearAgo());
     }
 
     public getSeriePeriodicity(): string {
         return i18nFrequency(this.serie.frequency || 'year');
+    }
+
+    private canFormatSerie(): boolean {
+        return this.serie.data.every((data: IDataPoint) => data.value > -1 && data.value < 1);
     }
 
 }

--- a/src/api/SerieConfig.ts
+++ b/src/api/SerieConfig.ts
@@ -1,15 +1,19 @@
+import {ISerie} from "./Serie";
+import {i18nFrequency} from "./utils/periodicityManager";
+
 export default class SerieConfig {
 
-    private serieId: string;
+    private serie: ISerie;
     private percentChange: boolean;
     private percentChangeAYearAgo: boolean;
+    private formatUnits: boolean;
 
-    public constructor(serieId: string) {
-        this.serieId = serieId;
+    public constructor(serie: ISerie) {
+        this.serie = serie;
     }
 
     public getSerieId() {
-        return this.serieId;
+        return this.serie.id;
     }
 
     public getPercentChange() {
@@ -28,8 +32,16 @@ export default class SerieConfig {
         this.percentChangeAYearAgo = percentChangeAYearAgo;
     }
 
-    public mustFormatUnits(formatUnits: boolean, formatUnitsBySerie: boolean):boolean {
-        return formatUnits && (formatUnitsBySerie || this.getPercentChange() || this.getPercentChangeAYearAgo());
+    public setMustFormatUnits(format: boolean) {
+        this.formatUnits = format;
+    }
+
+    public mustFormatUnits(formatUnits: boolean):boolean {
+        return formatUnits && (this.formatUnits || this.getPercentChange() || this.getPercentChangeAYearAgo());
+    }
+
+    public getSeriePeriodicity(): string {
+        return i18nFrequency(this.serie.frequency || 'year');
     }
 
 }

--- a/src/api/utils/periodicityManager.ts
+++ b/src/api/utils/periodicityManager.ts
@@ -21,6 +21,14 @@ const PERIODICITY_DATE_FORMAT = {
     'R/P6M': 'YYYY-MM',
 };
 
+const PERIODICITY_LANG = {
+    'day': 'Diaria',
+    'month': 'Mensual',
+    'quarter': 'Trimestral',
+    'semester': 'Semestral',
+    'year': 'Anual',
+};
+
 export class PeriodicityManager {
 
     private frequency: string;
@@ -77,4 +85,8 @@ export function parseFormatDate(format: string, dateString: string) {
     }
 
     return 'Frecuencia no soportada';
+}
+
+export function i18nFrequency(frequency: string): string {
+    return PERIODICITY_LANG[frequency];
 }

--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -12,6 +12,7 @@ import AddAndCustomizeSeriesButton from './AddAndCustomizeSeriesButton';
 import SeriesTags from './SeriesTags'
 
 import {clearViewSeries, loadViewSeries, setDate} from '../../actions/seriesActions';
+import {IDataPoint} from "../../api/DataPoint";
 import {IDateRange} from "../../api/DateSerie";
 import QueryParams from "../../api/QueryParams";
 import {ISerie} from '../../api/Serie';
@@ -372,9 +373,10 @@ export function seriesConfigByUrl(series: ISerie[], url: string): SerieConfig[] 
     const search = url.split(',');
 
     return series.map((serie: ISerie) => {
-        const seriesConfig = new SerieConfig(serie.id);
+        const seriesConfig = new SerieConfig(serie);
         seriesConfig.setPercentChange(search.some((value: string) => value.includes(serie.id) && value.includes('percent_change')));
         seriesConfig.setPercentChangeAYearAgo(search.some((value: string) => value.includes(serie.id) && value.includes('percent_change_a_year_ago')));
+        seriesConfig.setMustFormatUnits(serie.data.every((e: IDataPoint) => e.value > -1 && e.value < 1));
         return seriesConfig;
     });
 }

--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -3,16 +3,7 @@ import * as moment from "moment";
 import * as React from 'react';
 import {connect} from 'react-redux';
 import {RouterProps, withRouter} from "react-router";
-
-import ClearFix from '../style/ClearFix';
-import Colors, {Color} from '../style/Colors/Color';
-import Container from '../style/Common/Container';
-import SeriesHero from '../style/Hero/SeriesHero';
-import AddAndCustomizeSeriesButton from './AddAndCustomizeSeriesButton';
-import SeriesTags from './SeriesTags'
-
 import {clearViewSeries, loadViewSeries, setDate} from '../../actions/seriesActions';
-import {IDataPoint} from "../../api/DataPoint";
 import {IDateRange} from "../../api/DateSerie";
 import QueryParams from "../../api/QueryParams";
 import {ISerie} from '../../api/Serie';
@@ -20,12 +11,18 @@ import {ISerieApi} from '../../api/SerieApi';
 import SerieConfig from '../../api/SerieConfig';
 import {getId, removeDuplicates} from "../../helpers/commonFunctions";
 import SearchBox from '../common/searchbox/SearchBox'
+import ClearFix from '../style/ClearFix';
+import Colors, {Color} from '../style/Colors/Color';
+import Container from '../style/Common/Container';
+import SeriesHero from '../style/Hero/SeriesHero';
+import AddAndCustomizeSeriesButton from './AddAndCustomizeSeriesButton';
 import DetallePanel from './DetallePanel';
 import EmptySeries from "./EmptySeries";
 import FailedSeries from "./FailedSeries";
 import GraphicAndShare from "./graphic/GraphicAndShare";
 import MetaData from './metadata/MetaData';
 import SeriesPicker, {ISeriesPickerProps} from './seriespicker/SeriesPicker';
+import SeriesTags from './SeriesTags'
 
 interface IViewPageProps extends RouterProps {
     series: ISerie[];
@@ -376,7 +373,6 @@ export function seriesConfigByUrl(series: ISerie[], url: string): SerieConfig[] 
         const seriesConfig = new SerieConfig(serie);
         seriesConfig.setPercentChange(search.some((value: string) => value.includes(serie.id) && value.includes('percent_change')));
         seriesConfig.setPercentChangeAYearAgo(search.some((value: string) => value.includes(serie.id) && value.includes('percent_change_a_year_ago')));
-        seriesConfig.setMustFormatUnits(serie.data.every((e: IDataPoint) => e.value > -1 && e.value < 1));
         return seriesConfig;
     });
 }

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -152,6 +152,24 @@ export default class Graphic extends React.Component<IGraphicProps> {
                 text: '',
             },
 
+            tooltip:{
+                pointFormat: `
+                            <table style="width: 300px;">
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            <div class="tooltip-content">
+                                                <span style="color:{point.color};display:inline !important;">\u25CF</span>
+                                                {series.name}
+                                            </div>
+                                        </td>
+                                        <td><div class="tooltip-value">{point.y}</div></td>
+                                    </tr>
+                                </tbody>
+                            </table>`,
+                useHTML: true,
+            },
+
             xAxis: {
                 categories: this.categories(),
                 events: {

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -159,11 +159,10 @@ export default class Graphic extends React.Component<IGraphicProps> {
                     // @ts-ignore
                     const graphic: Graphic = _this;
                     const formatUnits = graphic.props.formatUnits || false;
-                    const seriesConfigFn = (serieId: string) => graphic.props.seriesConfig.find((config: SerieConfig) => config.getSerieId() === serieId);
 
                     let result = "";
                     self.points.forEach((point: any, index: number) => {
-                        const serieConfig = seriesConfigFn(point.series.options.serieId);
+                        const serieConfig = findSerieConfig(graphic.props.seriesConfig, point.series.options.serieId);
                         let value = (point.y).toFixed(2);
 
                         if (serieConfig) {
@@ -180,7 +179,6 @@ export default class Graphic extends React.Component<IGraphicProps> {
                     });
 
                     return result;
-
                 },
                 shared: true,
                 useHTML: true,
@@ -414,4 +412,8 @@ function tooltipFormatter(point: any, key: string, value: string) {
 function tooltipDateValue(periodicity: string, timest: number): string {
     const date = parseFormatDate(periodicity, new Date(timest).toLocaleString());
     return `<i>(${date})</i>`
+}
+
+function findSerieConfig(configs: SerieConfig[], serieId: string) {
+    return configs.find((config: SerieConfig) => config.getSerieId() === serieId);
 }

--- a/src/components/viewpage/graphic/highcharts.ts
+++ b/src/components/viewpage/graphic/highcharts.ts
@@ -25,6 +25,7 @@ export interface IHCSeries {
     dashStyle: string;
     yAxis: number;
     showInNavigator: boolean;
+    serieId: string;
 }
 
 export interface IHConfig {

--- a/src/tests/components/viewpage/graphic/Graphic.test.tsx
+++ b/src/tests/components/viewpage/graphic/Graphic.test.tsx
@@ -15,13 +15,13 @@ const series: ISerie[] = generateSeries();
 configure({ adapter: new Adapter() });
 
 it('renders without crashing', () => {
-    const wrapper = mount(<Graphic series={[]} range={{min: 0, max: 10}} seriesConfig={[new SerieConfig("test")]} locale="AR" />);
+    const wrapper = mount(<Graphic series={[]} range={{min: 0, max: 10}} seriesConfig={[new SerieConfig(series[0])]} locale="AR" />);
 
     expect(wrapper.find(Graphic).exists()).toBe(true);
 });
 
 it('renders without crashing', () => {
-    const wrapper = mount(<Graphic series={series} range={{min: 0, max: 10}} seriesConfig={[new SerieConfig("test")]} locale="AR" />);
+    const wrapper = mount(<Graphic series={series} range={{min: 0, max: 10}} seriesConfig={[new SerieConfig(series[0])]} locale="AR" />);
 
     expect(wrapper.find(Graphic).exists()).toBe(true);
 });


### PR DESCRIPTION
Closes #282 

Hice los siguientes cambios:
- El tooltip no ocupa inifito largo sino que se corta hasta un máximo de 3 líneas
- Se incluye la fecha en dicho tooltip, formateada como en el mini-gráfico
- Hay un solo tooltip para todas las series
- El valor tiene formato porcentaje (cuando aplica) y siempre hay máximo 2 decimales