### PR TITLE
fix tag colors

### DIFF
--- a/src/components/style/Card/Card.tsx
+++ b/src/components/style/Card/Card.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import { Color } from '../Colors/Color';
 import CardCheck from './CardCheck';
 
@@ -15,10 +14,8 @@ export default (props: ICardProps) =>
 
     <div onClick={props.onClick}
          title={props.title}
-         className={`series-card mg-lg-b
-                    ${props.checked ? "card-has-check" : ""}
-                    ${props.pegColor ? `sc-${props.pegColor.name}` : ""}
-                    `} >
+         className={`series-card mg-lg-b ${props.checked ? "card-has-check" : ""}`}
+         style={{borderRightColor: props.pegColor ? props.pegColor.code : ''}} >
         {props.children}
         {props.checked && <CardCheck onRemoveSerie={props.onRemoveSerie}/>}
     </div>

--- a/src/components/style/Colors/Color.ts
+++ b/src/components/style/Colors/Color.ts
@@ -17,3 +17,7 @@ const Colors = {
 export const NaC = new Color("", "");
 
 export default Colors;
+
+export function getColorBySerieId(serieId: string, colorForFn?: (serieId: string) => Color): string {
+    return colorForFn ? colorForFn(serieId).code : '';
+}

--- a/src/components/style/Details/DetailsTitleAndActions.tsx
+++ b/src/components/style/Details/DetailsTitleAndActions.tsx
@@ -1,20 +1,6 @@
 import * as React from 'react';
 
-import { Color } from '../Colors/Color';
 
-
-const pegColor = "pegColor";
-
-interface IDetailsTitleAndActionsProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
-    pegColor?: Color;
+export default (props: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>) => {
+    return <div className={'title-and-actions mg-b'} {...props} />
 }
-
-export default (props: IDetailsTitleAndActionsProps) => {
-
-    const divProps = { ...props };
-    delete divProps[pegColor];
-
-    return <div className={`title-and-actions mg-b ${props.pegColor ? `title-${props.pegColor.name}` : ""}`} {...divProps} />
-}
-
-

--- a/src/components/style/Details/SerieDetails.tsx
+++ b/src/components/style/Details/SerieDetails.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-
+import { ISerie } from '../../../api/Serie';
 import Row from '../../style/Common/Row';
-import {Color} from '../Colors/Color';
+import { Color, getColorBySerieId } from '../Colors/Color';
 import Details from './Details';
 import DetailsTitle from './DetailsTitle';
 import DetailsTitleAndActions from './DetailsTitleAndActions';
-
-import {ISerie} from '../../../api/Serie';
 
 
 interface ISerieDetailsProp extends React.Props<any> {
@@ -19,8 +17,8 @@ interface ISerieDetailsProp extends React.Props<any> {
 export default (props: ISerieDetailsProp) =>
 
     <Details key={props.serie.id}>
-        <DetailsTitleAndActions pegColor={props.pegColorFor && props.pegColorFor(props.serie.id)}>
-            <DetailsTitle>
+        <DetailsTitleAndActions>
+            <DetailsTitle style={{borderLeftColor: getColorBySerieId(props.serie.id, props.pegColorFor)}}>
                 {props.serie.description} ({props.serie.id})
             </DetailsTitle>
             {props.actions}

--- a/src/components/style/Tag/Tag.tsx
+++ b/src/components/style/Tag/Tag.tsx
@@ -15,7 +15,7 @@ export default (props: ITagProps) => {
     }
 
     return (
-        <span className={`tag ${props.pegColor ? `tag-${props.pegColor.name}` : ""}`}>
+        <span className={"tag"} style={{borderLeftColor: props.pegColor ? props.pegColor.code : ''}}>
             {props.children}
             {removeBtn}
         </span>

--- a/src/components/viewpage/SerieTagsReducer.ts
+++ b/src/components/viewpage/SerieTagsReducer.ts
@@ -3,8 +3,7 @@ import {ITagNamesAction} from "../../actions/seriesActions";
 import {ISerieTag} from "./SeriesTags";
 
 
-export default function serieTagsReducer(state: ISerieTag[] = [{id:'', title:''}], action: ITagNamesAction): ISerieTag[] {
-
+export default function serieTagsReducer(state: ISerieTag[] = [], action: ITagNamesAction): ISerieTag[] {
     switch(action.type){
         case actionTypes.SET_SERIE_TAGS: return action.serieTags;
         default: return state;

--- a/src/store/initialState.ts
+++ b/src/store/initialState.ts
@@ -43,7 +43,7 @@ const initialState: IStore = {
         q: "",
     },
     seriesApi: null,
-    tagNames: [{id: '', title: ''}],
+    tagNames: [],
     viewSeries: [],
 };
 


### PR DESCRIPTION
Closes #336 

Corrijo los colores que van al costado de:
-  tag de series elegidas (arriba del gráfico)
-  costado del título en la parte inferior
- costado de las tarjetas en la búsqueda de nuevas series