### PR TITLE
Fix doble eje

### DIFF
--- a/src/api/ITSAPIResponse.ts
+++ b/src/api/ITSAPIResponse.ts
@@ -85,6 +85,8 @@ export interface IField {
     time_index_start: string;
     time_index_end: string;
     time_index_size: number;
+    min_value: string;
+    max_value: string;
 }
 
 export interface IPublisher {

--- a/src/api/SearchResult.ts
+++ b/src/api/SearchResult.ts
@@ -91,4 +91,7 @@ export default class SearchResult implements ISerie {
         return '';
     }
 
+    get minValue() { return 0; }
+    get maxValue() { return 0; }
+
 }

--- a/src/api/Serie.ts
+++ b/src/api/Serie.ts
@@ -25,6 +25,8 @@ export interface ISerie {
     timeIndexSize: number,
     representationModeUnits: string,
     downloadURL: string,
+    minValue: number,
+    maxValue: number,
 }
 
 export default class Serie implements ISerie {
@@ -116,7 +118,7 @@ export default class Serie implements ISerie {
     get landingPage(){
         return this.datasetMeta.landingPage;
     }
-    
+
     get issued() {
         return this.distributionMeta.issued;
     }
@@ -146,6 +148,14 @@ export default class Serie implements ISerie {
         return this.distributionMeta.downloadURL;
     }
 
+    get minValue(): number {
+        return parseFloat(this.fieldMeta.min_value);
+    }
+
+    get maxValue(): number {
+        return parseFloat(this.fieldMeta.max_value);
+    }
+
     public bake(): ISerie {
         return {
             accrualPeriodicity: this.accrualPeriodicity,
@@ -160,6 +170,8 @@ export default class Serie implements ISerie {
             id: this.id,
             issued: this.issued,
             landingPage: this.landingPage,
+            maxValue: this.maxValue,
+            minValue: this.minValue,
             modified: this.modified,
             publisher: {...this.publisher},
             representationModeUnits: this.representationModeUnits,

--- a/src/api/Serie.ts
+++ b/src/api/Serie.ts
@@ -104,7 +104,7 @@ export default class Serie implements ISerie {
     }
 
     get representationModeUnits() {
-        return this.fieldMeta.representation_mode_units;
+        return this.fieldMeta.representation_mode_units || 'Cantidad'; // default porque a veces viene null. Podríamos llegar a querer usar otro
     }
 
     get startDate() {

--- a/src/components/style/Card/Serie/SerieCardWithChart.tsx
+++ b/src/components/style/Card/Serie/SerieCardWithChart.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import {IDataPoint} from "../../../../api/DataPoint";
 import D3SeriesChart from "../../../d3_charts/D3SeriesChart";
 import Row from "../../Common/Row";
 import Card from "../Card";
 import CardBody from "../CardBody";
 import CardSubtitle from "../CardSubtitle";
 import CardTitle from "../CardTitle";
-import {ISerieCardProps} from "./SerieCard";
+import { ISerieCardProps } from "./SerieCard";
 
 
 export default (props: ISerieCardProps) =>
@@ -28,12 +27,7 @@ export default (props: ISerieCardProps) =>
             </div>
 
             <div className="col-xs-4 d3-line-chart-container">
-                <D3SeriesChart data={notNullData(props.serie.data)} frequency={props.serie.accrualPeriodicity} />
+                <D3SeriesChart serie={props.serie} frequency={props.serie.accrualPeriodicity} />
             </div>
         </Row>
     </Card>
-
-
-function notNullData(data: IDataPoint[]): IDataPoint[] {
-    return data.filter((d: IDataPoint) => d.value !== null);
-}

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -5,7 +5,7 @@ import IDataPoint from '../../../api/DataPoint';
 import {ISerie} from '../../../api/Serie';
 import SerieConfig from "../../../api/SerieConfig";
 import {i18nFrequency} from "../../../api/utils/periodicityManager";
-import {maxNotNull, minNotNull, valueExist, valuesFromObject} from "../../../helpers/commonFunctions";
+import {valuesFromObject} from "../../../helpers/commonFunctions";
 import {formattedDateString, fullLocaleDate, localTimestamp, timestamp,} from "../../../helpers/dateFunctions";
 import {buildLocale} from "../../common/locale/buildLocale";
 import {Color} from '../../style/Colors/Color';
@@ -344,7 +344,7 @@ function dateFormatByPeriodicity(component: Graphic) {
 
 function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfig[], formatUnits: boolean): {} {
     const minAndMaxValues = series.reduce((result: any, serie: ISerie) => {
-        result[serie.id] = smartMinAndMaxFinder(serie.data);
+        result[serie.id] = { min: serie.minValue, max: serie.maxValue };
 
         return result;
     }, {});
@@ -371,18 +371,6 @@ function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfig[], fo
 function isOutOfScale(originalSerieId: string, serieId: string, minAndMaxValues: {}): boolean {
     return minAndMaxValues[originalSerieId].min > minAndMaxValues[serieId].max ||
            minAndMaxValues[originalSerieId].max < minAndMaxValues[serieId].min;
-}
-
-// returns the min and max values of the passed list in just one iteration, even if some of them is null or undefined
-export function smartMinAndMaxFinder(data: any[]): {min: number, max: number} {
-    return data.reduce((result: any, e: IDataPoint) => {
-        if (valueExist(e.value)) {
-            result.min = minNotNull(result.min, e.value);
-            result.max = maxNotNull(result.max, e.value);
-        }
-
-        return result;
-    }, {});
 }
 
 function yAxisConf(yAxisBySeries: IYAxisConf): IYAxis[] {

--- a/src/tests/api/mockApi.ts
+++ b/src/tests/api/mockApi.ts
@@ -95,6 +95,8 @@ export function toSerie(id: string): ISerie {
         units: `${id} units`,
 
         landingPage: `${id} landingPage`,
+        maxValue: 1,
+        minValue: 0,
         modified: `2018-01-01`,
         representationModeUnits: `${id} rep mode units`,
         startDate: 'start',

--- a/src/tests/support/factories/series_api.ts
+++ b/src/tests/support/factories/series_api.ts
@@ -60,6 +60,8 @@ export function generateITSAPIResponse(tsIDs: string[] = ["1.1", "1.2"]): ITSAPI
                     description: `${tsID} field description`,
                     frequency: `${tsID} field periodicity`,
                     id: tsID,
+                    max_value: "2",
+                    min_value: "0",
                     representation_mode_units: `${tsID} distribution representation_mode_units`,
                     time_index_end: '',
                     time_index_size: 0,


### PR DESCRIPTION
Closes #340 

- Borro función que calcula valores mínimos y máximos de una serie porque la API ya lo devuelve calculado
- Agrego valor default para el campo `representation_mode_units` para solucionar problemas de doble eje