### PR TITLE
No scrollear ante cambios en el gráfico

### DIFF
--- a/src/components/viewpage/seriespicker/SeriesPicker.tsx
+++ b/src/components/viewpage/seriespicker/SeriesPicker.tsx
@@ -25,6 +25,12 @@ class SeriesPicker extends React.Component<ISeriesPickerProps, any> {
         this.searchResultCardProps = this.searchResultCardProps.bind(this);
     }
 
+    // Never update component. It avoids re render (and scrolling), but it could be a risk.
+    // Refactor all nested components and, hopefully, it won't be needed.
+    public shouldComponentUpdate() {
+        return false;
+    }
+
     public render() {
         return (
             <FullSearcher


### PR DESCRIPTION
Closes #362 

Agrego función para prevenir la actualización del componente `SeriesPicker`. Esto hace que no se refresque parte de la pantalla lo cual provocaba un scroll hacia arriba.