### PR TITLE
Agregar gráfico Small a Card

### DIFF
--- a/src/components/exportable/CardExportable.tsx
+++ b/src/components/exportable/CardExportable.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import QueryParams from '../../api/QueryParams';
 import { ISerie } from '../../api/Serie';
 import SerieApi from '../../api/SerieApi';
+import { valuesFromObject } from '../../helpers/commonFunctions';
 import { ICardExportableConfig } from '../../indexCard';
 import FullCard from '../exportable_card/FullCard';
 
@@ -12,6 +13,15 @@ export interface ICardExportableProps extends ICardExportableConfig {
 
 interface ICardExportableState {
     serie: ISerie|null;
+    laps: number;
+}
+
+const LAPS = {
+    Anual: 10,
+    Diaria: 90,
+    Mensual: 24,
+    Semestral: 10,
+    Trimestral: 20,
 }
 
 export default class CardExportable extends React.Component<ICardExportableProps, ICardExportableState> {
@@ -20,6 +30,7 @@ export default class CardExportable extends React.Component<ICardExportableProps
         super(props);
 
         this.state = {
+            laps: 0,
             serie: null,
         }
     }
@@ -27,7 +38,7 @@ export default class CardExportable extends React.Component<ICardExportableProps
     public componentDidMount() {
         const percentChangeId = `${this.props.serieId}:percent_change_a_year_ago`
         const params = new QueryParams([this.props.serieId, percentChangeId]);
-        params.setLast(1);
+        params.setLast(higherLaps());
         this.fetchSeries(params);
     }
 
@@ -36,12 +47,24 @@ export default class CardExportable extends React.Component<ICardExportableProps
 
         return <FullCard serie={this.state.serie}
                             locale={this.props.locale}
-                            color={this.props.color} />
+                            color={this.props.color}
+                            hasChart={this.props.hasChart}
+                            laps={this.state.laps} />
     }
 
     private fetchSeries(params: QueryParams) {
         this.props.seriesApi.fetchSeries(params)
-            .then((series: ISerie[]) => this.setState({serie: series[0]}))
-            .catch((error: any) => alert("Ocurrió un error buscando la serie solicitada."));
+            .then((series: ISerie[]) => {
+                this.setState({
+                    laps: LAPS[series[0].accrualPeriodicity],
+                    serie: series[0]
+                })
+            })
+            .catch((error: any) => alert(`Ocurrió un error buscando la serie ${params.getIds()[0]}.`));
     }
+}
+
+
+function higherLaps(): number {
+    return Math.max.apply(null, valuesFromObject(LAPS))
 }

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -3,6 +3,7 @@ import { ISerie } from '../../api/Serie';
 import { fullLocaleDate } from '../../helpers/dateFunctions';
 import { buildLocale } from '../common/locale/buildLocale';
 import LocaleDefault from '../common/locale/LocaleDefault';
+import D3LineChart from '../d3_charts/D3LineChart';
 import FullCardHeader from '../style/exportable_card/FullCardHeader';
 import FullCardValue from '../style/exportable_card/FullCardValue';
 import FullCardLinks from './FullCardLinks';
@@ -12,25 +13,44 @@ interface IFullCardProps {
     serie: ISerie;
     locale: string;
     color: string;
+    hasChart: string;
+    laps: number;
 }
 
-export default (props: IFullCardProps) => {
-    const locale = buildLocale(props.locale);
+export default class FullCard extends React.Component<IFullCardProps, any> {
 
-    return (
-        <div className="full-card">
-            <FullCardHeader color={props.color} title={props.serie.description} date={fullLocaleDate('Diaria', props.serie.data[0].date)} />
-            <FullCardValue color={props.color} text={formattedValue(props.serie, locale)} />
-            <span className="units">{props.serie.units}</span>
-            <span className="source">Fuente: {props.serie.datasetSource}</span>
-            <FullCardLinks serie={props.serie} />
-        </div>
-    )
+    private locale: LocaleDefault;
+    private readonly myRef: React.RefObject<any>;
+
+    public constructor(props: IFullCardProps) {
+        super(props);
+
+        this.myRef = React.createRef();
+        this.locale = buildLocale(props.locale);
+    }
+
+    public render() {
+        return (
+            <div className="full-card" ref={this.myRef}>
+                <FullCardHeader color={this.props.color} title={this.props.serie.description} date={lastSerieDate(this.props.serie)} />
+                <FullCardValue color={this.props.color} text={formattedValue(this.props.serie, this.locale)} />
+                <D3LineChart renderTo={this.myRef} data={this.props.serie.data} />
+                <span className="units">{this.props.serie.units}</span>
+                <span className="source">Fuente: {this.props.serie.datasetSource}</span>
+                <FullCardLinks serie={this.props.serie} />
+            </div>
+        )
+    }
+
+}
+
+function lastSerieDate(serie: ISerie): string {
+    return fullLocaleDate(serie.accrualPeriodicity, serie.data[serie.data.length-1].date);
 }
 
 
 function formattedValue(serie: ISerie, locale: LocaleDefault): string {
-    const value: number = serie.data[0].value;
+    const value: number = serie.data[serie.data.length-1].value;
 
     if (serie.isPercentage) {
         return `${(value * 100).toFixed(2)}%`

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IDataPoint } from '../../api/DataPoint';
 import { ISerie } from '../../api/Serie';
 import { fullLocaleDate } from '../../helpers/dateFunctions';
 import { buildLocale } from '../common/locale/buildLocale';
@@ -20,12 +21,22 @@ export default (props: IFullCardProps) =>
     <div className="full-card" >
         <FullCardHeader color={props.color} title={props.serie.description} date={lastSerieDate(props.serie)} />
         <FullCardValue color={props.color} text={formattedValue(props.serie, props.locale)} />
-        <FullCardChart data={props.serie.data} chartType={props.hasChart} />
+        <FullCardChart data={shortDataList(props.serie.data, props.laps)} chartType={props.hasChart} />
         <span className="units">{props.serie.units}</span>
         <span className="source">Fuente: {props.serie.datasetSource}</span>
         <FullCardLinks serie={props.serie} />
     </div>
 
+
+function shortDataList(data: IDataPoint[], laps: number): IDataPoint[] {
+    const result = data.slice(Math.max(data.length - laps, 0));
+
+    return notNullData(result);
+}
+
+function notNullData(data: IDataPoint[]): IDataPoint[] {
+    return data.filter((d: IDataPoint) => d.value !== null);
+}
 
 function lastSerieDate(serie: ISerie): string {
     return fullLocaleDate(serie.accrualPeriodicity, serie.data[serie.data.length-1].date);

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import { ISerie } from '../../api/Serie';
 import { fullLocaleDate } from '../../helpers/dateFunctions';
 import { buildLocale } from '../common/locale/buildLocale';
-import LocaleDefault from '../common/locale/LocaleDefault';
-import D3LineChart from '../d3_charts/D3LineChart';
 import FullCardHeader from '../style/exportable_card/FullCardHeader';
 import FullCardValue from '../style/exportable_card/FullCardValue';
+import FullCardChart from './FullCardChart';
 import FullCardLinks from './FullCardLinks';
 
 
@@ -17,40 +16,24 @@ interface IFullCardProps {
     laps: number;
 }
 
-export default class FullCard extends React.Component<IFullCardProps, any> {
+export default (props: IFullCardProps) =>
+    <div className="full-card" >
+        <FullCardHeader color={props.color} title={props.serie.description} date={lastSerieDate(props.serie)} />
+        <FullCardValue color={props.color} text={formattedValue(props.serie, props.locale)} />
+        <FullCardChart data={props.serie.data} chartType={props.hasChart} />
+        <span className="units">{props.serie.units}</span>
+        <span className="source">Fuente: {props.serie.datasetSource}</span>
+        <FullCardLinks serie={props.serie} />
+    </div>
 
-    private locale: LocaleDefault;
-    private readonly myRef: React.RefObject<any>;
-
-    public constructor(props: IFullCardProps) {
-        super(props);
-
-        this.myRef = React.createRef();
-        this.locale = buildLocale(props.locale);
-    }
-
-    public render() {
-        return (
-            <div className="full-card" ref={this.myRef}>
-                <FullCardHeader color={this.props.color} title={this.props.serie.description} date={lastSerieDate(this.props.serie)} />
-                <FullCardValue color={this.props.color} text={formattedValue(this.props.serie, this.locale)} />
-                <D3LineChart renderTo={this.myRef} data={this.props.serie.data} />
-                <span className="units">{this.props.serie.units}</span>
-                <span className="source">Fuente: {this.props.serie.datasetSource}</span>
-                <FullCardLinks serie={this.props.serie} />
-            </div>
-        )
-    }
-
-}
 
 function lastSerieDate(serie: ISerie): string {
     return fullLocaleDate(serie.accrualPeriodicity, serie.data[serie.data.length-1].date);
 }
 
-
-function formattedValue(serie: ISerie, locale: LocaleDefault): string {
+function formattedValue(serie: ISerie, localeType: string): string {
     const value: number = serie.data[serie.data.length-1].value;
+    const locale = buildLocale(localeType);
 
     if (serie.isPercentage) {
         return `${(value * 100).toFixed(2)}%`

--- a/src/components/exportable_card/FullCardChart.tsx
+++ b/src/components/exportable_card/FullCardChart.tsx
@@ -1,28 +1,27 @@
 import * as React from 'react';
 import { IDataPoint } from '../../api/DataPoint';
-import D3LineChart from '../d3_charts/D3LineChart';
+import CardFullChart from './charts/CardFullChart';
+import CardNullChart from './charts/CardNullChart';
+import CardSmallChart from './charts/CardSmallChart';
 
 
-interface IFullCardChartProps {
+export interface ICardChartProps {
     data: IDataPoint[];
+}
+
+interface IFullCardChartProps extends ICardChartProps {
     chartType: string;
 }
 
-export default class FullCardChart extends React.Component<IFullCardChartProps, any> {
+const CHART_TYPES_COMPONENT = {
+    'full': CardFullChart,
+    'none': CardNullChart,
+    'small': CardSmallChart,
+}
 
-    private readonly myRef: React.RefObject<any>;
 
-    public constructor(props: IFullCardChartProps) {
-        super(props);
+export default (props: IFullCardChartProps) => {
+    const Chart = CHART_TYPES_COMPONENT[props.chartType];
 
-        this.myRef = React.createRef();
-    }
-
-    public render() {
-        return (
-            <div ref={this.myRef}>
-                <D3LineChart renderTo={this.myRef} data={this.props.data} />
-            </div>
-        )
-    }
+    return <Chart data={props.data} />
 }

--- a/src/components/exportable_card/FullCardChart.tsx
+++ b/src/components/exportable_card/FullCardChart.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { IDataPoint } from '../../api/DataPoint';
+import D3LineChart from '../d3_charts/D3LineChart';
+
+
+interface IFullCardChartProps {
+    data: IDataPoint[];
+    chartType: string;
+}
+
+export default class FullCardChart extends React.Component<IFullCardChartProps, any> {
+
+    private readonly myRef: React.RefObject<any>;
+
+    public constructor(props: IFullCardChartProps) {
+        super(props);
+
+        this.myRef = React.createRef();
+    }
+
+    public render() {
+        return (
+            <div ref={this.myRef}>
+                <D3LineChart renderTo={this.myRef} data={this.props.data} />
+            </div>
+        )
+    }
+}

--- a/src/components/exportable_card/charts/CardFullChart.tsx
+++ b/src/components/exportable_card/charts/CardFullChart.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import D3LineChart from '../../d3_charts/D3LineChart';
+import { ICardChartProps } from '../FullCardChart';
+
+export default class CardFullChart extends React.Component<ICardChartProps, any> {
+
+    private readonly myRef: React.RefObject<any>;
+
+    public constructor(props: ICardChartProps) {
+        super(props);
+
+        this.myRef = React.createRef();
+    }
+
+    public render() {
+        return (
+            <div ref={this.myRef}>
+                <D3LineChart renderTo={this.myRef} data={this.props.data} />
+            </div>
+        )
+    }
+}

--- a/src/components/exportable_card/charts/CardFullChart.tsx
+++ b/src/components/exportable_card/charts/CardFullChart.tsx
@@ -1,22 +1,16 @@
 import * as React from 'react';
-import D3LineChart from '../../d3_charts/D3LineChart';
 import { ICardChartProps } from '../FullCardChart';
+import CardSmallChart from './CardSmallChart';
 
 export default class CardFullChart extends React.Component<ICardChartProps, any> {
 
-    private readonly myRef: React.RefObject<any>;
-
     public constructor(props: ICardChartProps) {
         super(props);
-
-        this.myRef = React.createRef();
     }
 
     public render() {
         return (
-            <div ref={this.myRef}>
-                <D3LineChart renderTo={this.myRef} data={this.props.data} />
-            </div>
+            <CardSmallChart data={this.props.data} />
         )
     }
 }

--- a/src/components/exportable_card/charts/CardNullChart.tsx
+++ b/src/components/exportable_card/charts/CardNullChart.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { ICardChartProps } from '../FullCardChart';
+
+
+export default (props: ICardChartProps) =>
+    <div />

--- a/src/components/exportable_card/charts/CardSmallChart.tsx
+++ b/src/components/exportable_card/charts/CardSmallChart.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import D3LineChart from '../../d3_charts/D3LineChart';
+import { ICardChartProps } from '../FullCardChart';
+
+export default class CardSmallChart extends React.Component<ICardChartProps, any> {
+
+    private readonly myRef: React.RefObject<any>;
+
+    public constructor(props: ICardChartProps) {
+        super(props);
+
+        this.myRef = React.createRef();
+    }
+
+    public render() {
+        return (
+            <div ref={this.myRef}>
+                <D3LineChart renderTo={this.myRef} data={this.props.data} />
+            </div>
+        )
+    }
+}

--- a/src/components/exportable_card/charts/CardSmallChart.tsx
+++ b/src/components/exportable_card/charts/CardSmallChart.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import { IDataPoint } from '../../../api/DataPoint';
 import D3LineChart from '../../d3_charts/D3LineChart';
 import { ICardChartProps } from '../FullCardChart';
+
 
 export default class CardSmallChart extends React.Component<ICardChartProps, any> {
 
@@ -15,8 +17,12 @@ export default class CardSmallChart extends React.Component<ICardChartProps, any
     public render() {
         return (
             <div ref={this.myRef}>
-                <D3LineChart renderTo={this.myRef} data={this.props.data} />
+                <D3LineChart renderTo={this.myRef} data={notNullData(this.props.data)} />
             </div>
         )
     }
+}
+
+function notNullData(data: IDataPoint[]): IDataPoint[] {
+    return data.filter((d: IDataPoint) => d.value !== null);
 }

--- a/src/components/exportable_card/charts/CardSmallChart.tsx
+++ b/src/components/exportable_card/charts/CardSmallChart.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { IDataPoint } from '../../../api/DataPoint';
 import D3LineChart from '../../d3_charts/D3LineChart';
 import { ICardChartProps } from '../FullCardChart';
 
@@ -17,12 +16,8 @@ export default class CardSmallChart extends React.Component<ICardChartProps, any
     public render() {
         return (
             <div ref={this.myRef}>
-                <D3LineChart renderTo={this.myRef} data={notNullData(this.props.data)} />
+                <D3LineChart renderTo={this.myRef} data={this.props.data} />
             </div>
         )
     }
-}
-
-function notNullData(data: IDataPoint[]): IDataPoint[] {
-    return data.filter((d: IDataPoint) => d.value !== null);
 }


### PR DESCRIPTION
Closes #373

Agrego gráfico versión "small".
La versión "full" funciona igual porque todavía no está implementado.

Para probar ver #378 y agregar los parámetros necesarios de `hasChart`.