### PR TITLE
Formateo de porcentajes en el eje Y del gráfico

### DIFF
--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -85,7 +85,7 @@ export default class Graphic extends React.Component<IGraphicProps> {
 
     public render() {
         const formatUnits = this.props.formatUnits || false;
-        this.yAxisBySeries = generateYAxisBySeries(this.props.series, this.props.seriesConfig, formatUnits);
+        this.yAxisBySeries = generateYAxisBySeries(this.props.series, this.props.seriesConfig, formatUnits, this.props.locale);
 
         return (
             <ReactHighStock ref={this.myRef} config={this.highchartsConfig()} callback={this.afterRender} />
@@ -348,7 +348,7 @@ function dateFormatByPeriodicity(component: Graphic) {
     return DATE_FORMAT_BY_PERIODICITY[frequency];
 }
 
-function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfig[], formatUnits: boolean): {} {
+function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfig[], formatUnits: boolean, locale: string): {} {
     const minAndMaxValues = series.reduce((result: any, serie: ISerie) => {
         result[serie.id] = { min: serie.minValue, max: serie.maxValue };
 
@@ -367,7 +367,14 @@ function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfig[], fo
         const serieConfig = seriesConfig.find((config: SerieConfig) => config.getSerieId() === serie.id);
 
         if (serieConfig && serieConfig.mustFormatUnits(formatUnits)) {
-            result[serie.id].labels = { formatter: highchartsLabelFormatter};
+            result[serie.id].labels = { 
+                formatter() { 
+                    const localeObj = buildLocale(locale);
+                    const sep = localeObj.decimalSeparator();
+                    // @ts-ignore    
+                    return `${(this.value*100).toFixed(2).replace('.', sep)}%`                
+                }
+            };
         }
 
         return result;
@@ -398,12 +405,6 @@ function yAxisConf(yAxisBySeries: IYAxisConf): IYAxis[] {
 
     return leftAxis.concat(rightAxis);
 }
-
-function highchartsLabelFormatter(): string {
-    // @ts-ignore
-    return `${(this.value*100).toFixed(2)}%`
-}
-
 
 function setHighchartsGlobalConfig(locale: string) {
     const localeObj = buildLocale(locale);

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -10,6 +10,7 @@ import { formattedDateString, fullLocaleDate, localTimestamp, timestamp } from "
 import { buildLocale } from "../../common/locale/buildLocale";
 import { ISerieTag } from "../SeriesTags";
 import { colorFor } from '../ViewPage';
+import { formatterForSerie } from './formatterForSerie';
 import { IHConfig, IHCSeries, ReactHighStock } from './highcharts';
 
 // tslint:disable-next-line:no-var-requires
@@ -367,14 +368,7 @@ function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfig[], fo
         const serieConfig = seriesConfig.find((config: SerieConfig) => config.getSerieId() === serie.id);
 
         if (serieConfig && serieConfig.mustFormatUnits(formatUnits)) {
-            result[serie.id].labels = { 
-                formatter() { 
-                    const localeObj = buildLocale(locale);
-                    const sep = localeObj.decimalSeparator();
-                    // @ts-ignore    
-                    return `${(this.value*100).toFixed(2).replace('.', sep)}%`                
-                }
-            };
+            result[serie.id].labels = formatterForSerie(locale);
         }
 
         return result;

--- a/src/components/viewpage/graphic/formatterForSerie.tsx
+++ b/src/components/viewpage/graphic/formatterForSerie.tsx
@@ -2,10 +2,15 @@ import { buildLocale } from "../../common/locale/buildLocale";
 export function formatterForSerie(locale: string) {
     return {
         formatter(): string {
-            const localeObj = buildLocale(locale);
-            const sep = localeObj.decimalSeparator();
-            // @ts-ignore    
-            return `${(this.value * 100).toFixed(2).replace('.', sep)}%`;
+            // @ts-ignore
+            return formatValue(this.value, locale)
         }
     };
+}
+
+export function formatValue(value: number, locale: string) {
+    const localeObj = buildLocale(locale);
+    const sep = localeObj.decimalSeparator();
+    return `${(value * 100).toFixed(2).replace('.', sep)}%`;
+
 }

--- a/src/components/viewpage/graphic/formatterForSerie.tsx
+++ b/src/components/viewpage/graphic/formatterForSerie.tsx
@@ -1,0 +1,11 @@
+import { buildLocale } from "../../common/locale/buildLocale";
+export function formatterForSerie(locale: string) {
+    return {
+        formatter(): string {
+            const localeObj = buildLocale(locale);
+            const sep = localeObj.decimalSeparator();
+            // @ts-ignore    
+            return `${(this.value * 100).toFixed(2).replace('.', sep)}%`;
+        }
+    };
+}

--- a/src/tests/components/helpers/ChartYAxisValueFormatter.test.ts
+++ b/src/tests/components/helpers/ChartYAxisValueFormatter.test.ts
@@ -1,0 +1,11 @@
+import { formatValue } from "../../../components/viewpage/graphic/formatterForSerie";
+
+it("Formats a value with AR locale with a comma", () => {
+    const formatted = formatValue(0.1, 'AR')
+    expect(formatted).toBe('10,00%')
+});
+
+it("Formats a value with US locale with a dot", () => {
+    const formatted = formatValue(0.1, 'US')
+    expect(formatted).toBe('10.00%')
+});

--- a/src/tests/components/helpers/ChartYAxisValueFormatter.test.ts
+++ b/src/tests/components/helpers/ChartYAxisValueFormatter.test.ts
@@ -1,11 +1,13 @@
 import { formatValue } from "../../../components/viewpage/graphic/formatterForSerie";
 
-it("Formats a value with AR locale with a comma", () => {
-    const formatted = formatValue(0.1, 'AR')
-    expect(formatted).toBe('10,00%')
-});
+describe("formatterForSerie", () => {
+    it("Formats a value with AR locale with a comma", () => {
+        const formatted = formatValue(0.1, 'AR')
+        expect(formatted).toBe('10,00%')
+    });
 
-it("Formats a value with US locale with a dot", () => {
-    const formatted = formatValue(0.1, 'US')
-    expect(formatted).toBe('10.00%')
+    it("Formats a value with US locale with a dot", () => {
+        const formatted = formatValue(0.1, 'US')
+        expect(formatted).toBe('10.00%')
+    });
 });


### PR DESCRIPTION
Faltaba aplicar el formateo de la coma/punto según locale.

Closes #390 
