### PR TITLE
Atributos para overridear titulo, fuente y unidades

### DIFF
--- a/src/components/exportable/CardExportable.tsx
+++ b/src/components/exportable/CardExportable.tsx
@@ -55,7 +55,10 @@ export default class CardExportable extends React.Component<ICardExportableProps
                 explicitSign: this.props.explicitSign,
                 hasChart: this.props.hasChart,
                 links: this.props.links,
-                locale: this.props.locale
+                locale: this.props.locale,
+                sourceOverride: this.props.sourceOverride,
+                titleOverride: this.props.titleOverride,
+                unitsOverride:this.props.unitsOverride
             },
             downloadUrl: this.getDownloadUrl(),
             laps: this.state.laps,

--- a/src/components/exportable/CardExportable.tsx
+++ b/src/components/exportable/CardExportable.tsx
@@ -56,9 +56,9 @@ export default class CardExportable extends React.Component<ICardExportableProps
                 hasChart: this.props.hasChart,
                 links: this.props.links,
                 locale: this.props.locale,
-                sourceOverride: this.props.sourceOverride,
-                titleOverride: this.props.titleOverride,
-                unitsOverride:this.props.unitsOverride
+                source: this.props.source,
+                title: this.props.title,
+                units:this.props.units
             },
             downloadUrl: this.getDownloadUrl(),
             laps: this.state.laps,

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -34,13 +34,13 @@ export default (props: IFullCardProps) => {
     return (
         <FullCardContainer cardOptions={props.cardOptions}>
             <FullCardHeader color={props.cardOptions.color}
-                            override={props.cardOptions.titleOverride}
-                            title={props.serie.description}
+                            override={props.cardOptions.title}
+                            defaultTitle={props.serie.description}
                             date={lastSerieDate(props.serie)} />
             <FullCardValue color={props.cardOptions.color} text={formatter.formattedValue(value)} />
             <FullCardChart data={shortDataList(props.serie.data, props.laps)} chartType={props.cardOptions.hasChart} />
-            <FullCardUnits units={props.serie.units} override={props.cardOptions.unitsOverride}/>
-            <FullCardSource source={props.serie.datasetSource} override={props.cardOptions.sourceOverride}/>
+            <FullCardUnits units={props.serie.units} override={props.cardOptions.units}/>
+            <FullCardSource source={props.serie.datasetSource} override={props.cardOptions.source}/>
             <FullCardLinks options={options} />
         </FullCardContainer>
     )

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -6,6 +6,8 @@ import { fullLocaleDate } from '../../helpers/dateFunctions';
 import { ICardBaseConfig } from '../../indexCard';
 import FullCardContainer from '../style/exportable_card/FullCardContainer';
 import FullCardHeader from '../style/exportable_card/FullCardHeader';
+import FullCardSource from '../style/exportable_card/FullCardSource';
+import FullCardUnits from '../style/exportable_card/FullCardUnits';
 import FullCardValue from '../style/exportable_card/FullCardValue';
 import FullCardChart from './FullCardChart';
 import FullCardLinks from './FullCardLinks';
@@ -28,14 +30,17 @@ export default (props: IFullCardProps) => {
     const value = props.serie.data[props.serie.data.length-1].value
     const formatter = new CardValueFormatter(
         props.cardOptions.locale, props.serie.isPercentage, props.cardOptions.explicitSign)
-
+        
     return (
         <FullCardContainer cardOptions={props.cardOptions}>
-            <FullCardHeader color={props.cardOptions.color} title={props.serie.description} date={lastSerieDate(props.serie)} />
+            <FullCardHeader color={props.cardOptions.color}
+                            override={props.cardOptions.titleOverride}
+                            title={props.serie.description}
+                            date={lastSerieDate(props.serie)} />
             <FullCardValue color={props.cardOptions.color} text={formatter.formattedValue(value)} />
             <FullCardChart data={shortDataList(props.serie.data, props.laps)} chartType={props.cardOptions.hasChart} />
-            <p className="c-main-title">{props.serie.units}</p>
-            <p className="c-span bt">Fuente: {props.serie.datasetSource}</p>
+            <FullCardUnits units={props.serie.units} override={props.cardOptions.unitsOverride}/>
+            <FullCardSource source={props.serie.datasetSource} override={props.cardOptions.sourceOverride}/>
             <FullCardLinks options={options} />
         </FullCardContainer>
     )

--- a/src/components/style/exportable_card/FullCardHeader.tsx
+++ b/src/components/style/exportable_card/FullCardHeader.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 
+interface IHeaderProps {
+    defaultTitle: string;
+    override: string;
+    date: string;
+    color: string;
+}
 
-export default (props: {defaultTitle: string, override: string, date: string, color: string}) => {
+export default (props: IHeaderProps) => {
     if (props.override === "") {
         return(
             <p className="c-span">{props.date}</p>

--- a/src/components/style/exportable_card/FullCardHeader.tsx
+++ b/src/components/style/exportable_card/FullCardHeader.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 
 
-export default (props: {title: string, override: string, date: string, color: string}) => {
+export default (props: {defaultTitle: string, override: string, date: string, color: string}) => {
     if (props.override === "") {
-        return <div/>
+        return(
+            <p className="c-span">{props.date}</p>
+        )
     }
-    const title = props.override === undefined ? props.title : props.override
+    const title = props.override === undefined ? props.defaultTitle : props.override
     return(
         <div className="c-head">
             <p className="c-title" style={{borderTop: props.color}}>{title}</p>

--- a/src/components/style/exportable_card/FullCardHeader.tsx
+++ b/src/components/style/exportable_card/FullCardHeader.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
 
 
-export default (props: {title: string, date: string, color: string}) =>
-    <div className="c-head">
-        <p className="c-title" style={{borderTop: props.color}}>{props.title}</p>
-        <p className="c-span">{props.date}</p>
-    </div>
+export default (props: {title: string, override: string, date: string, color: string}) => {
+    if (props.override === "") {
+        return <div/>
+    }
+    const title = props.override === undefined ? props.title : props.override
+    return(
+        <div className="c-head">
+            <p className="c-title" style={{borderTop: props.color}}>{title}</p>
+            <p className="c-span">{props.date}</p>
+        </div>)
+}
+    

--- a/src/components/style/exportable_card/FullCardSource.tsx
+++ b/src/components/style/exportable_card/FullCardSource.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+
+export default (props: {source: string, override: string}) => {
+    if (props.override === "") {
+        return <div/>
+    }
+    const source = props.override === undefined ? "Fuente: " + props.source : props.override
+    return <p className="c-span bt">{source}</p>
+}

--- a/src/components/style/exportable_card/FullCardSource.tsx
+++ b/src/components/style/exportable_card/FullCardSource.tsx
@@ -6,5 +6,5 @@ export default (props: {source: string, override: string}) => {
         return <div/>
     }
     const source = props.override === undefined ? "Fuente: " + props.source : props.override
-    return <p className="c-span bt">{source}</p>
+    return <p className="c-span bt c-source">{source}</p>
 }

--- a/src/components/style/exportable_card/FullCardUnits.tsx
+++ b/src/components/style/exportable_card/FullCardUnits.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+
+export default (props: {units: string, override: string}) => {
+    if (props.override === "") {
+        return <div/>
+    }
+    const units = props.override === undefined ? props.units : props.override
+    return <p className="c-main-title">{units}</p>
+}

--- a/src/indexCard.tsx
+++ b/src/indexCard.tsx
@@ -11,8 +11,9 @@ export interface ICardBaseConfig {
     hasChart: string;
     chartType: string;
     explicitSign: boolean | false;
-    title?: string;
-    source?: string;
+    titleOverride: string;
+    sourceOverride: string;
+    unitsOverride: string;
 }
 
 export interface ICardExportableConfig extends ICardBaseConfig {
@@ -30,8 +31,9 @@ export function render(selector: string, config: ICardExportableConfig) {
                         hasChart={config.hasChart || 'full'}
                         chartType={config.chartType}
                         explicitSign={config.explicitSign}
-                        title={config.title}
-                        source={config.source}
+                        titleOverride={config.titleOverride}
+                        sourceOverride={config.sourceOverride}
+                        unitsOverride={config.unitsOverride}
                         seriesApi={seriesApi} />,
         document.getElementById(selector) as HTMLElement
     )

--- a/src/indexCard.tsx
+++ b/src/indexCard.tsx
@@ -11,9 +11,9 @@ export interface ICardBaseConfig {
     hasChart: string;
     chartType: string;
     explicitSign: boolean | false;
-    titleOverride: string;
-    sourceOverride: string;
-    unitsOverride: string;
+    title: string;
+    source: string;
+    units: string;
 }
 
 export interface ICardExportableConfig extends ICardBaseConfig {
@@ -31,9 +31,9 @@ export function render(selector: string, config: ICardExportableConfig) {
                         hasChart={config.hasChart || 'full'}
                         chartType={config.chartType}
                         explicitSign={config.explicitSign}
-                        titleOverride={config.titleOverride}
-                        sourceOverride={config.sourceOverride}
-                        unitsOverride={config.unitsOverride}
+                        title={config.title}
+                        source={config.source}
+                        units={config.units}
                         seriesApi={seriesApi} />,
         document.getElementById(selector) as HTMLElement
     )

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -94,22 +94,28 @@ describe('FullCard', () => {
         beforeAll(() => {
             mockSerie = generateMockSerie();
             mockCardOptions = generateMockCardOptions();
-            mockCardOptions.source = ""
-            mockCardOptions.title = ""
-            mockCardOptions.units = ""
+        })
+
+        function mountFullCard() {
             wrapper = mount(<FullCard serie={mockSerie}
                 downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
                 laps={3}
-                cardOptions={mockCardOptions} />);
-        })
+                cardOptions={mockCardOptions} />)
+        }
     
         it('does not render the title header', () => {
+            mockCardOptions.title = "";
+            mountFullCard();
             expect(wrapper.find('div .c-head').exists()).toBe(false)
         })
         it('does not render the source', () => {
+            mockCardOptions.source = "";
+            mountFullCard();
             expect(wrapper.find('p .c-source').exists()).toBe(false);
         })
         it('does not render the units', () => {
+            mockCardOptions.units = "";
+            mountFullCard();
             expect(wrapper.find('p .c-main-title').exists()).toBe(false);
         })
 

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -1,0 +1,129 @@
+import { configure, mount, ReactWrapper } from "enzyme";
+import * as Adapter from 'enzyme-adapter-react-16';
+import * as React from 'react';
+import { ISerie } from "../../../api/Serie";
+import FullCard from "../../../components/exportable_card/FullCard";
+
+configure({ adapter: new Adapter() });
+
+describe('FullCard', () => {
+
+    let mockSerie: ISerie;
+    let mockCardOptions: any;
+    let wrapper: ReactWrapper<any, any>;
+
+    function generateMockSerie() {
+        return {
+            accrualPeriodicity: "Mensual",
+            collapseAggregation: "CollapseAgregation",
+            data: [{ date: "2019-03-01", value: 150 },
+            { date: "2019-02-01", value: 140 },
+            { date: "2019-01-01", value: 180 }],
+            datasetSource: "EMAE",
+            datasetTitle: "EMAE",
+            description: "Descripcion",
+            distributionTitle: "EMAE. Base",
+            downloadURL: "https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv",
+            endDate: "2019-03-01",
+            frequency: "Mensual",
+            id: "143.3_NO_PR_2004_A_21",
+            isPercentage: false,
+            issued: "Issued",
+            landingPage: "LandingPage",
+            maxValue: 200,
+            minValue: 0,
+            modified: "Modified",
+            publisher: {
+                mbox: "Mbox",
+                name: "Name"
+            },
+            representationMode: "RepresentationMode",
+            representationModeUnits: "RepresentationModeUnits",
+            startDate: "2019-01-01",
+            themes: [{ id: "1", descripcion: "Tema1", label: "Label1" },
+            { id: "2", descripcion: "Tema2", label: "Label2" },
+            { id: "3", descripcion: "Tema3", label: "Label3" }],
+            timeIndexSize: 3,
+            title: "EMAE. Base 2004",
+            units: "Índice 2004=100",
+        }
+    }
+
+    describe('Shown overrideable attributes', () => {
+
+        beforeAll(() => {
+            mockSerie = generateMockSerie();
+            mockCardOptions = generateMockCardOptions();
+            wrapper = mount(<FullCard serie={mockSerie}
+                downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
+                laps={3}
+                cardOptions={mockCardOptions} />);
+        })
+
+        function generateMockCardOptions() {
+            return {
+                chartType: "line",
+                color: "#047FBC",
+                explicitSign: true,
+                hasChart: "full",
+                links: "full",
+                locale: "AR",
+                sourceOverride: undefined,
+                titleOverride: undefined,
+                unitsOverride: undefined
+            }
+        }
+
+        it('renders without crashing', () => {
+            expect(wrapper.find(FullCard).exists()).toBe(true);
+        });
+        it('renders the title header', () => {
+            expect(wrapper.find('div .c-head').exists()).toBe(true)
+        })
+        it('renders the source', () => {
+            expect(wrapper.find('p .c-span').exists()).toBe(true);
+        })
+        it('renders the units', () => {
+            expect(wrapper.find('p .c-main-title').exists()).toBe(true);
+        })
+
+    })
+
+    describe('Hidden overrideable attributes', () => {
+
+        beforeAll(() => {
+            mockSerie = generateMockSerie();
+            mockCardOptions = generateMockCardOptions();
+            wrapper = mount(<FullCard serie={mockSerie}
+                downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
+                laps={3}
+                cardOptions={mockCardOptions} />);
+        })
+
+        function generateMockCardOptions() {
+            return {
+                chartType: "line",
+                color: "#047FBC",
+                explicitSign: true,
+                hasChart: "full",
+                links: "full",
+                locale: "AR",
+                sourceOverride: "",
+                titleOverride: "",
+                unitsOverride: ""
+            }
+        }
+    
+        it('does not render the title header', () => {
+            expect(wrapper.find('div .c-head').exists()).toBe(false)
+        })
+        it('does not render the source', () => {
+            expect(wrapper.find('p .c-span').exists()).toBe(false);
+        })
+        it('does not render the units', () => {
+            expect(wrapper.find('p .c-main-title').exists()).toBe(false);
+        })
+
+    })
+
+})

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -49,6 +49,20 @@ describe('FullCard', () => {
         }
     }
 
+    function generateMockCardOptions() {
+        return {
+            chartType: "line",
+            color: "#047FBC",
+            explicitSign: true,
+            hasChart: "full",
+            links: "full",
+            locale: "AR",
+            sourceOverride: undefined,
+            titleOverride: undefined,
+            unitsOverride: undefined
+        }
+    }
+
     describe('Shown overrideable attributes', () => {
 
         beforeAll(() => {
@@ -59,20 +73,6 @@ describe('FullCard', () => {
                 laps={3}
                 cardOptions={mockCardOptions} />);
         })
-
-        function generateMockCardOptions() {
-            return {
-                chartType: "line",
-                color: "#047FBC",
-                explicitSign: true,
-                hasChart: "full",
-                links: "full",
-                locale: "AR",
-                sourceOverride: undefined,
-                titleOverride: undefined,
-                unitsOverride: undefined
-            }
-        }
 
         it('renders without crashing', () => {
             expect(wrapper.find(FullCard).exists()).toBe(true);
@@ -94,25 +94,14 @@ describe('FullCard', () => {
         beforeAll(() => {
             mockSerie = generateMockSerie();
             mockCardOptions = generateMockCardOptions();
+            mockCardOptions.sourceOverride = ""
+            mockCardOptions.titleOverride = ""
+            mockCardOptions.unitsOverride = ""
             wrapper = mount(<FullCard serie={mockSerie}
                 downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
                 laps={3}
                 cardOptions={mockCardOptions} />);
         })
-
-        function generateMockCardOptions() {
-            return {
-                chartType: "line",
-                color: "#047FBC",
-                explicitSign: true,
-                hasChart: "full",
-                links: "full",
-                locale: "AR",
-                sourceOverride: "",
-                titleOverride: "",
-                unitsOverride: ""
-            }
-        }
     
         it('does not render the title header', () => {
             expect(wrapper.find('div .c-head').exists()).toBe(false)

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -57,9 +57,9 @@ describe('FullCard', () => {
             hasChart: "full",
             links: "full",
             locale: "AR",
-            sourceOverride: undefined,
-            titleOverride: undefined,
-            unitsOverride: undefined
+            source: undefined,
+            title: undefined,
+            units: undefined
         }
     }
 
@@ -94,9 +94,9 @@ describe('FullCard', () => {
         beforeAll(() => {
             mockSerie = generateMockSerie();
             mockCardOptions = generateMockCardOptions();
-            mockCardOptions.sourceOverride = ""
-            mockCardOptions.titleOverride = ""
-            mockCardOptions.unitsOverride = ""
+            mockCardOptions.source = ""
+            mockCardOptions.title = ""
+            mockCardOptions.units = ""
             wrapper = mount(<FullCard serie={mockSerie}
                 downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
                 laps={3}
@@ -107,7 +107,7 @@ describe('FullCard', () => {
             expect(wrapper.find('div .c-head').exists()).toBe(false)
         })
         it('does not render the source', () => {
-            expect(wrapper.find('p .c-span').exists()).toBe(false);
+            expect(wrapper.find('p .c-source').exists()).toBe(false);
         })
         it('does not render the units', () => {
             expect(wrapper.find('p .c-main-title').exists()).toBe(false);


### PR DESCRIPTION
- Agrego tres atributos para poder elegir si overridear, dejar como está, o incluso ocultar el título, las unidades, y la fuente de la card: `titleOverride`, `unitsOverride` y `sourceOverride`.
- Agrego test de renderización para el componente FullCard