### PR TITLE
Agrego uso de Shiitake para poder truncar las unidades muy largas a una altura maxima de dos lineas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11006,6 +11006,14 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
+    "shiitake": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/shiitake/-/shiitake-2.3.0.tgz",
+      "integrity": "sha512-NsbSvqgV4DdX7bozmO3CJOFeRoIxF0+I76ZLSyvsiFK8wnrgyenYPen3MkE/UBh8bAMsH7SIoacISsDaglYk7w==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "redux": "^4.0.0",
     "request": "^2.88.0",
     "resolve": "1.6.0",
+    "shiitake": "^2.3.0",
     "source-map-loader": "^0.2.1",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",

--- a/src/components/style/exportable_card/FullCardUnits.tsx
+++ b/src/components/style/exportable_card/FullCardUnits.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-
+import Shiitake from 'shiitake'
 
 export default (props: {units: string, override: string}) => {
     if (props.override === "") {
         return <div/>
     }
     const units = props.override === undefined ? props.units : props.override
-    return <p className="c-main-title">{units}</p>
+    return <Shiitake lines={2} className="c-main-title" tagName="p">{units}</Shiitake>
 }

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -1,6 +1,7 @@
 import { configure, mount, ReactWrapper } from "enzyme";
 import * as Adapter from 'enzyme-adapter-react-16';
 import * as React from 'react';
+import Shiitake from "shiitake";
 import { ISerie } from "../../../api/Serie";
 import FullCard from "../../../components/exportable_card/FullCard";
 
@@ -68,6 +69,8 @@ describe('FullCard', () => {
         beforeAll(() => {
             mockSerie = generateMockSerie();
             mockCardOptions = generateMockCardOptions();
+            mockCardOptions.units = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
+            mockCardOptions.units += "sed do eiusmod tempor incididunt ut labore et dolore"
             wrapper = mount(<FullCard serie={mockSerie}
                 downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
                 laps={3}
@@ -84,9 +87,8 @@ describe('FullCard', () => {
             expect(wrapper.find('p .c-span').exists()).toBe(true);
         })
         it('renders the units', () => {
-            expect(wrapper.find('p .c-main-title').exists()).toBe(true);
+            expect(wrapper.find(Shiitake).exists()).toBe(true);
         })
-
     })
 
     describe('Hidden overrideable attributes', () => {
@@ -116,7 +118,7 @@ describe('FullCard', () => {
         it('does not render the units', () => {
             mockCardOptions.units = "";
             mountFullCard();
-            expect(wrapper.find('p .c-main-title').exists()).toBe(false);
+            expect(wrapper.find(Shiitake).exists()).toBe(false);
         })
 
     })

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -69,8 +69,7 @@ describe('FullCard', () => {
         beforeAll(() => {
             mockSerie = generateMockSerie();
             mockCardOptions = generateMockCardOptions();
-            mockCardOptions.units = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
-            mockCardOptions.units += "sed do eiusmod tempor incididunt ut labore et dolore"
+            mockCardOptions.units = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore"
             wrapper = mount(<FullCard serie={mockSerie}
                 downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
                 laps={3}
@@ -87,7 +86,7 @@ describe('FullCard', () => {
             expect(wrapper.find('p .c-span').exists()).toBe(true);
         })
         it('renders the units', () => {
-            expect(wrapper.find(Shiitake).exists()).toBe(true);
+            expect(wrapper.find('p .c-main-title').text()).toContain("Lorem ipsum dolor sit amet, consectetur adipiscing");
         })
     })
 


### PR DESCRIPTION
Uso Shiitake en el componente `FullCardUnits` para wrappear el `<p>` con el texto de unidades