### PR TITLE
Cambio uso de units a representationModeUnits, y mejoro algunos tests

### DIFF
--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -39,7 +39,7 @@ export default (props: IFullCardProps) => {
                             date={lastSerieDate(props.serie)} />
             <FullCardValue color={props.cardOptions.color} text={formatter.formattedValue(value)} />
             <FullCardChart data={shortDataList(props.serie.data, props.laps)} chartType={props.cardOptions.hasChart} />
-            <FullCardUnits units={props.serie.units} override={props.cardOptions.units}/>
+            <FullCardUnits units={props.serie.representationModeUnits} override={props.cardOptions.units}/>
             <FullCardSource source={props.serie.datasetSource} override={props.cardOptions.source}/>
             <FullCardLinks options={options} />
         </FullCardContainer>

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -20,9 +20,9 @@ describe('FullCard', () => {
             data: [{ date: "2019-03-01", value: 150 },
             { date: "2019-02-01", value: 140 },
             { date: "2019-01-01", value: 180 }],
-            datasetSource: "EMAE",
+            datasetSource: "Instituto Nacional de Estadística y Censos (INDEC)",
             datasetTitle: "EMAE",
-            description: "Descripcion",
+            description: "EMAE. Base 2004",
             distributionTitle: "EMAE. Base",
             downloadURL: "https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv",
             endDate: "2019-03-01",
@@ -39,7 +39,7 @@ describe('FullCard', () => {
                 name: "Name"
             },
             representationMode: "RepresentationMode",
-            representationModeUnits: "RepresentationModeUnits",
+            representationModeUnits: "Indice Personalizado",
             startDate: "2019-01-01",
             themes: [{ id: "1", descripcion: "Tema1", label: "Label1" },
             { id: "2", descripcion: "Tema2", label: "Label2" },
@@ -69,7 +69,7 @@ describe('FullCard', () => {
         beforeAll(() => {
             mockSerie = generateMockSerie();
             mockCardOptions = generateMockCardOptions();
-            mockCardOptions.units = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore"
+            mockCardOptions.units = "Lorem ipsum dolor sit amet"
             wrapper = mount(<FullCard serie={mockSerie}
                 downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
                 laps={3}
@@ -79,14 +79,14 @@ describe('FullCard', () => {
         it('renders without crashing', () => {
             expect(wrapper.find(FullCard).exists()).toBe(true);
         });
-        it('renders the title header', () => {
-            expect(wrapper.find('div .c-head').exists()).toBe(true)
+        it('renders the default title header', () => {
+            expect(wrapper.find('p .c-title').text()).toContain("EMAE. Base 2004")
         })
-        it('renders the source', () => {
-            expect(wrapper.find('p .c-span').exists()).toBe(true);
+        it('renders the default source', () => {
+            expect(wrapper.find('p .c-source').text()).toContain("Fuente: Instituto Nacional de Estadística y Censos (INDEC)");
         })
-        it('renders the units', () => {
-            expect(wrapper.find('p .c-main-title').text()).toContain("Lorem ipsum dolor sit amet, consectetur adipiscing");
+        it('renders the overriden units', () => {
+            expect(wrapper.find('p .c-main-title').text()).toContain("Lorem ipsum dolor sit amet");
         })
     })
 
@@ -117,7 +117,7 @@ describe('FullCard', () => {
         it('does not render the units', () => {
             mockCardOptions.units = "";
             mountFullCard();
-            expect(wrapper.find(Shiitake).exists()).toBe(false);
+            expect(wrapper.find('p .c-main-title').exists()).toBe(false);
         })
 
     })

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -39,7 +39,7 @@ describe('FullCard', () => {
                 name: "Name"
             },
             representationMode: "RepresentationMode",
-            representationModeUnits: "Indice Personalizado",
+            representationModeUnits: "Indice Especial",
             startDate: "2019-01-01",
             themes: [{ id: "1", descripcion: "Tema1", label: "Label1" },
             { id: "2", descripcion: "Tema2", label: "Label2" },
@@ -64,12 +64,11 @@ describe('FullCard', () => {
         }
     }
 
-    describe('Shown overrideable attributes', () => {
+    describe('Shown default attributes', () => {
 
         beforeAll(() => {
             mockSerie = generateMockSerie();
             mockCardOptions = generateMockCardOptions();
-            mockCardOptions.units = "Lorem ipsum dolor sit amet"
             wrapper = mount(<FullCard serie={mockSerie}
                 downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
                 laps={3}
@@ -84,6 +83,34 @@ describe('FullCard', () => {
         })
         it('renders the default source', () => {
             expect(wrapper.find('p .c-source').text()).toContain("Fuente: Instituto Nacional de Estadística y Censos (INDEC)");
+        })
+        it('renders the overriden units', () => {
+            expect(wrapper.find('p .c-main-title').text()).toContain("Indice Especial");
+        })
+    })
+
+    describe('Shown overriden attributes', () => {
+
+        beforeAll(() => {
+            mockSerie = generateMockSerie();
+            mockCardOptions = generateMockCardOptions();
+            mockCardOptions.title = "Lorem ipsum dolor sit amet"
+            mockCardOptions.source = "Lorem ipsum dolor sit amet"
+            mockCardOptions.units = "Lorem ipsum dolor sit amet"
+            wrapper = mount(<FullCard serie={mockSerie}
+                downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
+                laps={3}
+                cardOptions={mockCardOptions} />);
+        })
+
+        it('renders without crashing', () => {
+            expect(wrapper.find(FullCard).exists()).toBe(true);
+        });
+        it('renders the default title header', () => {
+            expect(wrapper.find('p .c-title').text()).toContain("Lorem ipsum dolor sit amet")
+        })
+        it('renders the default source', () => {
+            expect(wrapper.find('p .c-source').text()).toContain("Lorem ipsum dolor sit amet");
         })
         it('renders the overriden units', () => {
             expect(wrapper.find('p .c-main-title').text()).toContain("Lorem ipsum dolor sit amet");

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -1,7 +1,6 @@
 import { configure, mount, ReactWrapper } from "enzyme";
 import * as Adapter from 'enzyme-adapter-react-16';
 import * as React from 'react';
-import Shiitake from "shiitake";
 import { ISerie } from "../../../api/Serie";
 import FullCard from "../../../components/exportable_card/FullCard";
 
@@ -64,15 +63,22 @@ describe('FullCard', () => {
         }
     }
 
+    function mountFullCard() {
+        wrapper = mount(<FullCard serie={mockSerie}
+            downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
+            laps={3}
+            cardOptions={mockCardOptions} />)
+    }
+
+    beforeAll(() => {
+        mockSerie = generateMockSerie();
+        mockCardOptions = generateMockCardOptions();
+    })
+
     describe('Shown default attributes', () => {
 
         beforeAll(() => {
-            mockSerie = generateMockSerie();
-            mockCardOptions = generateMockCardOptions();
-            wrapper = mount(<FullCard serie={mockSerie}
-                downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
-                laps={3}
-                cardOptions={mockCardOptions} />);
+            mountFullCard();
         })
 
         it('renders without crashing', () => {
@@ -91,46 +97,29 @@ describe('FullCard', () => {
 
     describe('Shown overriden attributes', () => {
 
-        beforeAll(() => {
-            mockSerie = generateMockSerie();
-            mockCardOptions = generateMockCardOptions();
-            mockCardOptions.title = "Lorem ipsum dolor sit amet"
-            mockCardOptions.source = "Lorem ipsum dolor sit amet"
-            mockCardOptions.units = "Lorem ipsum dolor sit amet"
-            wrapper = mount(<FullCard serie={mockSerie}
-                downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
-                laps={3}
-                cardOptions={mockCardOptions} />);
-        })
-
         it('renders without crashing', () => {
+            mountFullCard();
             expect(wrapper.find(FullCard).exists()).toBe(true);
         });
         it('renders the default title header', () => {
+            mockCardOptions.title = "Lorem ipsum dolor sit amet";
+            mountFullCard();
             expect(wrapper.find('p .c-title').text()).toContain("Lorem ipsum dolor sit amet")
         })
         it('renders the default source', () => {
+            mockCardOptions.source = "Lorem ipsum dolor sit amet";
+            mountFullCard();
             expect(wrapper.find('p .c-source').text()).toContain("Lorem ipsum dolor sit amet");
         })
         it('renders the overriden units', () => {
+            mockCardOptions.units = "Lorem ipsum dolor sit amet";
+            mountFullCard();
             expect(wrapper.find('p .c-main-title').text()).toContain("Lorem ipsum dolor sit amet");
         })
     })
 
     describe('Hidden overrideable attributes', () => {
-
-        beforeAll(() => {
-            mockSerie = generateMockSerie();
-            mockCardOptions = generateMockCardOptions();
-        })
-
-        function mountFullCard() {
-            wrapper = mount(<FullCard serie={mockSerie}
-                downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
-                laps={3}
-                cardOptions={mockCardOptions} />)
-        }
-    
+  
         it('does not render the title header', () => {
             mockCardOptions.title = "";
             mountFullCard();


### PR DESCRIPTION
- Cambio el uso de la propiedad `units` de las series al `representationModeUnits`, para mostrar correctamente las unidades en caso de series porcentuales
- Cambio tests de FullCard, para que no evalúe que se rendereen los nodos, sino también que su contenido sea correcto. Separo en un `describe` para parámetros no overrideados (por default) y otro para parámetros overrideados (y no nulos)

Closes #400 