### PR TITLE
403 revisar componentes ejemplo gobar

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -274,8 +274,13 @@
   -webkit-line-clamp: 2;
 }
 
+.card .c-links {
+  height: 35px;
+}
+
 .card .c-foot {
   height: 35px;
+  display: inline-flex;
 }
 
 .card .c-foot div {
@@ -283,7 +288,6 @@
   float: left;
   height: 100%;
   text-align: center;
-  padding-top: 6px;
 }
 
 .card .c-foot div:only-child {
@@ -301,6 +305,12 @@
 
 .card .c-foot div a:hover {
   color: #005388;
+}
+
+.c-foot .c-download, .c-foot .c-viewmore {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .card .dropdown {

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -320,7 +320,7 @@
 
 /* Iconos */
 
-.fa-angle-up {
+.fa-angle-up, .fa-link {
   font-family: 'Font Awesome\ 5 Free';
   color: #0072BB;
 }

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -118,6 +118,10 @@
   padding: 7.5px 10px;
 }
 
+.card .graphic {
+  text-align: center;
+}
+
 .card.normal .c-data .graphic img {
   width: 100%;
   height: 100%;
@@ -152,7 +156,6 @@
 .card.full {
   -webkit-box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.5);
-  border-top: 5px solid #0072BB;
   background: #ffffff;
 }
 
@@ -304,6 +307,9 @@
   padding-top: 0 !important;
   text-align: center !important;
   width: 100% !important;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .__react_component_tooltip {
@@ -311,3 +317,12 @@
 }
 
 /* Fin Card */
+
+/* Iconos */
+
+.fa-angle-up {
+  font-family: 'Font Awesome\ 5 Free';
+  color: #0072BB;
+}
+
+/* Fin Iconos */

--- a/src/components/exportable_card/FullCardLinks.tsx
+++ b/src/components/exportable_card/FullCardLinks.tsx
@@ -23,6 +23,11 @@ interface IFullCardLinksOptions extends ICardBaseConfig {
 
 export default (props: { options: IFullCardLinksOptions }) => {
     const LinkComponent = TYPES[props.options.links]
+    
+    let linkClass = "c-links"
+    if (props.options.links === 'none') {
+        linkClass = ""
+    }
 
-    return <div> <LinkComponent options={props.options} /> </div>
+    return <div className={linkClass}> <LinkComponent options={props.options} /> </div>
 }

--- a/src/components/exportable_card/links/FullLinks.tsx
+++ b/src/components/exportable_card/links/FullLinks.tsx
@@ -7,7 +7,7 @@ import FullCardViewMore from '../FullCardViewMore';
 
 export default (props: {options: ICardLinksOptions}) =>
     <div className="c-foot">
-        <div><FullCardDownload downloadUrl={props.options.downloadUrl} /></div>
-        <div><FullCardViewMore serieId={props.options.serieId} /></div>
+        <div className="c-download"><FullCardDownload downloadUrl={props.options.downloadUrl} /></div>
+        <div className="c-viewmore"><FullCardViewMore serieId={props.options.serieId} /></div>
         <div className="enlaces"><FullCardDropdown options={props.options} /></div>
     </div>

--- a/src/components/style/Share/LinkShareItem.tsx
+++ b/src/components/style/Share/LinkShareItem.tsx
@@ -10,10 +10,10 @@ interface ILinkShareProps {
 export default (props: ILinkShareProps) =>
 
     <CopyToClipboard text={props.url}>
-        <li data-tip="Click me to show the tooltip" >
+        <li>
             <a className="pointer" >
                 <span>
-                    <i className="fas fa-link fa-lg"/> {props.text}
+                    <i className="fas fa-link"/> {props.text}
                 </span>
             </a>
         </li>

--- a/src/components/style/Share/ShareDropdownContainer.tsx
+++ b/src/components/style/Share/ShareDropdownContainer.tsx
@@ -12,12 +12,12 @@ export default (props: IShareDropdownContainerProps) => {
 
     return (
         <div className="dropdown">
-            <a href="#" className="btn btn-gray dropdown-toggle" data-toggle="dropdown">
+            <a className="btn btn-gray dropdown-toggle" data-toggle="dropdown">
                 {text} <i className="fas fa-angle-up"/> 
             </a>
             <ul className="dropdown-menu" {...propsAux} />
 
-            <ReactTooltip effect="solid" getContent={tooltipContent} place="right" globalEventOff='click' />
+            <ReactTooltip effect="solid" getContent={tooltipContent} place="right" globalEventOff="click" />
         </div>
     )
 }

--- a/src/components/style/Share/ShareDropdownContainer.tsx
+++ b/src/components/style/Share/ShareDropdownContainer.tsx
@@ -13,7 +13,7 @@ export default (props: IShareDropdownContainerProps) => {
     return (
         <div className="dropdown">
             <a href="#" className="btn btn-gray dropdown-toggle" data-toggle="dropdown">
-                <i className="fas fa-link fa-lg"/> {text}
+                {text} <i className="fas fa-angle-up"/> 
             </a>
             <ul className="dropdown-menu" {...propsAux} />
 

--- a/src/components/style/exportable_card/FullCardHeader.tsx
+++ b/src/components/style/exportable_card/FullCardHeader.tsx
@@ -15,8 +15,11 @@ export default (props: IHeaderProps) => {
         )
     }
     const title = props.override === undefined ? props.defaultTitle : props.override
+    const borderColorStyle = {
+        borderTop: "5px solid " + props.color
+    };
     return(
-        <div className="c-head" style={{borderTop: props.color}}>
+        <div className="c-head" style={borderColorStyle}>
             <Shiitake lines={2} className="c-title" tagName="p">{title}</Shiitake>
             <p className="c-span">{props.date}</p>
         </div>)

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -84,38 +84,44 @@ describe('FullCard', () => {
         it('renders without crashing', () => {
             expect(wrapper.find(FullCard).exists()).toBe(true);
         });
+        it('renders the links footer', () => {
+            expect(wrapper.find('div .c-links').exists()).toBe(true);
+        });
         it('renders the default title header', () => {
             expect(wrapper.find('p .c-title').text()).toContain("EMAE. Base 2004")
-        })
+        });
         it('renders the default source', () => {
             expect(wrapper.find('p .c-source').text()).toContain("Fuente: Instituto Nacional de Estadística y Censos (INDEC)");
-        })
-        it('renders the overriden units', () => {
+        });
+        it('renders the default units', () => {
             expect(wrapper.find('p .c-main-title').text()).toContain("Indice Especial");
-        })
+        });
+
     })
 
     describe('Shown overriden attributes', () => {
 
-        it('renders without crashing', () => {
+        it('does not render the links footer', () => {
+            mockCardOptions.links = "none";
             mountFullCard();
-            expect(wrapper.find(FullCard).exists()).toBe(true);
+            expect(wrapper.find('div .c-links').exists()).toBe(false);
         });
-        it('renders the default title header', () => {
+        it('renders the overriden title header', () => {
             mockCardOptions.title = "Lorem ipsum dolor sit amet";
             mountFullCard();
             expect(wrapper.find('p .c-title').text()).toContain("Lorem ipsum dolor sit amet")
-        })
-        it('renders the default source', () => {
+        });
+        it('renders the overriden source', () => {
             mockCardOptions.source = "Lorem ipsum dolor sit amet";
             mountFullCard();
             expect(wrapper.find('p .c-source').text()).toContain("Lorem ipsum dolor sit amet");
-        })
+        });
         it('renders the overriden units', () => {
             mockCardOptions.units = "Lorem ipsum dolor sit amet";
             mountFullCard();
             expect(wrapper.find('p .c-main-title').text()).toContain("Lorem ipsum dolor sit amet");
-        })
+        });
+
     })
 
     describe('Hidden overrideable attributes', () => {
@@ -124,17 +130,17 @@ describe('FullCard', () => {
             mockCardOptions.title = "";
             mountFullCard();
             expect(wrapper.find('div .c-head').exists()).toBe(false)
-        })
+        });
         it('does not render the source', () => {
             mockCardOptions.source = "";
             mountFullCard();
             expect(wrapper.find('p .c-source').exists()).toBe(false);
-        })
+        });
         it('does not render the units', () => {
             mockCardOptions.units = "";
             mountFullCard();
             expect(wrapper.find('p .c-main-title').exists()).toBe(false);
-        })
+        });
 
     })
 


### PR DESCRIPTION
- Hago que gráfico embebido siempre esté centrado en la Card
- Hago que borde superior de la Card sea del mismo color que el valor (elegido como parámetro)
- Fijo altura del footer de enlaces (sólo para la opción en que el parámetro `links` vale `'none'`), y alineo todos sus componentes verticalmente
- Corrijo uso de íconos de FontAwesome

Closes #403 