### PR TITLE
412 reemplazar bootstrap

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -327,6 +327,10 @@ main a[href^="https://"][target^="_blank"]::after {
   align-items: center;
 }
 
+.card .btn-group .btn {
+  text-transform: capitalize;
+}
+
 .c-linksButton {
   background-color: transparent;
 }

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -313,13 +313,28 @@
   align-items: center;
 }
 
-.card .dropdown {
+main a[href^="https://"][target^="_blank"]::after,
+main a[href^="https://"][target^="_blank"]::after {
+  content: " ";
+}
+
+.card .btn-group {
   padding-top: 0 !important;
   text-align: center !important;
   width: 100% !important;
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.c-linksButton {
+  background-color: transparent;
+}
+
+.open > .dropdown-toggle .c-linksButton:focus,
+.open > .dropdown-toggle .c-linksButton:hover {
+  background-color: transparent;
+  color: #0072BB;
 }
 
 .__react_component_tooltip {
@@ -330,7 +345,7 @@
 
 /* Iconos */
 
-.fa-angle-up, .fa-link {
+.fa-angle-up, .fa-link, .caret {
   font-family: 'Font Awesome\ 5 Free';
   color: #0072BB;
 }

--- a/src/components/exportable_card/FullCardDropdown.tsx
+++ b/src/components/exportable_card/FullCardDropdown.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import { formatUrl, viewDatosGobAr } from '../common/linkBuilders';
+import FullCardDropdownContainer from '../style/exportable_card/FullCardDropdownContainer';
 import LinkShareItem from '../style/Share/LinkShareItem';
-import ShareDropdownContainer from '../style/Share/ShareDropdownContainer';
 import { ICardLinksOptions } from './FullCardLinks';
 
 export default (props: {options: ICardLinksOptions}) =>
-    <ShareDropdownContainer text="Enlaces">
+    <FullCardDropdownContainer text="Enlaces">
         <LinkShareItem url={viewDatosGobAr(props.options.serieId)} text="Enlace web" />
         <LinkShareItem url={formatUrl(props.options.downloadUrl, "csv")} text="Enlace CSV" />
         <LinkShareItem url={formatUrl(props.options.downloadUrl, "json")} text="Enlace JSON" />
         <LinkShareItem url={webCode(props.options)} text="Código web" />
-    </ShareDropdownContainer>
+    </FullCardDropdownContainer>
 
 export interface IWebSnippetOptions {
     serieId: string,

--- a/src/components/style/Share/LinkShareItem.tsx
+++ b/src/components/style/Share/LinkShareItem.tsx
@@ -10,7 +10,7 @@ interface ILinkShareProps {
 export default (props: ILinkShareProps) =>
 
     <CopyToClipboard text={props.url}>
-        <li>
+        <li data-tip="Click me to show the tooltip">
             <a className="pointer" >
                 <span>
                     <i className="fas fa-link"/> {props.text}

--- a/src/components/style/Share/ShareDropdownContainer.tsx
+++ b/src/components/style/Share/ShareDropdownContainer.tsx
@@ -1,21 +1,27 @@
 import * as React from 'react';
+import * as ReactTooltip from 'react-tooltip';
 
-interface IShareDropdownContainerProps extends React.Props<any> {
+interface IShareDropdownContainerProps extends React.Props<any>{
     text: string;
 }
 
 export default (props: IShareDropdownContainerProps) => {
     const text = props.text;
-    const propsAux = { ...props };
+    const propsAux = {...props};
     delete propsAux.text;
 
     return (
-        <div className="btn-group">
-            <a type="button" className="btn dropdown-toggle c-linksButton"
-               data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                {text} <span className="caret"/>
+        <div className="dropdown">
+            <a href="#" className="btn btn-gray dropdown-toggle" data-toggle="dropdown">
+                <i className="fas fa-link fa-lg"/> {text}
             </a>
             <ul className="dropdown-menu" {...propsAux} />
+
+            <ReactTooltip effect="solid" getContent={tooltipContent} place="right" globalEventOff='click' />
         </div>
     )
+}
+
+function tooltipContent() {
+    return "Click para copiar";
 }

--- a/src/components/style/Share/ShareDropdownContainer.tsx
+++ b/src/components/style/Share/ShareDropdownContainer.tsx
@@ -1,27 +1,21 @@
 import * as React from 'react';
-import * as ReactTooltip from 'react-tooltip';
 
-interface IShareDropdownContainerProps extends React.Props<any>{
+interface IShareDropdownContainerProps extends React.Props<any> {
     text: string;
 }
 
 export default (props: IShareDropdownContainerProps) => {
     const text = props.text;
-    const propsAux = {...props};
+    const propsAux = { ...props };
     delete propsAux.text;
 
     return (
-        <div className="dropdown">
-            <a className="btn btn-gray dropdown-toggle" data-toggle="dropdown">
-                {text} <i className="fas fa-angle-up"/> 
+        <div className="btn-group">
+            <a type="button" className="btn dropdown-toggle c-linksButton"
+               data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                {text} <span className="caret"/>
             </a>
             <ul className="dropdown-menu" {...propsAux} />
-
-            <ReactTooltip effect="solid" getContent={tooltipContent} place="right" globalEventOff="click" />
         </div>
     )
-}
-
-function tooltipContent() {
-    return "Click para copiar";
 }

--- a/src/components/style/exportable_card/FullCardDropdownContainer.tsx
+++ b/src/components/style/exportable_card/FullCardDropdownContainer.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+
+interface IFullCardDropdownContainerProps extends React.Props<any> {
+    text: string;
+}
+
+interface IFullCardDropdownContainerState {
+    open: boolean;
+    text: string;
+    listItems: any;
+}
+
+export default class FullCardDropdownContainer
+    extends React.Component<IFullCardDropdownContainerProps, IFullCardDropdownContainerState> {
+
+    constructor(props: IFullCardDropdownContainerProps) {
+
+        super(props);
+
+        this.toggleOpen = this.toggleOpen.bind(this);
+        this.handleOutsideClick = this.handleOutsideClick.bind(this);
+
+        this.state = {
+            listItems: { ...props },
+            open: false,
+            text: props.text            
+        };
+        delete this.state.listItems.text;
+
+    }
+
+    public componentDidMount() {
+        document.addEventListener('mousedown', this.handleOutsideClick);
+      }
+    
+    public componentWillUnmount() {
+        document.removeEventListener('mousedown', this.handleOutsideClick);
+    }
+
+    public render() {
+        return (
+            <div className={"btn-group" + (this.state.open ? ' open' : '')}
+                 ref={node => { this.context.node = node; }}>
+                <a type="button" className="btn dropdown-toggle c-linksButton" onClick={this.toggleOpen}
+                   data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    {this.state.text} <span className="caret" />
+                </a>
+                <ul className="dropdown-menu" {...this.state.listItems} onClick={this.toggleOpen}/>
+            </div>
+        )
+    }
+
+    private toggleOpen() {
+        const currentState = this.state.open;
+        this.setState({ open: !currentState });
+    };
+      
+    private handleOutsideClick(e: Event) {
+
+        if (this.context.node.contains(e.target)) {
+            return;
+        }
+        
+        this.setState({ open: false });
+    }
+
+}

--- a/src/components/style/exportable_card/FullCardDropdownContainer.tsx
+++ b/src/components/style/exportable_card/FullCardDropdownContainer.tsx
@@ -20,7 +20,7 @@ export default class FullCardDropdownContainer
 
         super(props);
         this.toggleOpen = this.toggleOpen.bind(this);
-        this.handleOutsideClick = this.handleOutsideClick.bind(this);
+        this.closeDropdownOnOutsideClick = this.closeDropdownOnOutsideClick.bind(this);
 
         this.state = {
             listItems: { ...props },
@@ -32,11 +32,11 @@ export default class FullCardDropdownContainer
     }
 
     public componentDidMount() {
-        document.addEventListener('mousedown', this.handleOutsideClick);
+        document.addEventListener('mousedown', this.closeDropdownOnOutsideClick);
       }
     
     public componentWillUnmount() {
-        document.removeEventListener('mousedown', this.handleOutsideClick);
+        document.removeEventListener('mousedown', this.closeDropdownOnOutsideClick);
     }
 
     public render() {
@@ -56,7 +56,7 @@ export default class FullCardDropdownContainer
         this.setState({ open: !currentState });
     };
       
-    private handleOutsideClick(e: Event) {
+    private closeDropdownOnOutsideClick(e: Event) {
         const target = e.target as Node;
         if (this.dropdownRef.current && this.dropdownRef.current.contains(target)) {
             return;

--- a/src/components/style/exportable_card/FullCardDropdownContainer.tsx
+++ b/src/components/style/exportable_card/FullCardDropdownContainer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { createRef } from 'react';
 
 interface IFullCardDropdownContainerProps extends React.Props<any> {
     text: string;
@@ -12,11 +13,12 @@ interface IFullCardDropdownContainerState {
 
 export default class FullCardDropdownContainer
     extends React.Component<IFullCardDropdownContainerProps, IFullCardDropdownContainerState> {
+    
+    private ref: React.RefObject<HTMLDivElement> = createRef();
 
     constructor(props: IFullCardDropdownContainerProps) {
 
         super(props);
-
         this.toggleOpen = this.toggleOpen.bind(this);
         this.handleOutsideClick = this.handleOutsideClick.bind(this);
 
@@ -40,7 +42,8 @@ export default class FullCardDropdownContainer
     public render() {
         return (
             <div className={"btn-group" + (this.state.open ? ' open' : '')}
-                 ref={node => { this.context.node = node; }}>
+                 ref={this.ref}
+                    >
                 <a type="button" className="btn dropdown-toggle c-linksButton" onClick={this.toggleOpen}
                    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     {this.state.text} <span className="caret" />
@@ -56,8 +59,8 @@ export default class FullCardDropdownContainer
     };
       
     private handleOutsideClick(e: Event) {
-
-        if (this.context.node.contains(e.target)) {
+        const target = e.target as Node;
+        if (this.ref.current && this.ref.current.contains(target)) {
             return;
         }
         

--- a/src/components/style/exportable_card/FullCardDropdownContainer.tsx
+++ b/src/components/style/exportable_card/FullCardDropdownContainer.tsx
@@ -14,7 +14,7 @@ interface IFullCardDropdownContainerState {
 export default class FullCardDropdownContainer
     extends React.Component<IFullCardDropdownContainerProps, IFullCardDropdownContainerState> {
     
-    private ref: React.RefObject<HTMLDivElement> = createRef();
+    private dropdownRef: React.RefObject<HTMLDivElement> = createRef();
 
     constructor(props: IFullCardDropdownContainerProps) {
 
@@ -41,14 +41,12 @@ export default class FullCardDropdownContainer
 
     public render() {
         return (
-            <div className={"btn-group" + (this.state.open ? ' open' : '')}
-                 ref={this.ref}
-                    >
-                <a type="button" className="btn dropdown-toggle c-linksButton" onClick={this.toggleOpen}
+            <div className={"btn-group" + (this.state.open ? ' open' : '')} onClick={this.toggleOpen} ref={this.dropdownRef}>
+                <a type="button" className="btn dropdown-toggle c-linksButton" 
                    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     {this.state.text} <span className="caret" />
                 </a>
-                <ul className="dropdown-menu" {...this.state.listItems} onClick={this.toggleOpen}/>
+                <ul className="dropdown-menu" {...this.state.listItems}/>
             </div>
         )
     }
@@ -60,7 +58,7 @@ export default class FullCardDropdownContainer
       
     private handleOutsideClick(e: Event) {
         const target = e.target as Node;
-        if (this.ref.current && this.ref.current.contains(target)) {
+        if (this.dropdownRef.current && this.dropdownRef.current.contains(target)) {
             return;
         }
         

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -1,7 +1,6 @@
 import { configure, mount, ReactWrapper } from "enzyme";
 import * as Adapter from 'enzyme-adapter-react-16';
 import * as React from 'react';
-import * as CopyToClipboard from "react-copy-to-clipboard";
 import { ISerie } from "../../../api/Serie";
 import FullCard from "../../../components/exportable_card/FullCard";
 

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -97,6 +97,9 @@ describe('FullCard', () => {
         it('renders the default units', () => {
             expect(wrapper.find('p .c-main-title').text()).toContain("Indice Especial");
         });
+        it('dropdown begins closed', () => {
+            expect(wrapper.find('.btn-group .open').exists()).toBe(false);
+        });
         it('opens the dropdown upon clicking it', () => {
             wrapper.find('.btn-group').simulate('click');
             expect(wrapper.find('.btn-group .open').exists()).toBe(true);

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -1,6 +1,7 @@
 import { configure, mount, ReactWrapper } from "enzyme";
 import * as Adapter from 'enzyme-adapter-react-16';
 import * as React from 'react';
+import * as CopyToClipboard from "react-copy-to-clipboard";
 import { ISerie } from "../../../api/Serie";
 import FullCard from "../../../components/exportable_card/FullCard";
 
@@ -95,6 +96,15 @@ describe('FullCard', () => {
         });
         it('renders the default units', () => {
             expect(wrapper.find('p .c-main-title').text()).toContain("Indice Especial");
+        });
+        it('opens the dropdown upon clicking it', () => {
+            wrapper.find('.btn-group').simulate('click');
+            expect(wrapper.find('.btn-group .open').exists()).toBe(true);
+        });
+        it('closes the open dropdown upon clicking outside it', () => {
+            wrapper.find('.btn-group').simulate('click');
+            wrapper.find('.card').simulate('click');
+            expect(wrapper.find('.btn-group .open').exists()).toBe(false);
         });
 
     })


### PR DESCRIPTION
- Creo componente aparte para el dropdown de enlaces de los Components, el cual no depende de Bootstrap ni de Poncho JS
- Añado estilo para que los hipervínculos a abrir en otra pestaña no sean appendeados con el ícono deprecado

Closes #403
Closes #405 