### PR TITLE
409 variable forzar marco

### DIFF
--- a/src/components/exportable/CardExportable.tsx
+++ b/src/components/exportable/CardExportable.tsx
@@ -54,6 +54,7 @@ export default class CardExportable extends React.Component<ICardExportableProps
                 color: this.props.color,
                 explicitSign: this.props.explicitSign,
                 hasChart: this.props.hasChart,
+                hasFrame: this.props.hasFrame,
                 links: this.props.links,
                 locale: this.props.locale,
                 source: this.props.source,

--- a/src/components/exportable/ExportablePage.tsx
+++ b/src/components/exportable/ExportablePage.tsx
@@ -22,6 +22,7 @@ export class ExportablePage extends React.Component {
                             title={'title'}
                             units={'units'}
                             chartType={'full'}
+                            hasFrame={true}
                             explicitSign={false}
                             />
         </div>);

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -32,7 +32,9 @@ export default (props: IFullCardProps) => {
         props.cardOptions.locale, props.serie.isPercentage, props.cardOptions.explicitSign)
         
     return (
-        <FullCardContainer cardOptions={props.cardOptions}>
+        <FullCardContainer hasChart={props.cardOptions.hasChart}
+                           hasFrame={props.cardOptions.hasFrame}
+                           links={props.cardOptions.links}>
             <FullCardHeader color={props.cardOptions.color}
                             override={props.cardOptions.title}
                             defaultTitle={props.serie.description}

--- a/src/components/style/exportable_card/FullCardContainer.tsx
+++ b/src/components/style/exportable_card/FullCardContainer.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react';
-import { ICardBaseConfig } from '../../../indexCard';
 
 
-interface IFullCardContainerProps extends React.HTMLProps<HTMLDivElement> {
-    cardOptions: ICardBaseConfig
+export interface IFullCardContainerProps extends React.HTMLProps<HTMLDivElement> {
+    hasChart: string,
+    hasFrame?: boolean,
+    links: string
 }
 
 
 export default (props: IFullCardContainerProps) =>
-    <div className={`card ${chartClass(props.cardOptions.hasChart)} ${borderClass(props.cardOptions)}`}>
+    <div className={`card ${chartClass(props.hasChart)} ${borderClass(props)}`}>
         {props.children}
     </div>
 
@@ -23,7 +24,7 @@ function chartClass(chartMode: string): string {
     return modes[chartMode];
 }
 
-function borderClass(options:ICardBaseConfig): string {
+function borderClass(options:IFullCardContainerProps): string {
 
     if (options.hasFrame === undefined && (options.hasChart !== 'none' || options.links !== 'none')) {
             return 'full';

--- a/src/components/style/exportable_card/FullCardContainer.tsx
+++ b/src/components/style/exportable_card/FullCardContainer.tsx
@@ -23,10 +23,14 @@ function chartClass(chartMode: string): string {
     return modes[chartMode];
 }
 
-function borderClass(props:ICardBaseConfig): string {
-    if (props.hasChart !== 'none' || props.links !== 'none') {
-        return 'full'
-    } else{
-        return 'empty'
+function borderClass(options:ICardBaseConfig): string {
+
+    if (options.hasFrame === undefined && (options.hasChart !== 'none' || options.links !== 'none')) {
+            return 'full';
     }
+    else if (options.hasFrame === true) {
+        return 'full'
+    }
+    return 'empty';
+
 }

--- a/src/components/style/exportable_card/FullCardDropdownContainer.tsx
+++ b/src/components/style/exportable_card/FullCardDropdownContainer.tsx
@@ -14,7 +14,7 @@ interface IFullCardDropdownContainerState {
 
 export default class FullCardDropdownContainer
     extends React.Component<IFullCardDropdownContainerProps, IFullCardDropdownContainerState> {
-    
+
     private dropdownRef: React.RefObject<HTMLDivElement> = createRef();
 
     constructor(props: IFullCardDropdownContainerProps) {
@@ -26,7 +26,7 @@ export default class FullCardDropdownContainer
         this.state = {
             listItems: { ...props },
             open: false,
-            text: props.text            
+            text: props.text
         };
         delete this.state.listItems.text;
 
@@ -34,8 +34,8 @@ export default class FullCardDropdownContainer
 
     public componentDidMount() {
         document.addEventListener('click', this.closeDropdownOnOutsideClick);
-      }
-    
+    }
+
     public componentWillUnmount() {
         document.removeEventListener('click', this.closeDropdownOnOutsideClick);
     }
@@ -43,11 +43,11 @@ export default class FullCardDropdownContainer
     public render() {
         return (
             <div className={"btn-group" + (this.state.open ? ' open' : '')} onClick={this.toggleOpen} ref={this.dropdownRef}>
-                <a type="button" className="btn dropdown-toggle c-linksButton" 
-                   data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <a type="button" className="btn dropdown-toggle c-linksButton"
+                    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     {this.state.text} <span className="caret" />
                 </a>
-                <ul className="dropdown-menu" {...this.state.listItems}/>
+                <ul className="dropdown-menu" {...this.state.listItems} />
 
                 <ReactTooltip effect="solid" getContent={this.tooltipContent} place="right" globalEventOff='click' />
             </div>
@@ -58,13 +58,13 @@ export default class FullCardDropdownContainer
         const currentState = this.state.open;
         this.setState({ open: !currentState });
     };
-      
+
     private closeDropdownOnOutsideClick(e: Event) {
         const target = e.target as Node;
         if (this.dropdownRef.current && this.dropdownRef.current.contains(target)) {
             return;
         }
-        
+
         this.setState({ open: false });
     };
 

--- a/src/components/style/exportable_card/FullCardDropdownContainer.tsx
+++ b/src/components/style/exportable_card/FullCardDropdownContainer.tsx
@@ -33,11 +33,11 @@ export default class FullCardDropdownContainer
     }
 
     public componentDidMount() {
-        document.addEventListener('mousedown', this.closeDropdownOnOutsideClick);
+        document.addEventListener('click', this.closeDropdownOnOutsideClick);
       }
     
     public componentWillUnmount() {
-        document.removeEventListener('mousedown', this.closeDropdownOnOutsideClick);
+        document.removeEventListener('click', this.closeDropdownOnOutsideClick);
     }
 
     public render() {

--- a/src/indexCard.tsx
+++ b/src/indexCard.tsx
@@ -14,6 +14,7 @@ export interface ICardBaseConfig {
     title: string;
     source: string;
     units: string;
+    hasFrame?: boolean;
 }
 
 export interface ICardExportableConfig extends ICardBaseConfig {
@@ -34,6 +35,7 @@ export function render(selector: string, config: ICardExportableConfig) {
                         title={config.title}
                         source={config.source}
                         units={config.units}
+                        hasFrame={config.hasFrame}
                         seriesApi={seriesApi} />,
         document.getElementById(selector) as HTMLElement
     )

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -73,17 +73,26 @@ describe('FullCard', () => {
 
     beforeAll(() => {
         mockSerie = generateMockSerie();
+    })
+
+    beforeEach(() => {
         mockCardOptions = generateMockCardOptions();
     })
 
     describe('Shown default attributes', () => {
 
-        beforeAll(() => {
+        beforeEach(() => {
             mountFullCard();
         })
 
         it('renders without crashing', () => {
             expect(wrapper.find(FullCard).exists()).toBe(true);
+        });
+        it('renders the border', () => {
+            expect(wrapper.find('.card .full').exists()).toBe(true);
+        });
+        it('renders a full chart', () => {
+            expect(wrapper.find('.card .wide').exists()).toBe(true);
         });
         it('renders the links footer', () => {
             expect(wrapper.find('div .c-links').exists()).toBe(true);
@@ -109,8 +118,52 @@ describe('FullCard', () => {
         });
         it('closes the open dropdown upon clicking outside it', () => {
             wrapper.find('.btn-group').simulate('click');
-            wrapper.find('.card').simulate('click');
+            const click = new MouseEvent('click');
+            document.dispatchEvent(click);
             expect(wrapper.find('.btn-group .open').exists()).toBe(false);
+        });
+
+    })
+
+    describe('Graphic and border rendering', () => {
+        
+        it('having links but no chart, renders the border', () => {
+            mockCardOptions.hasChart = "none";
+            mountFullCard();
+            expect(wrapper.find('.card .full').exists()).toBe(true);
+        });
+        it('having chart but no links, renders the border', () => {
+            mockCardOptions.links = "none";
+            mountFullCard();
+            expect(wrapper.find('.card .full').exists()).toBe(true);
+        });
+        it('having no chart and no links, does not render the border', () => {
+            mockCardOptions.hasChart = "none";
+            mockCardOptions.links = "none";
+            mountFullCard();
+            expect(wrapper.find('.card .empty').exists()).toBe(true);
+        });
+        it('forcedly renders the border', () => {
+            mockCardOptions.hasChart = "none";
+            mockCardOptions.links = "none";
+            mockCardOptions.hasFrame = true;
+            mountFullCard();
+            expect(wrapper.find('.card .full').exists()).toBe(true);
+        });
+        it('forcedly does not render the border', () => {
+            mockCardOptions.hasFrame = false;
+            mountFullCard();
+            expect(wrapper.find('.card .empty').exists()).toBe(true);
+        });
+        it('renders a small graphic chart', () => {
+            mockCardOptions.hasChart = "small";
+            mountFullCard();
+            expect(wrapper.find('.card .normal').exists()).toBe(true);
+        });
+        it('does not render any chart', () => {
+            mockCardOptions.hasChart = "none";
+            mountFullCard();
+            expect(wrapper.find('.card .no-graph').exists()).toBe(true);
         });
 
     })

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -109,19 +109,6 @@ describe('FullCard', () => {
         it('renders the default units', () => {
             expect(wrapper.find('p .c-units').text()).toContain("Indice Especial");
         });
-        it('dropdown begins closed', () => {
-            expect(wrapper.find('.btn-group .open').exists()).toBe(false);
-        });
-        it('opens the dropdown upon clicking it', () => {
-            wrapper.find('.btn-group').simulate('click');
-            expect(wrapper.find('.btn-group .open').exists()).toBe(true);
-        });
-        it('closes the open dropdown upon clicking outside it', () => {
-            wrapper.find('.btn-group').simulate('click');
-            const click = new MouseEvent('click');
-            document.dispatchEvent(click);
-            expect(wrapper.find('.btn-group .open').exists()).toBe(false);
-        });
 
     })
 

--- a/src/tests/components/exportable/FullCardDropdownContainer.test.tsx
+++ b/src/tests/components/exportable/FullCardDropdownContainer.test.tsx
@@ -1,0 +1,41 @@
+import { configure, shallow, ShallowWrapper } from 'enzyme';
+import * as Adapter from 'enzyme-adapter-react-16';
+import * as React from 'react';
+import FullCardDropdownContainer from '../../../components/style/exportable_card/FullCardDropdownContainer';
+import LinkShareItem from '../../../components/style/Share/LinkShareItem';
+
+configure({ adapter: new Adapter() });
+
+describe('FullCardDropdownContainer', () => {
+
+    let wrapper: ShallowWrapper<any, any>;
+
+    beforeEach(() => {
+        wrapper = shallow(
+            <FullCardDropdownContainer text="Enlaces">
+                <LinkShareItem url="web.url" text="Enlace web" />
+                <LinkShareItem url="csv.url" text="Enlace CSV" />
+                <LinkShareItem url="json.url" text="Enlace JSON" />
+            </FullCardDropdownContainer>);
+    })
+
+    it('dropdown begins closed', () => {
+        expect(wrapper.instance().state.open).toBe(false);
+    });
+    it('opens the dropdown upon clicking it', () => {
+        wrapper.find('.btn-group').simulate('click');
+        expect(wrapper.instance().state.open).toBe(true);
+    });
+    it('closes the open dropdown upon clicking it again', () => {
+        wrapper.find('.btn-group').simulate('click');
+        wrapper.find('.btn-group').simulate('click');
+        expect(wrapper.instance().state.open).toBe(false);
+    });
+    it('closes the open dropdown upon clicking outside it', () => {
+        wrapper.find('.btn-group').simulate('click');
+        const click = new MouseEvent('click');
+        document.dispatchEvent(click);
+        expect(wrapper.instance().state.open).toBe(false);
+    });
+
+})


### PR DESCRIPTION
Agrego variable `hasFrame` al componente `FullCard` para determinar la presencia de un marco/borde en el mismo. Sus posibles valores son:

- `true` para que, no obstante los demás flags de la card, se le coloque el marco y el fondo.
- `false` para que, no obstante los demás flags de la card, no posea marco ni fondo.
- `undefined` para que se guíe por los demás flags (si la card posee gráfico o footer de enlaces; es decir, si tiene los flags `hasChart` o `links` con valores distintos a `'none'`).