### PR TITLE
406 argumento elegir eje grafico

### DIFF
--- a/public/components.html
+++ b/public/components.html
@@ -264,6 +264,50 @@ body {
             seriesAxis: { '143.3_NO_PR_2004_A_21': 'right', '116.4_TCRZE_2015_D_36_4': 'right' }
         })
 
+        TSComponents.Graphic.render('emae-graphic-without-filters', {
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=defensa_FAA_0006,99.3_IR_2008_0_9&limit=1000&start=0&format=json',
+            chartOptions: { // Override highstock configs. See https://api.highcharts.com/highstock/
+            },
+            source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
+            datePickerEnabled: false,
+            navigator: false,
+            title: "Estimador Mensual de Actividad Económica (EMAE)",
+            chartTypes: { 'defensa_FAA_0006': 'area', '99.3_IR_2008_0_9': 'area' },
+            legendLabel: { 'defensa_FAA_0006': "Fuerza Aérea", '99.3_IR_2008_0_9': "IPC" },
+            seriesAxis: { 'defensa_FAA_0006': 'right', '99.3_IR_2008_0_9': 'right' }
+        })
+
+        TSComponents.Graphic.render('ica-graphic-without-filters', {
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=74.3_IET_0_M_16,74.3_IIT_0_M_25,74.3_ISC_0_M_19&collapse=year&collapse_aggregation=sum',
+            chartTypes: { '74.3_IET_0_M_16': 'line', '74.3_IIT_0_M_25': 'line', '74.3_ISC_0_M_19': 'column' },
+            title: "Intercambio Comercial Argentino (ICA)",
+            navigator: false,
+            datePickerEnabled: false,
+            source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
+        })
+
+        TSComponents.Graphic.render('ipc-graphic-min', {
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change_a_year_ago',
+            navigator: false,
+            datePickerEnabled: false,
+            title: "Inflación interanual (nivel general)"
+        })
+
+        TSComponents.Graphic.render('rem-graphic-min', {
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=430.1_MEDIANA_IP_12_M_0_0_27_96',
+            navigator: false,
+            datePickerEnabled: false,
+            title: "REM mediana de expectativas de inflación a 12 meses"
+        })
+
+        TSComponents.Graphic.render('tcbna-graphic-min', {
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=168.1_T_CAMBIOR_D_0_0_26',
+            navigator: false,
+            datePickerEnabled: false,
+            title: "Tipo de Cambio Vendedor (BNA)"
+        })
+
+
     }
     </script>
     <script type='text/javascript' src='assets/js/components.js'></script>

--- a/public/components.html
+++ b/public/components.html
@@ -261,52 +261,8 @@ body {
             source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
             chartTypes: { '143.3_NO_PR_2004_A_21': 'column' },
             navigator: true,
-            seriesAxis: { '143.3_NO_PR_2004_A_21': 'left', '116.4_TCRZE_2015_D_36_4': 'right' }
+            seriesAxis: { '143.3_NO_PR_2004_A_21': 'right', '116.4_TCRZE_2015_D_36_4': 'right' }
         })
-
-        TSComponents.Graphic.render('emae-graphic-without-filters', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=defensa_FAA_0006,99.3_IR_2008_0_9&limit=1000&start=0&format=json',
-            chartOptions: { // Override highstock configs. See https://api.highcharts.com/highstock/
-            },
-            source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
-            datePickerEnabled: false,
-            navigator: false,
-            title: "Estimador Mensual de Actividad Económica (EMAE)",
-            chartTypes: { 'defensa_FAA_0006': 'area', '99.3_IR_2008_0_9': 'area' },
-            legendLabel: { 'defensa_FAA_0006': "Fuerza Aérea", '99.3_IR_2008_0_9': "IPC" },
-            seriesAxis: { 'defensa_FAA_0006': 'right', '99.3_IR_2008_0_9': 'right' }
-        })
-
-        TSComponents.Graphic.render('ica-graphic-without-filters', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=74.3_IET_0_M_16,74.3_IIT_0_M_25,74.3_ISC_0_M_19&collapse=year&collapse_aggregation=sum',
-            chartTypes: { '74.3_IET_0_M_16': 'line', '74.3_IIT_0_M_25': 'line', '74.3_ISC_0_M_19': 'column' },
-            title: "Intercambio Comercial Argentino (ICA)",
-            navigator: false,
-            datePickerEnabled: false,
-            source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
-        })
-
-        TSComponents.Graphic.render('ipc-graphic-min', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change_a_year_ago',
-            navigator: false,
-            datePickerEnabled: false,
-            title: "Inflación interanual (nivel general)"
-        })
-
-        TSComponents.Graphic.render('rem-graphic-min', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=430.1_MEDIANA_IP_12_M_0_0_27_96',
-            navigator: false,
-            datePickerEnabled: false,
-            title: "REM mediana de expectativas de inflación a 12 meses"
-        })
-
-        TSComponents.Graphic.render('tcbna-graphic-min', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=168.1_T_CAMBIOR_D_0_0_26',
-            navigator: false,
-            datePickerEnabled: false,
-            title: "Tipo de Cambio Vendedor (BNA)"
-        })
-
 
     }
     </script>

--- a/public/components.html
+++ b/public/components.html
@@ -98,7 +98,7 @@ body {
         // componentes de series de tiempo
 
         TSComponents.Card.render('ipc-card', {
-            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+            serieId: '116.4_TCRZE_2015_D_36_4',
             color: '#F9A822',
             hasChart: 'small',
             title: "Indice de Precios al Consumidor Nacional"
@@ -260,19 +260,21 @@ body {
             title: "Nivel de actividad y tipo de cambio real",
             source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
             chartTypes: { '143.3_NO_PR_2004_A_21': 'column' },
-            navigator: true
+            navigator: true,
+            seriesAxis: { '143.3_NO_PR_2004_A_21': 'left', '116.4_TCRZE_2015_D_36_4': 'right' }
         })
 
         TSComponents.Graphic.render('emae-graphic-without-filters', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=11.3_VMATC_2004_M_12:percent_change_a_year_ago,143.3_NO_PR_2004_A_21:percent_change_a_year_ago&limit=1000&start=0&format=json',
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=defensa_FAA_0006,99.3_IR_2008_0_9&limit=1000&start=0&format=json',
             chartOptions: { // Override highstock configs. See https://api.highcharts.com/highstock/
             },
             source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
             datePickerEnabled: false,
             navigator: false,
             title: "Estimador Mensual de Actividad Económica (EMAE)",
-            chartTypes: { '11.3_VMATC_2004_M_12': 'area', '143.3_NO_PR_2004_A_21': 'area' },
-            legendLabel: { '11.3_VMATC_2004_M_12': "Construcción", '143.3_NO_PR_2004_A_21': "Nivel general" }
+            chartTypes: { 'defensa_FAA_0006': 'area', '99.3_IR_2008_0_9': 'area' },
+            legendLabel: { 'defensa_FAA_0006': "Fuerza Aérea", '99.3_IR_2008_0_9': "IPC" },
+            seriesAxis: { 'defensa_FAA_0006': 'right', '99.3_IR_2008_0_9': 'right' }
         })
 
         TSComponents.Graphic.render('ica-graphic-without-filters', {

--- a/src/components/exportable/GraphicExportable.tsx
+++ b/src/components/exportable/GraphicExportable.tsx
@@ -6,10 +6,9 @@ import SerieApi from "../../api/SerieApi";
 import { valuesFromObject } from "../../helpers/commonFunctions";
 import Colors, { Color } from "../style/Colors/Color";
 import ExportableGraphicContainer from "../style/Graphic/ExportableGraphicContainer";
-import Graphic, { IChartTypeProps, ILegendLabel } from "../viewpage/graphic/Graphic";
+import Graphic, { IChartTypeProps, ILegendLabel, ISeriesAxisSides } from "../viewpage/graphic/Graphic";
 import { chartExtremes } from "../viewpage/graphic/GraphicAndShare";
 import { seriesConfigByUrl } from "../viewpage/ViewPage";
-
 
 export interface IGraphicExportableProps {
     graphicUrl: string;
@@ -27,6 +26,7 @@ export interface IGraphicExportableProps {
     source?: string;
     displayUnits?: boolean;
     legendLabel?: ILegendLabel;
+    seriesAxis?: ISeriesAxisSides;
 }
 
 interface IGraphicExportableState {
@@ -85,7 +85,8 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
                          legendField={legendValue(this.props.legendField)}
                          chartTypes={this.props.chartTypes}
                          afterRender={this.afterRender}
-                         legendLabel={this.props.legendLabel} />
+                         legendLabel={this.props.legendLabel}
+                         seriesAxis={this.props.seriesAxis} />
             </ExportableGraphicContainer>
         )
     }

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -54,7 +54,9 @@ interface IYAxis {
     opposite: boolean;
     title: {text: string};
     yAxis: number;
-    labels?: { formatter: ()=>string }
+    labels?: { formatter?: ()=>string,
+               align?: "left"|"right"|"center",
+               x?: number }
 }
 
 export interface IYAxisConf {
@@ -370,6 +372,18 @@ function yAxisConf(yAxisBySeries: IYAxisConf): IYAxis[] {
 
     leftAxis = leftAxis.filter((item: IYAxis, pos: number) => leftAxisTitles.indexOf(item.title.text) === pos);
     rightAxis = rightAxis.filter((item: IYAxis, pos: number) => rightAxisTitles.indexOf(item.title.text) === pos);
+
+    let rightSpace = 0;
+
+    rightAxis.forEach((rightConfig: IYAxis) => {
+        const originalLabels = rightConfig.labels;
+        rightConfig.labels = {
+            ...originalLabels,
+            align: 'right',
+            x: rightSpace 
+        }
+        rightSpace += 50;
+    })
 
     return leftAxis.concat(rightAxis);
 }

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -373,16 +373,16 @@ function yAxisConf(yAxisBySeries: IYAxisConf): IYAxis[] {
     leftAxis = leftAxis.filter((item: IYAxis, pos: number) => leftAxisTitles.indexOf(item.title.text) === pos);
     rightAxis = rightAxis.filter((item: IYAxis, pos: number) => rightAxisTitles.indexOf(item.title.text) === pos);
 
-    let rightSpace = 0;
+    let rightSpace = 10;
 
     rightAxis.forEach((rightConfig: IYAxis) => {
         const originalLabels = rightConfig.labels;
         rightConfig.labels = {
             ...originalLabels,
-            align: 'right',
+            align: 'left',
             x: rightSpace 
         }
-        rightSpace += 50;
+        rightSpace -= 10;
     })
 
     return leftAxis.concat(rightAxis);

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -373,18 +373,18 @@ function yAxisConf(yAxisBySeries: IYAxisConf): IYAxis[] {
     leftAxis = leftAxis.filter((item: IYAxis, pos: number) => leftAxisTitles.indexOf(item.title.text) === pos);
     rightAxis = rightAxis.filter((item: IYAxis, pos: number) => rightAxisTitles.indexOf(item.title.text) === pos);
 
-    let rightSpace = 10;
-
-    rightAxis.forEach((rightConfig: IYAxis) => {
-        const originalLabels = rightConfig.labels;
-        rightConfig.labels = {
-            ...originalLabels,
-            align: 'left',
-            x: rightSpace 
-        }
-        rightSpace -= 10;
-    })
-
+    // Case where there are only right-sided axis
+    if(leftAxis.length === 0) {
+        rightAxis.forEach((rightConfig: IYAxis) => {
+            const originalLabels = rightConfig.labels;
+            rightConfig.labels = {
+                ...originalLabels,
+                align: 'right',
+                x: -30
+            }
+        })
+    }
+    
     return leftAxis.concat(rightAxis);
 }
 

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -10,8 +10,8 @@ import { formattedDateString, fullLocaleDate, localTimestamp, timestamp } from "
 import { buildLocale } from "../../common/locale/buildLocale";
 import { ISerieTag } from "../SeriesTags";
 import { colorFor } from '../ViewPage';
-import { formatterForSerie } from './formatterForSerie';
 import { IHConfig, IHCSeries, ReactHighStock } from './highcharts';
+import { generateYAxisBySeries } from './axisConfiguration';
 
 // tslint:disable-next-line:no-var-requires
 const deepMerge = require('deepmerge');
@@ -20,6 +20,9 @@ export interface ILegendLabel {
     [clave: string]: string;
 }
 
+export interface ISeriesAxisSides {
+    [clave: string]: string;
+}
 
 export interface IGraphicProps {
     series: ISerie[];
@@ -35,6 +38,7 @@ export interface IGraphicProps {
     chartTypes?: IChartTypeProps;
     afterRender?: (chart: any) => void;
     legendLabel?: ILegendLabel;
+    seriesAxis?: ISeriesAxisSides;
 }
 
 export interface IChartTypeProps {
@@ -53,7 +57,7 @@ interface IYAxis {
     labels?: { formatter: ()=>string }
 }
 
-interface IYAxisConf {
+export interface IYAxisConf {
     [clave: string]: IYAxis
 }
 
@@ -86,7 +90,8 @@ export default class Graphic extends React.Component<IGraphicProps> {
 
     public render() {
         const formatUnits = this.props.formatUnits || false;
-        this.yAxisBySeries = generateYAxisBySeries(this.props.series, this.props.seriesConfig, formatUnits, this.props.locale);
+        this.yAxisBySeries = generateYAxisBySeries(this.props.series, this.props.seriesConfig, 
+            formatUnits, this.props.locale, this.props.seriesAxis);
 
         return (
             <ReactHighStock ref={this.myRef} config={this.highchartsConfig()} callback={this.afterRender} />
@@ -347,37 +352,6 @@ function dateFormatByPeriodicity(component: Graphic) {
     const frequency = component.props.series.length > 0 ? component.props.series[0].frequency || 'day' : 'day';
 
     return DATE_FORMAT_BY_PERIODICITY[frequency];
-}
-
-function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfig[], formatUnits: boolean, locale: string): {} {
-    const minAndMaxValues = series.reduce((result: any, serie: ISerie) => {
-        result[serie.id] = { min: serie.minValue, max: serie.maxValue };
-
-        return result;
-    }, {});
-
-    return series.sort((serie: ISerie) => serie.minValue).reduce((result: IYAxisConf, serie: ISerie) => {
-        const outOfScale = isOutOfScale(series[0].id, serie.id, minAndMaxValues);
-
-        result[serie.id] = {
-            opposite: outOfScale,
-            title: { text: serie.representationModeUnits },
-            yAxis: outOfScale ? 1 : 0
-        };
-
-        const serieConfig = seriesConfig.find((config: SerieConfig) => config.getSerieId() === serie.id);
-
-        if (serieConfig && serieConfig.mustFormatUnits(formatUnits)) {
-            result[serie.id].labels = formatterForSerie(locale);
-        }
-
-        return result;
-    }, {});
-}
-
-function isOutOfScale(originalSerieId: string, serieId: string, minAndMaxValues: {}): boolean {
-    return minAndMaxValues[originalSerieId].min > minAndMaxValues[serieId].max ||
-           minAndMaxValues[originalSerieId].max < minAndMaxValues[serieId].min;
 }
 
 function yAxisConf(yAxisBySeries: IYAxisConf): IYAxis[] {

--- a/src/components/viewpage/graphic/axisConfiguration.ts
+++ b/src/components/viewpage/graphic/axisConfiguration.ts
@@ -1,0 +1,50 @@
+import { ISeriesAxisSides, IYAxisConf } from "./Graphic";
+import { ISerie } from "../../../api/Serie";
+import SerieConfig from "../../../api/SerieConfig";
+import { formatterForSerie } from "./formatterForSerie";
+
+function isOutOfScale(originalSerieId: string, serieId: string, minAndMaxValues: {}): boolean {
+    return minAndMaxValues[originalSerieId].min > minAndMaxValues[serieId].max ||
+           minAndMaxValues[originalSerieId].max < minAndMaxValues[serieId].min;
+}
+
+function getYAxisSide(serieID:string, outOfScale: boolean, axisSideConf?: ISeriesAxisSides, ) {
+    
+    if (axisSideConf !== undefined) {
+        return axisSideConf[serieID];
+    }
+    if (outOfScale) {
+        return 'right';
+    }
+    return 'left';
+
+}
+
+export function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfig[], 
+    formatUnits: boolean, locale: string, axisSides?: ISeriesAxisSides): {} {
+    const minAndMaxValues = series.reduce((result: any, serie: ISerie) => {
+        result[serie.id] = { min: serie.minValue, max: serie.maxValue };
+
+        return result;
+    }, {});
+
+    return series.sort((serie: ISerie) => serie.minValue).reduce((result: IYAxisConf, serie: ISerie) => {
+
+        const outOfScale = isOutOfScale(series[0].id, serie.id, minAndMaxValues);
+        const yAxisSide = getYAxisSide(serie.id, outOfScale, axisSides);
+
+        result[serie.id] = {
+            opposite: yAxisSide === 'right' ? true : false,
+            title: { text: serie.representationModeUnits },
+            yAxis: yAxisSide === 'right' ? 1 : 0
+        };
+
+        const serieConfig = seriesConfig.find((config: SerieConfig) => config.getSerieId() === serie.id);
+
+        if (serieConfig && serieConfig.mustFormatUnits(formatUnits)) {
+            result[serie.id].labels = formatterForSerie(locale);
+        }
+
+        return result;
+    }, {});
+}

--- a/src/indexGraphic.tsx
+++ b/src/indexGraphic.tsx
@@ -19,7 +19,8 @@ export function render(selector: string, config: IGraphicExportableProps) {
                            title={config.title}
                            source={config.source}
                            displayUnits={config.displayUnits}
-                           legendLabel={config.legendLabel} />,
+                           legendLabel={config.legendLabel}
+                           seriesAxis={config.seriesAxis} />,
         document.getElementById(selector) as HTMLElement
     )
 }

--- a/src/tests/components/helpers/CardValueFormatter.test.ts
+++ b/src/tests/components/helpers/CardValueFormatter.test.ts
@@ -4,29 +4,29 @@ describe("CardValueFormatter", () => {
 
     describe("Positive values", () => {
 
-        const percValue : number = 0.120918
-        const value : number = 26.0720161742
+        const percValue : number = 0.120918;
+        const value : number = 26.0720161742;
 
         it("AR locale, percentage value with explicit sign option", () => {
             const formatter = new CardValueFormatter("AR", true, true)
             expect(formatter.formattedValue(percValue)).toEqual('+12,09%')
-        })
+        });
         it("AR locale, percentage value without explicit sign option", () => {
             const formatter = new CardValueFormatter("AR", true, false)
             expect(formatter.formattedValue(percValue)).toEqual('12,09%')
-        })
+        });
         it("AR locale, non-percentage value with explicit sign option", () => {
             const formatter = new CardValueFormatter("AR", false, true)
             expect(formatter.formattedValue(value)).toEqual('+26,07')
-        })
+        });
         it("AR locale, non-percentage value without explicit sign option", () => {
             const formatter = new CardValueFormatter("AR", false, false)
             expect(formatter.formattedValue(value)).toEqual('26,07')
-        })
+        });
         it("US locale, percentage value with explicit sign option", () => {
             const formatter = new CardValueFormatter("US", true, false)
             expect(formatter.formattedValue(percValue)).toEqual('12.09%')
-        }) 
+        }); 
     })
 
     describe("Negative values", () => {

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -1,4 +1,4 @@
-/*import { ISerie } from "../../../../api/Serie";
+import { ISerie } from "../../../../api/Serie";
 import SerieConfig from "../../../../api/SerieConfig";
 import { IYAxisConf, ISeriesAxisSides } from "../../../../components/viewpage/graphic/Graphic";
 import { generateYAxisBySeries } from "../../../../components/viewpage/graphic/axisConfiguration";
@@ -188,4 +188,4 @@ describe("Axis Configuration functions", () => {
 
     })
 
-})*/
+})

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -1,4 +1,4 @@
-import { ISerie } from "../../../../api/Serie";
+/*import { ISerie } from "../../../../api/Serie";
 import SerieConfig from "../../../../api/SerieConfig";
 import { IYAxisConf, ISeriesAxisSides } from "../../../../components/viewpage/graphic/Graphic";
 import { generateYAxisBySeries } from "../../../../components/viewpage/graphic/axisConfiguration";
@@ -188,4 +188,4 @@ describe("Axis Configuration functions", () => {
 
     })
 
-})
+})*/

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -1,0 +1,191 @@
+import { ISerie } from "../../../../api/Serie";
+import SerieConfig from "../../../../api/SerieConfig";
+import { IYAxisConf, ISeriesAxisSides } from "../../../../components/viewpage/graphic/Graphic";
+import { generateYAxisBySeries } from "../../../../components/viewpage/graphic/axisConfiguration";
+
+describe("Axis Configuration functions", () => {
+
+    let mockSerieOne: ISerie;
+    let mockSerieTwo: ISerie;
+    let series: ISerie[];
+    let seriesConfig: SerieConfig[];
+    let yAxisBySeries: IYAxisConf;
+    const locale = 'AR';
+    const formatUnits = false;
+
+    function generateMockSerieOne() {
+        return {
+            accrualPeriodicity: "Mensual",
+            collapseAggregation: "CollapseAgregation",
+            data: [{ date: "2018-07-01", value: 145.30019275372558 },
+            { date: "2018-08-01", value: 145.96423636915267 },
+            { date: "2018-09-01", value: 138.2697148141647 },
+            { date: "2018-10-01", value: 142.93901932020637 },
+            { date: "2018-11-01", value: 140.9176486292864 },
+            { date: "2018-12-01", value: 136.7947106501288 },
+            { date: "2019-01-01", value: 135.52989549467978 },
+            { date: "2019-02-01", value: 132.32429767911992 },
+            { date: "2019-03-01", value: 144.47228283126861 },
+            { date: "2019-04-01", value: 151.03561866080827 }],
+            datasetSource: "Instituto Nacional de Estadística y Censos (INDEC)",
+            datasetTitle: "Estimador Mensual de Actividad Económica (EMAE). Base 2004",
+            description: "EMAE. Base 2004",
+            distributionTitle: "EMAE. Índice Base 2004.Valores mensuales.",
+            downloadURL: "https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=10&format=csv",
+            endDate: "2018-07-01",
+            frequency: "Mensual",
+            id: "143.3_NO_PR_2004_A_21",
+            isPercentage: false,
+            issued: "2017-09-28",
+            landingPage: "LandingPage",
+            maxValue: 155,
+            minValue: 130,
+            modified: "Modified",
+            publisher: {
+                mbox: "Mbox",
+                name: "Name"
+            },
+            representationMode: "value",
+            representationModeUnits: "Índice 2004=100",
+            startDate: "2019-04-01",
+            themes: [{ id: "1", descripcion: "Tema1", label: "Label1" },
+            { id: "2", descripcion: "Tema2", label: "Label2" },
+            { id: "3", descripcion: "Tema3", label: "Label3" }],
+            timeIndexSize: 3,
+            title: "EMAE. Base 2004",
+            units: "Índice 2004=100",
+        };
+    }
+
+    function generateMockSerieTwo() {
+        return {
+            accrualPeriodicity: "Mensual",
+            collapseAggregation: "CollapseAgregation",
+            data: [{ date: "2018-09-01", value: 33896 },
+            { date: "2018-10-01", value: 35567 },
+            { date: "2018-11-01", value: 29485 },
+            { date: "2018-12-01", value: 25159 },
+            { date: "2019-01-01", value: 40256 },
+            { date: "2019-02-01", value: 31843 },
+            { date: "2019-03-01", value: 30292 },
+            { date: "2019-04-01", value: 28645 },
+            { date: "2019-05-01", value: 25409 },
+            { date: "2019-64-01", value: 20284 }],
+            datasetSource: "Ministerio de Producción. Secretaría de la Transformación Productiva. Subsecretaría de Desarrollo y Planeamiento Productivo.",
+            datasetTitle: "Indicadores Sectoriales de Motos",
+            description: "Motos: número de patentamientos de motocicletas",
+            distributionTitle: "Motos: número de patentamientos por categoría de motocicleta (series)",
+            downloadURL: "https://apis.datos.gob.ar/series/api/series/?ids=Motos_patentamiento_8myrF9&last=10&format=csv",
+            endDate: "2018-09-01",
+            frequency: "Mensual",
+            id: "Motos_patentamiento_8myrF9",
+            isPercentage: false,
+            issued: "2018-06-12",
+            landingPage: "LandingPage",
+            maxValue: 45000,
+            minValue: 15000,
+            modified: "Modified",
+            publisher: {
+                mbox: "Mbox",
+                name: "Name"
+            },
+            representationMode: "value",
+            representationModeUnits: "Unidades",
+            startDate: "2019-06-01",
+            themes: [{ id: "1", descripcion: "Tema1", label: "Label1" },
+            { id: "2", descripcion: "Tema2", label: "Label2" },
+            { id: "3", descripcion: "Tema3", label: "Label3" }],
+            timeIndexSize: 3,
+            title: "Motos: número de patentamientos de motocicletas",
+            units: "Unidades",
+        };
+        
+    }
+
+    beforeAll(() => {
+        mockSerieOne = generateMockSerieOne();
+        mockSerieTwo = generateMockSerieTwo();
+        series = [mockSerieOne, mockSerieTwo];
+        seriesConfig = [new SerieConfig(mockSerieOne),
+                        new SerieConfig(mockSerieTwo)];
+    })
+
+    describe("Default axis configuration, without optional parameter", () => {     
+
+        beforeAll(() => {
+            yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale);
+        })
+
+        it("Each unit label goes to a different axis", () => {
+            expect(yAxisBySeries['143.3_NO_PR_2004_A_21'].opposite).toBe(true);
+            expect(yAxisBySeries['Motos_patentamiento_8myrF9'].opposite).toBe(false);
+        });
+        it("Unit label titles are properly written", () => {
+            expect(yAxisBySeries['143.3_NO_PR_2004_A_21'].title.text).toEqual("Índice 2004=100");
+            expect(yAxisBySeries['Motos_patentamiento_8myrF9'].title.text).toEqual("Unidades");
+        });
+        it("Each unit values column goes to a different axis", () => {
+            expect(yAxisBySeries['143.3_NO_PR_2004_A_21'].yAxis).toEqual(1);
+            expect(yAxisBySeries['Motos_patentamiento_8myrF9'].yAxis).toEqual(0);
+        });
+
+    })
+
+    describe("Explicit configuration, switching the default sides", () => {
+
+        beforeAll(() => {
+            const axisSides: ISeriesAxisSides = { '143.3_NO_PR_2004_A_21': 'left',
+                                                  'Motos_patentamiento_8myrF9': 'right' }
+            yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale, axisSides);
+        })
+
+        it("Originally left-sided serie goes to the right", () => {
+            expect(yAxisBySeries['143.3_NO_PR_2004_A_21'].opposite).toBe(false);
+            expect(yAxisBySeries['143.3_NO_PR_2004_A_21'].yAxis).toEqual(0);
+        });
+        it("Originally right-sided serie goes to the left", () => {
+            expect(yAxisBySeries['Motos_patentamiento_8myrF9'].opposite).toBe(true);
+            expect(yAxisBySeries['Motos_patentamiento_8myrF9'].yAxis).toEqual(1);
+        });
+
+    })
+
+    describe("Explicit configuration, both on the left side", () => {
+
+        beforeAll(() => {
+            const axisSides: ISeriesAxisSides = { '143.3_NO_PR_2004_A_21': 'left',
+                                                  'Motos_patentamiento_8myrF9': 'left' }
+            yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale, axisSides);
+        })
+
+        it("Every unit label goes to the right axis", () => {
+            expect(yAxisBySeries['143.3_NO_PR_2004_A_21'].opposite).toBe(false);
+            expect(yAxisBySeries['Motos_patentamiento_8myrF9'].opposite).toBe(false);
+        });
+        it("Every unit value to the right axis", () => {
+            expect(yAxisBySeries['143.3_NO_PR_2004_A_21'].yAxis).toEqual(0);
+            expect(yAxisBySeries['Motos_patentamiento_8myrF9'].yAxis).toEqual(0);
+        });
+
+    })
+
+    describe("Explicit configuration, both on the right side", () => {
+
+        beforeAll(() => {
+            const axisSides: ISeriesAxisSides = { '143.3_NO_PR_2004_A_21': 'right',
+                                                  'Motos_patentamiento_8myrF9': 'right' }
+            yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale, axisSides);
+        })
+
+        it("Every unit label goes to the right axis", () => {
+            expect(yAxisBySeries['143.3_NO_PR_2004_A_21'].opposite).toBe(true);
+            expect(yAxisBySeries['Motos_patentamiento_8myrF9'].opposite).toBe(true);
+        });
+        it("Every unit value to the right axis", () => {
+            expect(yAxisBySeries['143.3_NO_PR_2004_A_21'].yAxis).toEqual(1);
+            expect(yAxisBySeries['Motos_patentamiento_8myrF9'].yAxis).toEqual(1);
+        });
+
+    })
+
+})


### PR DESCRIPTION
Agrego argumento opcional ´seriesAxis´ para elegir de qué lado del gráfico van las ordenadas y unidades de cada serie, en el caso de tener un gráfico con dos series.

Closes #406 