### PR TITLE
426 seteo configuracion id con modificadores

### DIFF
--- a/public/components.html
+++ b/public/components.html
@@ -259,9 +259,9 @@ body {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=143.3_NO_PR_2004_A_21:percent_change_a_year_ago,116.4_TCRZE_2015_D_36_4&limit=1000&start=0',
             title: "Nivel de actividad y tipo de cambio real",
             source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
-            chartTypes: { '143.3_NO_PR_2004_A_21': 'column' },
+            chartTypes: { '143.3_NO_PR_2004_A_21:percent_change_a_year_ago': 'column' },
             navigator: true,
-            seriesAxis: { '143.3_NO_PR_2004_A_21': 'right', '116.4_TCRZE_2015_D_36_4': 'right' }
+            seriesAxis: { '143.3_NO_PR_2004_A_21:percent_change_a_year_ago': 'right', '116.4_TCRZE_2015_D_36_4': 'right' }
         })
 
         TSComponents.Graphic.render('emae-graphic-without-filters', {

--- a/src/api/ITSAPIResponse.ts
+++ b/src/api/ITSAPIResponse.ts
@@ -80,6 +80,7 @@ export interface IField {
     title: string;
     description: string;
     units: string;
+    representation_mode: string;
     representation_mode_units: string;
     frequency: string;
     time_index_start: string;

--- a/src/api/Serie.ts
+++ b/src/api/Serie.ts
@@ -111,7 +111,7 @@ export default class Serie implements ISerie {
     }
 
     get representationMode(): string {
-        return this.tsResponse.params.representation_mode;
+        return this.meta.field.representation_mode;
     }
 
     get collapseAggregation(): string {

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -444,7 +444,7 @@ function findSerieConfig(configs: SerieConfig[], serieId: string) {
     return configs.find((config: SerieConfig) => config.getSerieId() === serieId);
 }
 
-function getChartType(serie: ISerie, types?: IChartTypeProps): string {
+export function getChartType(serie: ISerie, types?: IChartTypeProps): string {
     if (!types) { return 'line' }
 
     return types[getFullSerieId(serie)];

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -284,7 +284,7 @@ export default class Graphic extends React.Component<IGraphicProps> {
 
     public hcSerieFromISerie(serie: ISerie, hcConfig: IHConfig): IHCSeries {
         const data = serie.data.map(datapoint => [timestamp(datapoint.date), datapoint.value]);
-        const chartType = getChartType(serie.id, this.props.chartTypes);
+        const chartType = getChartType(serie, this.props.chartTypes);
 
         return {
             ...this.defaultHCSeriesConfig(),
@@ -293,9 +293,9 @@ export default class Graphic extends React.Component<IGraphicProps> {
             data,
             name: getLegendLabel(serie, this.props),
             navigatorOptions: { type: chartType },
-            serieId: serie.id,
+            serieId: getFullSerieId(serie),
             type: chartType,
-            yAxis: this.yAxisBySeries[serie.id].yAxis,
+            yAxis: this.yAxisBySeries[getFullSerieId(serie)].yAxis,
         }
 
     }
@@ -388,6 +388,15 @@ function yAxisConf(yAxisBySeries: IYAxisConf): IYAxis[] {
     return leftAxis.concat(rightAxis);
 }
 
+export function getFullSerieId(serie: ISerie): string {
+
+    if (serie.representationMode === 'value') {
+        return serie.id
+    }
+    return `${serie.id}:${serie.representationMode}`;
+
+}
+
 function setHighchartsGlobalConfig(locale: string) {
     const localeObj = buildLocale(locale);
 
@@ -435,17 +444,17 @@ function findSerieConfig(configs: SerieConfig[], serieId: string) {
     return configs.find((config: SerieConfig) => config.getSerieId() === serieId);
 }
 
-function getChartType(serieId: string, types?: IChartTypeProps): string {
+function getChartType(serie: ISerie, types?: IChartTypeProps): string {
     if (!types) { return 'line' }
 
-    return types[serieId];
+    return types[getFullSerieId(serie)];
 }
 
 function getLegendLabel(serie: ISerie, props: IGraphicProps): string {
     let label = serie.description;
     if (props.legendLabel) {
-        if (props.legendLabel[serie.id]) {
-            label = props.legendLabel[serie.id];
+        if (props.legendLabel[getFullSerieId(serie)]) {
+            label = props.legendLabel[getFullSerieId(serie)];
         }
     } else if(props.legendField) {
         label = props.legendField(serie);

--- a/src/components/viewpage/graphic/axisConfiguration.ts
+++ b/src/components/viewpage/graphic/axisConfiguration.ts
@@ -1,4 +1,4 @@
-import { ISeriesAxisSides, IYAxisConf } from "./Graphic";
+import { ISeriesAxisSides, IYAxisConf, getFullSerieId } from "./Graphic";
 import { ISerie } from "../../../api/Serie";
 import SerieConfig from "../../../api/SerieConfig";
 import { formatterForSerie } from "./formatterForSerie";
@@ -23,26 +23,29 @@ function getYAxisSide(serieID:string, outOfScale: boolean, axisSideConf?: ISerie
 export function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfig[], 
     formatUnits: boolean, locale: string, axisSides?: ISeriesAxisSides): {} {
     const minAndMaxValues = series.reduce((result: any, serie: ISerie) => {
-        result[serie.id] = { min: serie.minValue, max: serie.maxValue };
+
+        const fullId = getFullSerieId(serie);
+        result[fullId] = { min: serie.minValue, max: serie.maxValue };
 
         return result;
     }, {});
 
     return series.sort((serie: ISerie) => serie.minValue).reduce((result: IYAxisConf, serie: ISerie) => {
 
-        const outOfScale = isOutOfScale(series[0].id, serie.id, minAndMaxValues);
-        const yAxisSide = getYAxisSide(serie.id, outOfScale, axisSides);
+        const fullId = getFullSerieId(serie);
+        const outOfScale = isOutOfScale(getFullSerieId(series[0]), fullId, minAndMaxValues);
+        const yAxisSide = getYAxisSide(fullId, outOfScale, axisSides);
 
-        result[serie.id] = {
+        result[fullId] = {
             opposite: yAxisSide === 'right' ? true : false,
             title: { text: serie.representationModeUnits },
             yAxis: yAxisSide === 'right' ? 1 : 0
         };
 
-        const serieConfig = seriesConfig.find((config: SerieConfig) => config.getSerieId() === serie.id);
+        const serieConfig = seriesConfig.find((config: SerieConfig) => config.getSerieId() === fullId);
 
         if (serieConfig && serieConfig.mustFormatUnits(formatUnits)) {
-            result[serie.id].labels = formatterForSerie(locale);
+            result[fullId].labels = formatterForSerie(locale);
         }
 
         return result;

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 import * as ReactTooltip from 'react-tooltip';
 import { ISerie } from "../../../api/Serie";
 import FullCard from "../../../components/exportable_card/FullCard";
+import { generateCommonMockSerieEMAE } from "../../support/mockers/seriesMockers";
+import { generateCommonMockCardOptions } from "../../support/mockers/cardMockers";
 
 configure({ adapter: new Adapter() });
 
@@ -13,57 +15,6 @@ describe('FullCard', () => {
     let mockCardOptions: any;
     let wrapper: ReactWrapper<any, any>;
 
-    function generateMockSerie() {
-        return {
-            accrualPeriodicity: "Mensual",
-            collapseAggregation: "CollapseAgregation",
-            data: [{ date: "2019-03-01", value: 150 },
-            { date: "2019-02-01", value: 140 },
-            { date: "2019-01-01", value: 180 }],
-            datasetSource: "Instituto Nacional de Estadística y Censos (INDEC)",
-            datasetTitle: "EMAE",
-            description: "EMAE. Base 2004",
-            distributionTitle: "EMAE. Base",
-            downloadURL: "https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv",
-            endDate: "2019-03-01",
-            frequency: "Mensual",
-            id: "143.3_NO_PR_2004_A_21",
-            isPercentage: false,
-            issued: "Issued",
-            landingPage: "LandingPage",
-            maxValue: 200,
-            minValue: 0,
-            modified: "Modified",
-            publisher: {
-                mbox: "Mbox",
-                name: "Name"
-            },
-            representationMode: "RepresentationMode",
-            representationModeUnits: "Indice Especial",
-            startDate: "2019-01-01",
-            themes: [{ id: "1", descripcion: "Tema1", label: "Label1" },
-            { id: "2", descripcion: "Tema2", label: "Label2" },
-            { id: "3", descripcion: "Tema3", label: "Label3" }],
-            timeIndexSize: 3,
-            title: "EMAE. Base 2004",
-            units: "Índice 2004=100",
-        }
-    }
-
-    function generateMockCardOptions() {
-        return {
-            chartType: "line",
-            color: "#047FBC",
-            explicitSign: true,
-            hasChart: "full",
-            links: "full",
-            locale: "AR",
-            source: undefined,
-            title: undefined,
-            units: undefined
-        }
-    }
-
     function mountFullCard() {
         wrapper = mount(<FullCard serie={mockSerie}
             downloadUrl="https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=5000&format=csv"
@@ -72,11 +23,11 @@ describe('FullCard', () => {
     }
 
     beforeAll(() => {
-        mockSerie = generateMockSerie();
+        mockSerie = generateCommonMockSerieEMAE();
     })
 
     beforeEach(() => {
-        mockCardOptions = generateMockCardOptions();
+        mockCardOptions = generateCommonMockCardOptions();
     })
 
     describe('Shown default attributes', () => {
@@ -107,7 +58,7 @@ describe('FullCard', () => {
             expect(wrapper.find('p .c-source').text()).toContain("Fuente: Instituto Nacional de Estadística y Censos (INDEC)");
         });
         it('renders the default units', () => {
-            expect(wrapper.find('p .c-units').text()).toContain("Indice Especial");
+            expect(wrapper.find('p .c-units').text()).toContain("Índice 2004=100");
         });
 
     })

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -2,6 +2,7 @@ import { ISerie } from "../../../../api/Serie";
 import SerieConfig from "../../../../api/SerieConfig";
 import { IYAxisConf, ISeriesAxisSides } from "../../../../components/viewpage/graphic/Graphic";
 import { generateYAxisBySeries } from "../../../../components/viewpage/graphic/axisConfiguration";
+import { generateCommonMockSerieMotos, generateCommonMockSerieEMAE } from "../../../support/mockers/seriesMockers";
 
 describe("Axis Configuration functions", () => {
 
@@ -13,98 +14,9 @@ describe("Axis Configuration functions", () => {
     const locale = 'AR';
     const formatUnits = false;
 
-    function generateMockSerieOne() {
-        return {
-            accrualPeriodicity: "Mensual",
-            collapseAggregation: "CollapseAgregation",
-            data: [{ date: "2018-07-01", value: 145.30019275372558 },
-            { date: "2018-08-01", value: 145.96423636915267 },
-            { date: "2018-09-01", value: 138.2697148141647 },
-            { date: "2018-10-01", value: 142.93901932020637 },
-            { date: "2018-11-01", value: 140.9176486292864 },
-            { date: "2018-12-01", value: 136.7947106501288 },
-            { date: "2019-01-01", value: 135.52989549467978 },
-            { date: "2019-02-01", value: 132.32429767911992 },
-            { date: "2019-03-01", value: 144.47228283126861 },
-            { date: "2019-04-01", value: 151.03561866080827 }],
-            datasetSource: "Instituto Nacional de Estadística y Censos (INDEC)",
-            datasetTitle: "Estimador Mensual de Actividad Económica (EMAE). Base 2004",
-            description: "EMAE. Base 2004",
-            distributionTitle: "EMAE. Índice Base 2004.Valores mensuales.",
-            downloadURL: "https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=10&format=csv",
-            endDate: "2018-07-01",
-            frequency: "Mensual",
-            id: "TestId",
-            isPercentage: false,
-            issued: "2017-09-28",
-            landingPage: "LandingPage",
-            maxValue: 155,
-            minValue: 130,
-            modified: "Modified",
-            publisher: {
-                mbox: "Mbox",
-                name: "Name"
-            },
-            representationMode: "value",
-            representationModeUnits: "Índice 2004=100",
-            startDate: "2019-04-01",
-            themes: [{ id: "1", descripcion: "Tema1", label: "Label1" },
-            { id: "2", descripcion: "Tema2", label: "Label2" },
-            { id: "3", descripcion: "Tema3", label: "Label3" }],
-            timeIndexSize: 3,
-            title: "EMAE. Base 2004",
-            units: "Índice 2004=100",
-        };
-    }
-
-    function generateMockSerieTwo() {
-        return {
-            accrualPeriodicity: "Mensual",
-            collapseAggregation: "CollapseAgregation",
-            data: [{ date: "2018-09-01", value: 33896 },
-            { date: "2018-10-01", value: 35567 },
-            { date: "2018-11-01", value: 29485 },
-            { date: "2018-12-01", value: 25159 },
-            { date: "2019-01-01", value: 40256 },
-            { date: "2019-02-01", value: 31843 },
-            { date: "2019-03-01", value: 30292 },
-            { date: "2019-04-01", value: 28645 },
-            { date: "2019-05-01", value: 25409 },
-            { date: "2019-64-01", value: 20284 }],
-            datasetSource: "Ministerio de Producción. Secretaría de la Transformación Productiva. Subsecretaría de Desarrollo y Planeamiento Productivo.",
-            datasetTitle: "Indicadores Sectoriales de Motos",
-            description: "Motos: número de patentamientos de motocicletas",
-            distributionTitle: "Motos: número de patentamientos por categoría de motocicleta (series)",
-            downloadURL: "https://apis.datos.gob.ar/series/api/series/?ids=Motos_patentamiento_8myrF9&last=10&format=csv",
-            endDate: "2018-09-01",
-            frequency: "Mensual",
-            id: "Motos_patentamiento_8myrF9",
-            isPercentage: false,
-            issued: "2018-06-12",
-            landingPage: "LandingPage",
-            maxValue: 45000,
-            minValue: 15000,
-            modified: "Modified",
-            publisher: {
-                mbox: "Mbox",
-                name: "Name"
-            },
-            representationMode: "value",
-            representationModeUnits: "Unidades",
-            startDate: "2019-06-01",
-            themes: [{ id: "1", descripcion: "Tema1", label: "Label1" },
-            { id: "2", descripcion: "Tema2", label: "Label2" },
-            { id: "3", descripcion: "Tema3", label: "Label3" }],
-            timeIndexSize: 3,
-            title: "Motos: número de patentamientos de motocicletas",
-            units: "Unidades",
-        };
-        
-    }
-
     beforeAll(() => {
-        mockSerieOne = generateMockSerieOne();
-        mockSerieTwo = generateMockSerieTwo();
+        mockSerieOne = generateCommonMockSerieEMAE();
+        mockSerieTwo = generateCommonMockSerieMotos();
         series = [mockSerieOne, mockSerieTwo];
         seriesConfig = [new SerieConfig(mockSerieOne),
                         new SerieConfig(mockSerieTwo)];
@@ -117,15 +29,15 @@ describe("Axis Configuration functions", () => {
         })
 
         it("Each unit label goes to a different axis", () => {
-            expect(yAxisBySeries.TestId.opposite).toBe(true);
+            expect(yAxisBySeries.EMAE2004.opposite).toBe(true);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(false);
         });
         it("Unit label titles are properly written", () => {
-            expect(yAxisBySeries.TestId.title.text).toEqual("Índice 2004=100");
+            expect(yAxisBySeries.EMAE2004.title.text).toEqual("Índice 2004=100");
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.title.text).toEqual("Unidades");
         });
         it("Each unit values column goes to a different axis", () => {
-            expect(yAxisBySeries.TestId.yAxis).toEqual(1);
+            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(1);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(0);
         });
 
@@ -134,14 +46,14 @@ describe("Axis Configuration functions", () => {
     describe("Explicit configuration, switching the default sides", () => {
 
         beforeAll(() => {
-            const axisSides: ISeriesAxisSides = { 'TestId': 'left',
+            const axisSides: ISeriesAxisSides = { 'EMAE2004': 'left',
                                                   'Motos_patentamiento_8myrF9': 'right' }
             yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale, axisSides);
         })
 
         it("Originally left-sided serie goes to the right", () => {
-            expect(yAxisBySeries.TestId.opposite).toBe(false);
-            expect(yAxisBySeries.TestId.yAxis).toEqual(0);
+            expect(yAxisBySeries.EMAE2004.opposite).toBe(false);
+            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(0);
         });
         it("Originally right-sided serie goes to the left", () => {
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(true);
@@ -153,17 +65,17 @@ describe("Axis Configuration functions", () => {
     describe("Explicit configuration, both on the left side", () => {
 
         beforeAll(() => {
-            const axisSides: ISeriesAxisSides = { 'TestId': 'left',
+            const axisSides: ISeriesAxisSides = { 'EMAE2004': 'left',
                                                   'Motos_patentamiento_8myrF9': 'left' }
             yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale, axisSides);
         })
 
         it("Every unit label goes to the right axis", () => {
-            expect(yAxisBySeries.TestId.opposite).toBe(false);
+            expect(yAxisBySeries.EMAE2004.opposite).toBe(false);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(false);
         });
         it("Every unit value to the right axis", () => {
-            expect(yAxisBySeries.TestId.yAxis).toEqual(0);
+            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(0);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(0);
         });
 
@@ -172,17 +84,17 @@ describe("Axis Configuration functions", () => {
     describe("Explicit configuration, both on the right side", () => {
 
         beforeAll(() => {
-            const axisSides: ISeriesAxisSides = { 'TestId': 'right',
+            const axisSides: ISeriesAxisSides = { 'EMAE2004': 'right',
                                                   'Motos_patentamiento_8myrF9': 'right' }
             yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale, axisSides);
         })
 
         it("Every unit label goes to the right axis", () => {
-            expect(yAxisBySeries.TestId.opposite).toBe(true);
+            expect(yAxisBySeries.EMAE2004.opposite).toBe(true);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(true);
         });
         it("Every unit value to the right axis", () => {
-            expect(yAxisBySeries.TestId.yAxis).toEqual(1);
+            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(1);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
         });
 

--- a/src/tests/components/viewpage/graphic/ChartType.test.ts
+++ b/src/tests/components/viewpage/graphic/ChartType.test.ts
@@ -1,0 +1,42 @@
+import { IChartTypeProps, getChartType } from "../../../../components/viewpage/graphic/Graphic";
+import { ISerie } from "../../../../api/Serie";
+import { generateCommonMockSerieEMAE, generateCommonMockSerieMotos, generatePercentageMockSerie, generatePercentageYearMockSerie } from "../../../support/mockers/seriesMockers";
+
+describe("Chart Type settings between different series", () => {
+
+    let props: IChartTypeProps;
+    let commonMockSerieOne: ISerie;
+    let commonMockSerieTwo: ISerie;
+    let wholePercentageMockSerie: ISerie;
+    let yearPercentageMockSerie: ISerie;
+
+    beforeAll(() => {
+
+        commonMockSerieOne = generateCommonMockSerieEMAE();
+        commonMockSerieTwo = generateCommonMockSerieMotos();
+        wholePercentageMockSerie = generatePercentageMockSerie();
+        yearPercentageMockSerie = generatePercentageYearMockSerie();
+        props = {
+            'Motos_patentamiento_8myrF9': 'line',
+            'EMAE2004:percent_change': 'column',
+            'EMAE2004:percent_change_a_year_ago': 'area'
+        }
+
+    })
+
+    it('There is no default chart type: it must be defined', () => {
+        const chartType = getChartType(commonMockSerieOne, props);
+        expect(chartType).toBeUndefined();
+    });
+
+    it('Explicitly chosen chart types are bound to their IDs', () => {
+        const lineChartType = getChartType(commonMockSerieTwo, props);
+        expect(lineChartType).toEqual('line');
+        const columnChartType = getChartType(wholePercentageMockSerie, props);
+        expect(columnChartType).toEqual('column');
+        const areaChartType = getChartType(yearPercentageMockSerie, props);
+        expect(areaChartType).toEqual('area');
+    });
+
+
+})

--- a/src/tests/components/viewpage/graphic/FullSerieId.test.ts
+++ b/src/tests/components/viewpage/graphic/FullSerieId.test.ts
@@ -1,0 +1,25 @@
+import { generateCommonMockSerieEMAE, generatePercentageYearMockSerie } from "../../../support/mockers/seriesMockers";
+import { ISerie } from "../../../../api/Serie";
+import { getFullSerieId } from "../../../../components/viewpage/graphic/Graphic";
+
+describe("Obtainment of a serie's full ID", () => {
+
+    let commonMockSerie: ISerie;
+    let yearPercentageMockSerie: ISerie;
+
+    beforeAll(() => {
+        commonMockSerie = generateCommonMockSerieEMAE();
+        yearPercentageMockSerie = generatePercentageYearMockSerie();
+    })
+
+    it('A serie with "value" representation mode does not append it to the ID', () => {
+        const fullId = getFullSerieId(commonMockSerie);
+        expect(fullId).toEqual('EMAE2004');
+    });
+
+    it('A representation mode different than "value" is appended to the ID', () => {
+        const fullId = getFullSerieId(yearPercentageMockSerie);
+        expect(fullId).toEqual('EMAE2004:percent_change_a_year_ago');
+    });
+
+})

--- a/src/tests/support/factories/series_api.ts
+++ b/src/tests/support/factories/series_api.ts
@@ -63,6 +63,7 @@ export function generateITSAPIResponse(tsIDs: string[] = ["1.1", "1.2"]): ITSAPI
                     is_percentage: true,
                     max_value: "2",
                     min_value: "0",
+                    representation_mode: 'value',
                     representation_mode_units: `${tsID} distribution representation_mode_units`,
                     time_index_end: '',
                     time_index_size: 0,

--- a/src/tests/support/mockers/cardMockers.ts
+++ b/src/tests/support/mockers/cardMockers.ts
@@ -1,0 +1,13 @@
+export function generateCommonMockCardOptions() {
+    return {
+        chartType: "line",
+        color: "#047FBC",
+        explicitSign: true,
+        hasChart: "full",
+        links: "full",
+        locale: "AR",
+        source: undefined,
+        title: undefined,
+        units: undefined
+    }
+}

--- a/src/tests/support/mockers/seriesMockers.ts
+++ b/src/tests/support/mockers/seriesMockers.ts
@@ -1,0 +1,106 @@
+export function generateCommonMockSerieEMAE() {
+
+    return {
+        accrualPeriodicity: "Mensual",
+        collapseAggregation: "CollapseAgregation",
+        data: [{ date: "2018-07-01", value: 145.30019275372558 },
+        { date: "2018-08-01", value: 145.96423636915267 },
+        { date: "2018-09-01", value: 138.2697148141647 },
+        { date: "2018-10-01", value: 142.93901932020637 },
+        { date: "2018-11-01", value: 140.9176486292864 },
+        { date: "2018-12-01", value: 136.7947106501288 },
+        { date: "2019-01-01", value: 135.52989549467978 },
+        { date: "2019-02-01", value: 132.32429767911992 },
+        { date: "2019-03-01", value: 144.47228283126861 },
+        { date: "2019-04-01", value: 151.03561866080827 }],
+        datasetSource: "Instituto Nacional de Estadística y Censos (INDEC)",
+        datasetTitle: "Estimador Mensual de Actividad Económica (EMAE). Base 2004",
+        description: "EMAE. Base 2004",
+        distributionTitle: "EMAE. Índice Base 2004.Valores mensuales.",
+        downloadURL: "https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=10&format=csv",
+        endDate: "2018-07-01",
+        frequency: "Mensual",
+        id: "EMAE2004",
+        isPercentage: false,
+        issued: "2017-09-28",
+        landingPage: "LandingPage",
+        maxValue: 155,
+        minValue: 130,
+        modified: "Modified",
+        publisher: {
+            mbox: "Mbox",
+            name: "Name"
+        },
+        representationMode: "value",
+        representationModeUnits: "Índice 2004=100",
+        startDate: "2019-04-01",
+        themes: [{ id: "1", descripcion: "Tema1", label: "Label1" },
+        { id: "2", descripcion: "Tema2", label: "Label2" },
+        { id: "3", descripcion: "Tema3", label: "Label3" }],
+        timeIndexSize: 3,
+        title: "EMAE. Base 2004",
+        units: "Índice 2004=100",
+    };
+}
+
+export function generateCommonMockSerieMotos() {
+
+    return {
+        accrualPeriodicity: "Mensual",
+        collapseAggregation: "CollapseAgregation",
+        data: [{ date: "2018-09-01", value: 33896 },
+        { date: "2018-10-01", value: 35567 },
+        { date: "2018-11-01", value: 29485 },
+        { date: "2018-12-01", value: 25159 },
+        { date: "2019-01-01", value: 40256 },
+        { date: "2019-02-01", value: 31843 },
+        { date: "2019-03-01", value: 30292 },
+        { date: "2019-04-01", value: 28645 },
+        { date: "2019-05-01", value: 25409 },
+        { date: "2019-64-01", value: 20284 }],
+        datasetSource: "Ministerio de Producción. Secretaría de la Transformación Productiva. Subsecretaría de Desarrollo y Planeamiento Productivo.",
+        datasetTitle: "Indicadores Sectoriales de Motos",
+        description: "Motos: número de patentamientos de motocicletas",
+        distributionTitle: "Motos: número de patentamientos por categoría de motocicleta (series)",
+        downloadURL: "https://apis.datos.gob.ar/series/api/series/?ids=Motos_patentamiento_8myrF9&last=10&format=csv",
+        endDate: "2018-09-01",
+        frequency: "Mensual",
+        id: "Motos_patentamiento_8myrF9",
+        isPercentage: false,
+        issued: "2018-06-12",
+        landingPage: "LandingPage",
+        maxValue: 45000,
+        minValue: 15000,
+        modified: "Modified",
+        publisher: {
+            mbox: "Mbox",
+            name: "Name"
+        },
+        representationMode: "value",
+        representationModeUnits: "Unidades",
+        startDate: "2019-06-01",
+        themes: [{ id: "1", descripcion: "Tema1", label: "Label1" },
+        { id: "2", descripcion: "Tema2", label: "Label2" },
+        { id: "3", descripcion: "Tema3", label: "Label3" }],
+        timeIndexSize: 3,
+        title: "Motos: número de patentamientos de motocicletas",
+        units: "Unidades",
+    };
+    
+}
+
+export function generatePercentageMockSerie() {
+
+    const serie = generateCommonMockSerieEMAE();
+    serie.representationMode = "percent_change";
+    return serie;
+
+}
+
+export function generatePercentageYearMockSerie() {
+
+    const serie = generateCommonMockSerieEMAE();
+    serie.representationMode = "percent_change_a_year_ago";
+    return serie;
+
+}


### PR DESCRIPTION
Permito que las series representadas en un `Graphic` puedan distinguirse no sólo por id de la serie de tiempo, sino también por la forma en que es representada por sus puntos: es decir, puedo tener una misma serie `s` representada tanto por valores netos por fecha (por defecto) como por cambios porcentuales entre fecha y fecha, etc. Así, coexistirían en un mismo `Graphic` las series `s` (valores netos) y `s:percent_change` (cambios porcentuales).
Esto permite que los parámetros `chartTypes`, `seriesAxis` y `legendLabel`, que son objetos cuyas claves son los IDs de las series, puedan emplear este nuevo formato de IDs `<id>:<modificador>`.

A su vez, creo los tests necesarios y reordeno los directorios para tener las funciones de mockeo por separado.

Closes #426 