### PR TITLE
Leyenda segun series en eje auxiliar

### DIFF
--- a/public/components.html
+++ b/public/components.html
@@ -274,16 +274,17 @@ body {
             title: "Estimador Mensual de Actividad Económica (EMAE)",
             chartTypes: { 'defensa_FAA_0006': 'area', '99.3_IR_2008_0_9': 'area' },
             legendLabel: { 'defensa_FAA_0006': "Fuerza Aérea", '99.3_IR_2008_0_9': "IPC" },
-            seriesAxis: { 'defensa_FAA_0006': 'right', '99.3_IR_2008_0_9': 'right' }
+            seriesAxis: { 'defensa_FAA_0006': 'left', '99.3_IR_2008_0_9': 'right' }
         })
 
         TSComponents.Graphic.render('ica-graphic-without-filters', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=74.3_IET_0_M_16,74.3_IIT_0_M_25,74.3_ISC_0_M_19&collapse=year&collapse_aggregation=sum',
-            chartTypes: { '74.3_IET_0_M_16': 'line', '74.3_IIT_0_M_25': 'line', '74.3_ISC_0_M_19': 'column' },
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=74.3_IET_0_M_16,74.3_IIT_0_M_25,74.3_ISC_0_M_19,307.2_SERVICIOS_IOS_0_T_51_87&collapse=year&collapse_aggregation=sum',
+            chartTypes: { '74.3_IET_0_M_16': 'line', '74.3_IIT_0_M_25': 'line', '74.3_ISC_0_M_19': 'column', '307.2_SERVICIOS_IOS_0_T_51_87': 'line' },
             title: "Intercambio Comercial Argentino (ICA)",
             navigator: false,
             datePickerEnabled: false,
             source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
+            seriesAxis: { '74.3_IET_0_M_16': 'left', '74.3_IIT_0_M_25': 'left', '74.3_ISC_0_M_19': 'right', '307.2_SERVICIOS_IOS_0_T_51_87': 'right'}
         })
 
         TSComponents.Graphic.render('ipc-graphic-min', {

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -267,6 +267,18 @@ export default class Graphic extends React.Component<IGraphicProps> {
         return deepMerge(ownConfig, this.props.chartOptions || {}); // chartOptions overrides ownConfig
     }
 
+    public getYAxisBySeries() {
+        return this.yAxisBySeries
+    }
+    
+    public atLeastOneRightSidedSerie(): boolean {
+    
+        const configs = valuesFromObject(this.yAxisBySeries);
+        return configs.some((config: IYAxis) => {
+            return config.opposite;
+        });
+    
+    }
 
     public categories() {
         return (
@@ -291,7 +303,7 @@ export default class Graphic extends React.Component<IGraphicProps> {
             ...hcConfig,
             color: colorFor(this.props.series, serie.id).code,
             data,
-            name: getLegendLabel(serie, this.props),
+            name: getLegendLabel(serie, this),
             navigatorOptions: { type: chartType },
             serieId: getFullSerieId(serie),
             type: chartType,
@@ -450,18 +462,32 @@ export function getChartType(serie: ISerie, types?: IChartTypeProps): string {
     return types[getFullSerieId(serie)];
 }
 
-function getLegendLabel(serie: ISerie, props: IGraphicProps): string {
+export function getLegendLabel(serie: ISerie, graphic: Graphic): string {
+    
     let label = serie.description;
-    if (props.legendLabel) {
-        if (props.legendLabel[getFullSerieId(serie)]) {
-            label = props.legendLabel[getFullSerieId(serie)];
+    const fullId = getFullSerieId(serie);
+
+    if (graphic.props.legendLabel) {
+        if (graphic.props.legendLabel[fullId]) {
+            label = graphic.props.legendLabel[fullId];
         }
-    } else if(props.legendField) {
-        label = props.legendField(serie);
+    } else if(graphic.props.legendField) {
+        label = graphic.props.legendField(serie);
+    }
+
+    if (graphic.atLeastOneRightSidedSerie()) {
+        const conf = graphic.getYAxisBySeries()[fullId]
+        if (conf.opposite){
+            label += ' (der)';
+        }
+        else {
+            label += ' (izq)';
+        }
     }
 
     return label;
 }
+
 
 function changeCreditsPosition(chart: any) {
     chart.container.getElementsByClassName('highcharts-credits')[0].setAttribute('y', 460); // change position of 'credits'

--- a/src/components/viewpage/graphic/legendConfiguration.ts
+++ b/src/components/viewpage/graphic/legendConfiguration.ts
@@ -1,0 +1,35 @@
+import { ISerie } from "../../../api/Serie";
+import { ILegendLabel, IYAxisConf, getFullSerieId } from "./Graphic";
+
+export interface ILegendConfiguration {
+    axisConf: IYAxisConf;
+    legendLabel?: ILegendLabel;
+    legendField?: (serie: ISerie) => string;
+    rightSidedSeries: boolean;
+}
+
+export function getLegendLabel(serie: ISerie, config: ILegendConfiguration): string {
+    
+    let label = serie.description;
+    const fullId = getFullSerieId(serie);
+
+    if (config.legendLabel) {
+        if (config.legendLabel[fullId]) {
+            label = config.legendLabel[fullId];
+        }
+    } else if(config.legendField) {
+        label = config.legendField(serie);
+    }
+
+    if (config.rightSidedSeries) {
+        const conf = config.axisConf[fullId]
+        if (conf.opposite){
+            label += ' (der)';
+        }
+        else {
+            label += ' (izq)';
+        }
+    }
+
+    return label;
+}

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -1,6 +1,6 @@
 import { ISerie } from "../../../../api/Serie";
 import SerieConfig from "../../../../api/SerieConfig";
-import { IYAxisConf, ISeriesAxisSides } from "../../../../components/viewpage/graphic/Graphic";
+import Graphic, { IYAxisConf, ISeriesAxisSides, IGraphicProps, IChartExtremeProps, getLegendLabel } from "../../../../components/viewpage/graphic/Graphic";
 import { generateYAxisBySeries } from "../../../../components/viewpage/graphic/axisConfiguration";
 import { generateCommonMockSerieMotos, generateCommonMockSerieEMAE } from "../../../support/mockers/seriesMockers";
 
@@ -9,8 +9,11 @@ describe("Axis Configuration functions", () => {
     let mockSerieOne: ISerie;
     let mockSerieTwo: ISerie;
     let series: ISerie[];
-    let seriesConfig: SerieConfig[];
+    let mockConfig: SerieConfig[];
+    let axisSides: ISeriesAxisSides;
     let yAxisBySeries: IYAxisConf;
+    let graphicProps: IGraphicProps;
+    let graphic: Graphic;
     const locale = 'AR';
     const formatUnits = false;
 
@@ -18,14 +21,24 @@ describe("Axis Configuration functions", () => {
         mockSerieOne = generateCommonMockSerieEMAE();
         mockSerieTwo = generateCommonMockSerieMotos();
         series = [mockSerieOne, mockSerieTwo];
-        seriesConfig = [new SerieConfig(mockSerieOne),
+        mockConfig = [new SerieConfig(mockSerieOne),
                         new SerieConfig(mockSerieTwo)];
+        const mockRange: IChartExtremeProps = {
+            min: -1000000,
+            max: 1000000
+        };
+        graphicProps = {
+            locale: 'AR',
+            range: mockRange,
+            series: [mockSerieOne, mockSerieTwo],
+            seriesConfig: mockConfig
+        }
     })
 
     describe("Default axis configuration, without optional parameter", () => {     
 
         beforeAll(() => {
-            yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale);
+            yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale);
         })
 
         it("Each unit label goes to a different axis", () => {
@@ -40,15 +53,21 @@ describe("Axis Configuration functions", () => {
             expect(yAxisBySeries.EMAE2004.yAxis).toEqual(1);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(0);
         });
+        it("Legend labels below the graphic are properly written", () => {
+            graphic = new Graphic(graphicProps);
+            graphic.render();   // Mock the graphic's rendering, to set its yAxisBySeries
+            expect(getLegendLabel(mockSerieOne, graphic)).toEqual("EMAE. Base 2004 (der)");
+            expect(getLegendLabel(mockSerieTwo, graphic)).toEqual("Motos: número de patentamientos de motocicletas (izq)");
+        });
 
     })
 
     describe("Explicit configuration, switching the default sides", () => {
 
         beforeAll(() => {
-            const axisSides: ISeriesAxisSides = { 'EMAE2004': 'left',
-                                                  'Motos_patentamiento_8myrF9': 'right' }
-            yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale, axisSides);
+            axisSides = { 'EMAE2004': 'left',
+                          'Motos_patentamiento_8myrF9': 'right' }
+            yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, axisSides);
         })
 
         it("Originally left-sided serie goes to the right", () => {
@@ -59,15 +78,22 @@ describe("Axis Configuration functions", () => {
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(true);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
         });
+        it("Legend labels below the graphic are properly written", () => {
+            graphicProps.seriesAxis = axisSides
+            graphic = new Graphic(graphicProps);
+            graphic.render();   // Mock the graphic's rendering, to set its yAxisBySeries
+            expect(getLegendLabel(mockSerieOne, graphic)).toEqual("EMAE. Base 2004 (izq)");
+            expect(getLegendLabel(mockSerieTwo, graphic)).toEqual("Motos: número de patentamientos de motocicletas (der)");
+        });
 
     })
 
     describe("Explicit configuration, both on the left side", () => {
 
         beforeAll(() => {
-            const axisSides: ISeriesAxisSides = { 'EMAE2004': 'left',
-                                                  'Motos_patentamiento_8myrF9': 'left' }
-            yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale, axisSides);
+            axisSides = { 'EMAE2004': 'left',
+                          'Motos_patentamiento_8myrF9': 'left' }
+            yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, axisSides);
         })
 
         it("Every unit label goes to the right axis", () => {
@@ -78,15 +104,22 @@ describe("Axis Configuration functions", () => {
             expect(yAxisBySeries.EMAE2004.yAxis).toEqual(0);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(0);
         });
+        it("As there are no series on the auxiliar axes, no text is appended to legend labels", () => {
+            graphicProps.seriesAxis = axisSides
+            graphic = new Graphic(graphicProps);
+            graphic.render();   // Mock the graphic's rendering, to set its yAxisBySeries
+            expect(getLegendLabel(mockSerieOne, graphic)).toEqual("EMAE. Base 2004");
+            expect(getLegendLabel(mockSerieTwo, graphic)).toEqual("Motos: número de patentamientos de motocicletas");
+        });
 
     })
 
     describe("Explicit configuration, both on the right side", () => {
 
         beforeAll(() => {
-            const axisSides: ISeriesAxisSides = { 'EMAE2004': 'right',
-                                                  'Motos_patentamiento_8myrF9': 'right' }
-            yAxisBySeries = generateYAxisBySeries(series, seriesConfig, formatUnits, locale, axisSides);
+            axisSides = { 'EMAE2004': 'right',
+                          'Motos_patentamiento_8myrF9': 'right' }
+            yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, axisSides);
         })
 
         it("Every unit label goes to the right axis", () => {
@@ -96,6 +129,13 @@ describe("Axis Configuration functions", () => {
         it("Every unit value to the right axis", () => {
             expect(yAxisBySeries.EMAE2004.yAxis).toEqual(1);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
+        });
+        it("Legend labels below the graphic are properly written", () => {
+            graphicProps.seriesAxis = axisSides
+            graphic = new Graphic(graphicProps);
+            graphic.render();   // Mock the graphic's rendering, to set its yAxisBySeries
+            expect(getLegendLabel(mockSerieOne, graphic)).toEqual("EMAE. Base 2004 (der)");
+            expect(getLegendLabel(mockSerieTwo, graphic)).toEqual("Motos: número de patentamientos de motocicletas (der)");
         });
 
     })

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -1,8 +1,9 @@
 import { ISerie } from "../../../../api/Serie";
 import SerieConfig from "../../../../api/SerieConfig";
-import Graphic, { IYAxisConf, ISeriesAxisSides, IGraphicProps, IChartExtremeProps, getLegendLabel } from "../../../../components/viewpage/graphic/Graphic";
+import { IYAxisConf, ISeriesAxisSides } from "../../../../components/viewpage/graphic/Graphic";
 import { generateYAxisBySeries } from "../../../../components/viewpage/graphic/axisConfiguration";
 import { generateCommonMockSerieMotos, generateCommonMockSerieEMAE } from "../../../support/mockers/seriesMockers";
+import { ILegendConfiguration, getLegendLabel } from "../../../../components/viewpage/graphic/legendConfiguration";
 
 describe("Axis Configuration functions", () => {
 
@@ -12,8 +13,7 @@ describe("Axis Configuration functions", () => {
     let mockConfig: SerieConfig[];
     let axisSides: ISeriesAxisSides;
     let yAxisBySeries: IYAxisConf;
-    let graphicProps: IGraphicProps;
-    let graphic: Graphic;
+    let legendProps: ILegendConfiguration;
     const locale = 'AR';
     const formatUnits = false;
 
@@ -23,16 +23,6 @@ describe("Axis Configuration functions", () => {
         series = [mockSerieOne, mockSerieTwo];
         mockConfig = [new SerieConfig(mockSerieOne),
                         new SerieConfig(mockSerieTwo)];
-        const mockRange: IChartExtremeProps = {
-            min: -1000000,
-            max: 1000000
-        };
-        graphicProps = {
-            locale: 'AR',
-            range: mockRange,
-            series: [mockSerieOne, mockSerieTwo],
-            seriesConfig: mockConfig
-        }
     })
 
     describe("Default axis configuration, without optional parameter", () => {     
@@ -54,10 +44,12 @@ describe("Axis Configuration functions", () => {
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(0);
         });
         it("Legend labels below the graphic are properly written", () => {
-            graphic = new Graphic(graphicProps);
-            graphic.render();   // Mock the graphic's rendering, to set its yAxisBySeries
-            expect(getLegendLabel(mockSerieOne, graphic)).toEqual("EMAE. Base 2004 (der)");
-            expect(getLegendLabel(mockSerieTwo, graphic)).toEqual("Motos: número de patentamientos de motocicletas (izq)");
+            legendProps = {
+                axisConf: yAxisBySeries,
+                rightSidedSeries: true
+            }
+            expect(getLegendLabel(mockSerieOne, legendProps)).toEqual("EMAE. Base 2004 (der)");
+            expect(getLegendLabel(mockSerieTwo, legendProps)).toEqual("Motos: número de patentamientos de motocicletas (izq)");
         });
 
     })
@@ -79,11 +71,12 @@ describe("Axis Configuration functions", () => {
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
         });
         it("Legend labels below the graphic are properly written", () => {
-            graphicProps.seriesAxis = axisSides
-            graphic = new Graphic(graphicProps);
-            graphic.render();   // Mock the graphic's rendering, to set its yAxisBySeries
-            expect(getLegendLabel(mockSerieOne, graphic)).toEqual("EMAE. Base 2004 (izq)");
-            expect(getLegendLabel(mockSerieTwo, graphic)).toEqual("Motos: número de patentamientos de motocicletas (der)");
+            legendProps = {
+                axisConf: yAxisBySeries,
+                rightSidedSeries: true
+            }
+            expect(getLegendLabel(mockSerieOne, legendProps)).toEqual("EMAE. Base 2004 (izq)");
+            expect(getLegendLabel(mockSerieTwo, legendProps)).toEqual("Motos: número de patentamientos de motocicletas (der)");
         });
 
     })
@@ -105,11 +98,12 @@ describe("Axis Configuration functions", () => {
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(0);
         });
         it("As there are no series on the auxiliar axes, no text is appended to legend labels", () => {
-            graphicProps.seriesAxis = axisSides
-            graphic = new Graphic(graphicProps);
-            graphic.render();   // Mock the graphic's rendering, to set its yAxisBySeries
-            expect(getLegendLabel(mockSerieOne, graphic)).toEqual("EMAE. Base 2004");
-            expect(getLegendLabel(mockSerieTwo, graphic)).toEqual("Motos: número de patentamientos de motocicletas");
+            legendProps = {
+                axisConf: yAxisBySeries,
+                rightSidedSeries: false
+            }
+            expect(getLegendLabel(mockSerieOne, legendProps)).toEqual("EMAE. Base 2004");
+            expect(getLegendLabel(mockSerieTwo, legendProps)).toEqual("Motos: número de patentamientos de motocicletas");
         });
 
     })
@@ -131,11 +125,12 @@ describe("Axis Configuration functions", () => {
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
         });
         it("Legend labels below the graphic are properly written", () => {
-            graphicProps.seriesAxis = axisSides
-            graphic = new Graphic(graphicProps);
-            graphic.render();   // Mock the graphic's rendering, to set its yAxisBySeries
-            expect(getLegendLabel(mockSerieOne, graphic)).toEqual("EMAE. Base 2004 (der)");
-            expect(getLegendLabel(mockSerieTwo, graphic)).toEqual("Motos: número de patentamientos de motocicletas (der)");
+            legendProps = {
+                axisConf: yAxisBySeries,
+                rightSidedSeries: true
+            }
+            expect(getLegendLabel(mockSerieOne, legendProps)).toEqual("EMAE. Base 2004 (der)");
+            expect(getLegendLabel(mockSerieTwo, legendProps)).toEqual("Motos: número de patentamientos de motocicletas (der)");
         });
 
     })


### PR DESCRIPTION
Al ya existente comportamiento dinámico para determinar cuál será la leyenda de cada serie (el título de la misma, debajo del gráfico), le agrego la consideración de que, en caso de haber al menos una serie en el eje auxiliar (es decir, con unidades y ordenadas a la derecha), se deba distinguir cada leyenda appendeando un `(der)` o `(izq)` a la misma. Creo los casos de test necesarios, que prueban la función encargada de dicho cálculo (`getLegendLabel`).

Closes #432 