### PR TITLE
Arreglo altura de texto en titulo de Card

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -226,7 +226,7 @@
 }
 
 .card .c-head .c-title {
-  height: 40px;
+  height: 42px;
   margin: 0px;
   text-align: center;
   font-weight: 500;


### PR DESCRIPTION
Cambio la propiedad `height` del selector del título de la `Card`, para que entren dos líneas de texto en el mismo. Debe ser el doble de la propiedad `line-height`, dado que son dos líneas máximo.

Closes #439 