### PR TITLE
Inyecto estilo de padding al titulo del Graphic

### DIFF
--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -179,7 +179,10 @@ export default class Graphic extends React.Component<IGraphicProps> {
             },
 
             title: {
-                text: '',
+                style: {
+                    "paddingBottom": "40px"
+                },
+                text: ''
             },
 
             tooltip:{
@@ -266,10 +269,6 @@ export default class Graphic extends React.Component<IGraphicProps> {
         };
 
         return deepMerge(ownConfig, this.props.chartOptions || {}); // chartOptions overrides ownConfig
-    }
-
-    public getYAxisBySeries() {
-        return this.yAxisBySeries
     }
 
     public categories() {


### PR DESCRIPTION
Agrego inyección de estilo CSS al atributo `title` de Highcharts, para que todos sus títulos sufran la personalización. El `padding-bottom` agrega espacio debajo, de manera que puedan entrar las letras largas (q, g) de la segunda línea.

Closes #443 