### PR TITLE
444 - Agrego pesos y colores de fuente a los textos del Graphic

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -61,8 +61,9 @@
 }
 
 .highcharts-legend-item tspan {
+  color: #333333;
   font-family: "Roboto", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-  font-weight: 600;
+  font-weight: 400;
   font-size: 15px;
 }
 

--- a/src/components/exportable/GraphicExportable.tsx
+++ b/src/components/exportable/GraphicExportable.tsx
@@ -214,11 +214,12 @@ function titleOptions(componentProps: IGraphicExportableProps) {
     const options: any = Object.assign({}, componentProps.title);
     options.text = componentProps.title;
     options.style = {
-        color: "#595959",
-        fontSize: "20px",
-        fontWeight: "410",
+        color: "#333333",
+        fontSize: "20.8px",
+        fontWeight: "500",
         fontFamily: ["Roboto", "Helvetica Neue", "Helvetica", "Arial", "sans-serif"],
-        lineHeight: "0.92"
+        lineHeight: "0.92",
+        paddingBottom: "40px"
     };
 
     if (!componentProps.zoom && !componentProps.datePickerEnabled) { // remove margin between title and chart
@@ -233,9 +234,9 @@ function subtitleOptions(componentProps: IGraphicExportableProps) {
     if (componentProps.source) {
         options.align = "center";
         options.style = {
-            color: "#828282",
+            color: "#707070",
             fontSize: "15px",
-            fontWeight: "410",
+            fontWeight: "400",
             fontFamily: ["Roboto", "Helvetica Neue", "Helvetica", "Arial", "sans-serif"]
         };
         options.text = componentProps.source;

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -179,9 +179,6 @@ export default class Graphic extends React.Component<IGraphicProps> {
             },
 
             title: {
-                style: {
-                    "paddingBottom": "40px"
-                },
                 text: ''
             },
 


### PR DESCRIPTION
Agrego parámetros `color` y `font-weight` a los textos involucrados en el Graphic (`title` para el título; `subtitle` para la fuente; y `legend`, por CSS, para la leyenda con el nombre de la serie), desde sus opciones de configuración. A su vez, muevo el seteo de `padding-bottom` para el título de la configuración del chart a la configuración del Graphic en sí.

Closes #444 