### PR TITLE
446 - Arreglo tooltip roto

### DIFF
--- a/src/api/SerieConfig.ts
+++ b/src/api/SerieConfig.ts
@@ -1,6 +1,7 @@
 import {IDataPoint} from "./DataPoint";
 import {ISerie} from "./Serie";
 import {i18nFrequency} from "./utils/periodicityManager";
+import { getFullSerieId } from "../components/viewpage/graphic/Graphic";
 
 export default class SerieConfig {
 
@@ -12,8 +13,8 @@ export default class SerieConfig {
         this.serie = serie;
     }
 
-    public getSerieId() {
-        return this.serie.id;
+    public getFullSerieId() {
+        return getFullSerieId(this.serie);
     }
 
     public getPercentChange() {

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -457,7 +457,7 @@ function tooltipDateValue(frequency: string, timest: number): string {
 }
 
 function findSerieConfig(configs: SerieConfig[], serieId: string) {
-    return configs.find((config: SerieConfig) => config.getSerieId() === serieId);
+    return configs.find((config: SerieConfig) => config.getFullSerieId() === serieId);
 }
 
 export function getChartType(serie: ISerie, types?: IChartTypeProps): string {

--- a/src/components/viewpage/graphic/axisConfiguration.ts
+++ b/src/components/viewpage/graphic/axisConfiguration.ts
@@ -42,7 +42,7 @@ export function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfi
             yAxis: yAxisSide === 'right' ? 1 : 0
         };
 
-        const serieConfig = seriesConfig.find((config: SerieConfig) => config.getSerieId() === fullId);
+        const serieConfig = seriesConfig.find((config: SerieConfig) => config.getFullSerieId() === fullId);
 
         if (serieConfig && serieConfig.mustFormatUnits(formatUnits)) {
             result[fullId].labels = formatterForSerie(locale);

--- a/src/tests/components/viewpage/graphic/FullSerieId.test.ts
+++ b/src/tests/components/viewpage/graphic/FullSerieId.test.ts
@@ -1,8 +1,9 @@
 import { generateCommonMockSerieEMAE, generatePercentageYearMockSerie } from "../../../support/mockers/seriesMockers";
-import { ISerie } from "../../../../api/Serie";
+import Serie, { ISerie } from "../../../../api/Serie";
 import { getFullSerieId } from "../../../../components/viewpage/graphic/Graphic";
+import SerieConfig from "../../../../api/SerieConfig";
 
-describe("Obtainment of a serie's full ID", () => {
+describe("Obtainment of full IDs", () => {
 
     let commonMockSerie: ISerie;
     let yearPercentageMockSerie: ISerie;
@@ -12,14 +13,38 @@ describe("Obtainment of a serie's full ID", () => {
         yearPercentageMockSerie = generatePercentageYearMockSerie();
     })
 
-    it('A serie with "value" representation mode does not append it to the ID', () => {
-        const fullId = getFullSerieId(commonMockSerie);
-        expect(fullId).toEqual('EMAE2004');
-    });
+    describe("Full ID of a ISerie object", () => {
 
-    it('A representation mode different than "value" is appended to the ID', () => {
-        const fullId = getFullSerieId(yearPercentageMockSerie);
-        expect(fullId).toEqual('EMAE2004:percent_change_a_year_ago');
-    });
+        it('A serie with "value" representation mode does not append it to the ID', () => {
+            const fullId = getFullSerieId(commonMockSerie);
+            expect(fullId).toEqual('EMAE2004');
+        });
+        it('A representation mode different than "value" is appended to the ID', () => {
+            const fullId = getFullSerieId(yearPercentageMockSerie);
+            expect(fullId).toEqual('EMAE2004:percent_change_a_year_ago');
+        });
+
+    })
+
+    describe("Full ID of a SerieConfig object", () => {
+        
+        let commonMockSerieConfig: SerieConfig;
+        let yearPercentageMockSerieConfig: SerieConfig;
+
+        beforeAll(() => {
+            commonMockSerieConfig = new SerieConfig(commonMockSerie);
+            yearPercentageMockSerieConfig = new SerieConfig(yearPercentageMockSerie);
+        })
+
+        it('A SerieConfig from a Serie with "value" representation mode does not append it to the ID', () => {
+            const fullId = commonMockSerieConfig.getFullSerieId();
+            expect(fullId).toEqual('EMAE2004');
+        });
+        it('A SerieConfig from a Serie with another representation mode is appended to the ID', () => {
+            const fullId = yearPercentageMockSerieConfig.getFullSerieId();
+            expect(fullId).toEqual('EMAE2004:percent_change_a_year_ago');
+        });
+
+    })
 
 })


### PR DESCRIPTION
- Cambio el uso de `getSerieId` por el de `getFullSerieId` en el formatter del tooltip, para que al buscar los valores que tendría el tooltip en cada punto se guíe por el ID compuesto (`id:modificador`) de la serie, y no sólo su id nativo.
- Elimino el método `getSerieId` de la clase `SeriesConfig`. ya que no se usa más.

Closes #446 