### PR TITLE
Asignar colores a series a partir de ID + rep mode

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -4,5 +4,5 @@ DIR=$(dirname "$0")
 cd ${DIR}/..
 
 echo "npm test"
-npm test -- --forceExit --all --coverage
+npm test -- --forceExit --all
 echo "npm test OK :)"

--- a/src/components/exportable/GraphicExportable.tsx
+++ b/src/components/exportable/GraphicExportable.tsx
@@ -3,8 +3,6 @@ import { ApiClient } from "../../api/ApiClient";
 import QueryParams from "../../api/QueryParams";
 import { ISerie } from "../../api/Serie";
 import SerieApi from "../../api/SerieApi";
-import { valuesFromObject } from "../../helpers/commonFunctions";
-import Colors, { Color } from "../style/Colors/Color";
 import ExportableGraphicContainer from "../style/Graphic/ExportableGraphicContainer";
 import Graphic, { IChartTypeProps, ILegendLabel, ISeriesAxisSides, IPropsPerId } from "../viewpage/graphic/Graphic";
 import { chartExtremes } from "../viewpage/graphic/GraphicAndShare";
@@ -40,7 +38,6 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
 
     public constructor(props: any) {
         super(props);
-        this.colorFor = this.colorFor.bind(this);
         this.afterRender = this.afterRender.bind(this);
 
         this.seriesApi = new SerieApi(new ApiClient(extractUriFromUrl(props.graphicUrl), 'ts-components'));
@@ -137,12 +134,6 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
         }
     }
 
-    private colorFor(serieId: string): Color {
-        const colors = this.props.colors ? buildColors(this.props.colors) : valuesFromObject(Colors);
-        const index = this.state.series.findIndex(viewSerie => viewSerie.id === serieId) % colors.length;
-
-        return colors[index];
-    }
 
     private fetchSeries(params: QueryParams) {
         this.seriesApi.fetchSeries(params)
@@ -180,9 +171,6 @@ function extractUriFromUrl(url: string): string {
     return url.split('series/?')[0];
 }
 
-function buildColors(colors: string[]): Color[] {
-    return colors.map((color: string) => new Color('customColor', color));
-}
 
 function legendValue(field?: string): ((serie: ISerie) => string) {
     const f = field || 'description';

--- a/src/components/style/Colors/Color.ts
+++ b/src/components/style/Colors/Color.ts
@@ -1,4 +1,5 @@
 import { ISerie } from "../../../api/Serie";
+import { getFullSerieId } from "../../viewpage/graphic/Graphic";
 
 export class Color {
     constructor(public name: string, public code: string){}
@@ -16,7 +17,6 @@ const Colors = {
     a8Blue2: new Color("blue2", "#039BE5"),
     a9Green2: new Color("green2", "#6EA100"),
 };
-export const NaC = new Color("", "");
 
 export default Colors;
 
@@ -24,9 +24,9 @@ export function getColorBySerieId(series: ISerie[], serieId: string): string {
     return colorFor(series, serieId).code;
 }
 
-export function colorFor(series: ISerie[], serieId: string): Color {
+export function colorFor(series: ISerie[], fullSerieId: string): Color {
     const colors = (Object as any).values(Colors);
-    const index = series.findIndex(viewSerie => viewSerie.id === serieId) % colors.length;
+    const index = series.findIndex(viewSerie => getFullSerieId(viewSerie) === fullSerieId) % colors.length;
 
     return colors[index];
 }

--- a/src/components/style/Colors/Color.ts
+++ b/src/components/style/Colors/Color.ts
@@ -1,5 +1,4 @@
 import { ISerie } from "../../../api/Serie";
-import { colorFor } from "../../viewpage/ViewPage";
 
 export class Color {
     constructor(public name: string, public code: string){}
@@ -23,4 +22,11 @@ export default Colors;
 
 export function getColorBySerieId(series: ISerie[], serieId: string): string {
     return colorFor(series, serieId).code;
+}
+
+export function colorFor(series: ISerie[], serieId: string): Color {
+    const colors = (Object as any).values(Colors);
+    const index = series.findIndex(viewSerie => viewSerie.id === serieId) % colors.length;
+
+    return colors[index];
 }

--- a/src/components/viewpage/SeriesTags.tsx
+++ b/src/components/viewpage/SeriesTags.tsx
@@ -3,11 +3,13 @@ import { connect } from "react-redux";
 import { ISerie } from '../../api/Serie';
 import Tag from '../style/Tag/Tag';
 import { colorFor } from '../style/Colors/Color';
+import { getFullSerieId } from './graphic/Graphic';
 
 
 export interface ISerieTag {
     id: string;
     title: string;
+    representationMode: string;
 }
 
 interface ISeriesTagsProps extends React.Props<any> {
@@ -20,7 +22,7 @@ function seriesTags(props: ISeriesTagsProps, state: any) {
     return (
         <span>
             {props.serieTags.map((serieTag: ISerieTag, index: number) =>
-                <Tag key={index} pegColor={colorFor(props.series, serieTag.id)} onClose={getOnCloseFor(props.serieTags, serieTag.id, props.onTagClose)}>
+                <Tag key={index} pegColor={colorFor(props.series, getFullSerieId(serieTag))} onClose={getOnCloseFor(props.serieTags, serieTag.id, props.onTagClose)}>
                     {serieTag.title}
                 </Tag>
             )}

--- a/src/components/viewpage/SeriesTags.tsx
+++ b/src/components/viewpage/SeriesTags.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from "react-redux";
 import { ISerie } from '../../api/Serie';
 import Tag from '../style/Tag/Tag';
-import { colorFor } from './ViewPage';
+import { colorFor } from '../style/Colors/Color';
 
 
 export interface ISerieTag {

--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -12,7 +12,6 @@ import { getId, removeDuplicates } from "../../helpers/commonFunctions";
 import { IStore } from '../../store/initialState';
 import SearchBox from '../common/searchbox/SearchBox';
 import ClearFix from '../style/ClearFix';
-import Colors, { Color } from '../style/Colors/Color';
 import Container from '../style/Common/Container';
 import SeriesHero from '../style/Hero/SeriesHero';
 import AddAndCustomizeSeriesButton from './AddAndCustomizeSeriesButton';
@@ -246,13 +245,6 @@ export function seriesConfigByUrl(url: string): (series: ISerie[]) => SerieConfi
         seriesConfig.setPercentChangeAYearAgo(search.some((value: string) => value.includes(serie.id) && value.includes('percent_change_a_year_ago')));
         return seriesConfig;
     });
-}
-
-export function colorFor(series: ISerie[], serieId: string): Color {
-    const colors = (Object as any).values(Colors);
-    const index = series.findIndex(viewSerie => viewSerie.id === serieId) % colors.length;
-
-    return colors[index];
 }
 
 function serieIdSanitizer(serieId: string): string {

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -297,7 +297,7 @@ export default class Graphic extends React.Component<IGraphicProps> {
         return {
             ...this.defaultHCSeriesConfig(),
             ...hcConfig,
-            color: colorFor(this.props.series, serie.id).code,
+            color: colorFor(this.props.series, getFullSerieId(serie)).code,
             data,
             name: getLegendLabel(serie, legendProps),
             navigatorOptions: { type: chartType },
@@ -352,10 +352,10 @@ export default class Graphic extends React.Component<IGraphicProps> {
         if (this.props.series.some((serie: ISerie) => yAXisBySeries[serie.id].opposite)) {
             this.props.series.forEach((serie: ISerie) => {
                 const title = yAXisBySeries[serie.id].opposite ? `${serie.description} (der)` : `${serie.description} (izq)`;
-                titlesResult.push({id: serie.id, title});
+                titlesResult.push({id: serie.id, title, representationMode: serie.representationMode});
             });
         } else {
-            titlesResult = this.props.series.map((serie: ISerie) => ({id: serie.id, title: serie.description}));
+            titlesResult = this.props.series.map((serie: ISerie) => ({id: serie.id, title: serie.description, representationMode: serie.representationMode}));
         }
 
         this.props.dispatch(setSerieTags(titlesResult))
@@ -404,7 +404,12 @@ function yAxisConf(yAxisBySeries: IYAxisConf): IYAxis[] {
     return leftAxis.concat(rightAxis);
 }
 
-export function getFullSerieId(serie: ISerie): string {
+export interface ISerieFullID {
+    id: string;
+    representationMode: string;
+}
+
+export function getFullSerieId(serie: ISerieFullID): string {
 
     if (serie.representationMode === 'value') {
         return serie.id

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -9,10 +9,10 @@ import { valuesFromObject } from "../../../helpers/commonFunctions";
 import { formattedDateString, fullLocaleDate, localTimestamp, timestamp } from "../../../helpers/dateFunctions";
 import { buildLocale } from "../../common/locale/buildLocale";
 import { ISerieTag } from "../SeriesTags";
-import { colorFor } from '../ViewPage';
 import { IHConfig, IHCSeries, ReactHighStock } from './highcharts';
 import { generateYAxisBySeries } from './axisConfiguration';
 import { ILegendConfiguration, getLegendLabel } from './legendConfiguration';
+import { colorFor } from '../../style/Colors/Color';
 
 // tslint:disable-next-line:no-var-requires
 const deepMerge = require('deepmerge');

--- a/src/components/viewpage/graphic/axisConfiguration.ts
+++ b/src/components/viewpage/graphic/axisConfiguration.ts
@@ -30,7 +30,8 @@ export function generateYAxisBySeries(series: ISerie[], seriesConfig: SerieConfi
         return result;
     }, {});
 
-    return series.sort((serie: ISerie) => serie.minValue).reduce((result: IYAxisConf, serie: ISerie) => {
+    
+    return series.slice().sort((serie: ISerie) => serie.minValue).reduce((result: IYAxisConf, serie: ISerie) => {
 
         const fullId = getFullSerieId(serie);
         const outOfScale = isOutOfScale(getFullSerieId(series[0]), fullId, minAndMaxValues);

--- a/src/components/viewpage/seriespicker/SeriesPicker.tsx
+++ b/src/components/viewpage/seriespicker/SeriesPicker.tsx
@@ -6,7 +6,6 @@ import { ISerieApi } from '../../../api/SerieApi';
 import initialState, { IStore } from '../../../store/initialState';
 import FullSearcher from '../../common/searcher/FullSearcher';
 import SerieCard from '../../style/Card/Serie/SerieCard';
-import { colorFor } from '../../style/Colors/Color';
 
 
 export interface ISeriesPickerProps {
@@ -60,7 +59,6 @@ class SeriesPicker extends React.Component<ISeriesPickerProps, any> {
             checked: this.isChecked(searchResult.id),
             onClick: this.handlePick(searchResult.id),
             onRemoveSerie: () => this.props.onRemoveSerie(searchResult.id),
-            pegColor: colorFor(this.props.series, searchResult.id),
             serie: searchResult,
         }
     }

--- a/src/components/viewpage/seriespicker/SeriesPicker.tsx
+++ b/src/components/viewpage/seriespicker/SeriesPicker.tsx
@@ -6,7 +6,7 @@ import { ISerieApi } from '../../../api/SerieApi';
 import initialState, { IStore } from '../../../store/initialState';
 import FullSearcher from '../../common/searcher/FullSearcher';
 import SerieCard from '../../style/Card/Serie/SerieCard';
-import { colorFor } from '../ViewPage';
+import { colorFor } from '../../style/Colors/Color';
 
 
 export interface ISeriesPickerProps {

--- a/src/tests/components/style/Color.test.ts
+++ b/src/tests/components/style/Color.test.ts
@@ -1,0 +1,22 @@
+import { ISerie } from "../../../api/Serie";
+import { generateCommonMockSerieEMAE, generateCommonMockSerieMotos } from "../../support/mockers/seriesMockers";
+import { colorFor } from "../../../components/style/Colors/Color";
+import { getFullSerieId } from "../../../components/viewpage/graphic/Graphic";
+
+describe("Colors", () => {
+
+    let mockSerieOne: ISerie;
+    let mockSerieTwo: ISerie;
+
+    beforeAll(() => {
+        mockSerieOne = generateCommonMockSerieEMAE();
+        mockSerieTwo = generateCommonMockSerieMotos();
+    });
+
+    it("Single serie returns blue color", () => {
+        const series = [mockSerieOne, mockSerieTwo];
+        const color = colorFor(series, getFullSerieId(mockSerieOne));
+        
+        expect(color.name).toEqual("blue1");
+    });
+});

--- a/src/tests/components/style/Color.test.ts
+++ b/src/tests/components/style/Color.test.ts
@@ -1,5 +1,5 @@
 import { ISerie } from "../../../api/Serie";
-import { generateCommonMockSerieEMAE, generateCommonMockSerieMotos } from "../../support/mockers/seriesMockers";
+import { generateCommonMockSerieEMAE, generateCommonMockSerieMotos, generatePercentageMockSerie } from "../../support/mockers/seriesMockers";
 import { colorFor } from "../../../components/style/Colors/Color";
 import { getFullSerieId } from "../../../components/viewpage/graphic/Graphic";
 
@@ -21,9 +21,8 @@ describe("Colors", () => {
     });
 
     it("Same serie id different rep mode returns different colors", () => {
-        let emae_2 = Object.assign({}, mockSerieOne);
-        emae_2.representationMode = 'percent_change';
-        const series = [mockSerieOne, emae_2];
+        let emae_2 = generatePercentageMockSerie()
+        const series = [mockSerieOne, emae_2]
         const color = colorFor(series, getFullSerieId(series[0]));
         const color_2 = colorFor(series, getFullSerieId(series[1]));
         expect(color).not.toEqual(color_2)

--- a/src/tests/components/style/Color.test.ts
+++ b/src/tests/components/style/Color.test.ts
@@ -14,9 +14,32 @@ describe("Colors", () => {
     });
 
     it("Single serie returns blue color", () => {
-        const series = [mockSerieOne, mockSerieTwo];
+        const series = [mockSerieOne];
         const color = colorFor(series, getFullSerieId(mockSerieOne));
         
         expect(color.name).toEqual("blue1");
+    });
+
+    it("Same serie id different rep mode returns different colors", () => {
+        let emae_2 = Object.assign({}, mockSerieOne);
+        emae_2.representationMode = 'percent_change';
+        const series = [mockSerieOne, emae_2];
+        const color = colorFor(series, getFullSerieId(series[0]));
+        const color_2 = colorFor(series, getFullSerieId(series[1]));
+        expect(color).not.toEqual(color_2)
+    });
+
+    it("Different serie ids return different colors", () => {
+        const series = [mockSerieOne, mockSerieTwo];
+        const color = colorFor(series, getFullSerieId(series[0]));
+        const color_2 = colorFor(series, getFullSerieId(series[1]));
+        expect(color).not.toEqual(color_2)
+    });
+
+    it("Same serie with same rep mode returns same color", () => {
+        const series = [mockSerieOne, mockSerieOne];
+        const color = colorFor(series, getFullSerieId(series[0]));
+        const color_2 = colorFor(series, getFullSerieId(series[1]));
+        expect(color).toEqual(color_2)
     });
 });

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -32,24 +32,24 @@ describe("Axis Configuration functions", () => {
         })
 
         it("Each unit label goes to a different axis", () => {
-            expect(yAxisBySeries.EMAE2004.opposite).toBe(true);
-            expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(false);
+            expect(yAxisBySeries.EMAE2004.opposite).toBe(false);
+            expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(true);
         });
         it("Unit label titles are properly written", () => {
             expect(yAxisBySeries.EMAE2004.title.text).toEqual("Índice 2004=100");
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.title.text).toEqual("Unidades");
         });
         it("Each unit values column goes to a different axis", () => {
-            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(1);
-            expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(0);
+            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(0);
+            expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
         });
         it("Legend labels below the graphic are properly written", () => {
             legendProps = {
                 axisConf: yAxisBySeries,
                 rightSidedSeries: true
             }
-            expect(getLegendLabel(mockSerieOne, legendProps)).toEqual("EMAE. Base 2004 (der)");
-            expect(getLegendLabel(mockSerieTwo, legendProps)).toEqual("Motos: número de patentamientos de motocicletas (izq)");
+            expect(getLegendLabel(mockSerieOne, legendProps)).toContain("(izq)");
+            expect(getLegendLabel(mockSerieTwo, legendProps)).toContain("(der)");
         });
 
     })


### PR DESCRIPTION
Closes #448 

- Unifica criterio de elección de colores en la base de código (existía código repetido y no usado)
- Se pasa a elegir color en `Graphic` a partir de  `getFullSerieId` en vez de únicamente el ID de la serie.