### PR TITLE
438 - ChartType y logica de clase para ajustar props

### DIFF
--- a/src/components/exportable/GraphicExportable.tsx
+++ b/src/components/exportable/GraphicExportable.tsx
@@ -6,8 +6,9 @@ import SerieApi from "../../api/SerieApi";
 import { valuesFromObject } from "../../helpers/commonFunctions";
 import Colors, { Color } from "../style/Colors/Color";
 import ExportableGraphicContainer from "../style/Graphic/ExportableGraphicContainer";
-import Graphic, { IChartTypeProps, ILegendLabel, ISeriesAxisSides, IPropsPerId } from "../viewpage/graphic/Graphic";
+import Graphic, { IChartTypeProps, ILegendLabel, ISeriesAxisSides } from "../viewpage/graphic/Graphic";
 import { chartExtremes } from "../viewpage/graphic/GraphicAndShare";
+import { PropsAdjuster } from "../viewpage/graphic/propsAdjuster";
 import { seriesConfigByUrl } from "../viewpage/ViewPage";
 
 export interface IGraphicExportableProps {
@@ -27,6 +28,7 @@ export interface IGraphicExportableProps {
     displayUnits?: boolean;
     legendLabel?: ILegendLabel;
     seriesAxis?: ISeriesAxisSides;
+    chartType?: string;
 }
 
 interface IGraphicExportableState {
@@ -70,9 +72,8 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
         params.addParamsFrom(url);
         this.fetchSeries(params);
 
-        adjustPropsUponIds(ids, this.props.chartTypes);
-        adjustPropsUponIds(ids, this.props.legendLabel);
-        adjustPropsUponIds(ids, this.props.seriesAxis);
+        const adjuster = new PropsAdjuster(ids);
+        adjuster.adjustAll(this.props.chartTypes, this.props.legendLabel, this.props.seriesAxis, this.props.chartType);
 
     }
 
@@ -148,26 +149,6 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
         this.seriesApi.fetchSeries(params)
             .then((series: ISerie[]) => this.setState({series}))
             .catch(alert);
-    }
-
-}
-
-export function adjustPropsUponIds(seriesIds: string[], props?: IPropsPerId) {
-
-    if (props === undefined) {
-        return;
-    }
-
-    for (const propSerieId in props) {
-        if(propSerieId.indexOf(':') <= -1) {   // Si es ID pura
-            const relatedUnspecifiedSeries = seriesIds.filter((id: string) => id.split(':')[0] === propSerieId && props[id] === undefined);
-            relatedUnspecifiedSeries.forEach((id: string) => props[id] = props[propSerieId])
-            // Para cada serie de series que comience con este ID y no este en props
-                // Guardo una entrada en newProps que sea 'serieFullID: setting.valor'
-            if (seriesIds.indexOf(propSerieId) <= -1) { // Si esa id no está idéntica en series, no lo tomo en cuent
-                delete props[propSerieId];
-            }
-        }
     }
 
 }

--- a/src/components/exportable/GraphicExportable.tsx
+++ b/src/components/exportable/GraphicExportable.tsx
@@ -26,8 +26,8 @@ export interface IGraphicExportableProps {
     title?: string;
     source?: string;
     displayUnits?: boolean;
-    legendLabel?: ILegendLabel;
-    seriesAxis?: ISeriesAxisSides;
+    legendLabel: ILegendLabel;
+    seriesAxis: ISeriesAxisSides;
     chartType?: string;
 }
 

--- a/src/components/viewpage/graphic/propsAdjuster.ts
+++ b/src/components/viewpage/graphic/propsAdjuster.ts
@@ -1,0 +1,67 @@
+import { IPropsPerId, IChartTypeProps, ILegendLabel, ISeriesAxisSides } from "./Graphic";
+
+export class PropsAdjuster {
+
+    private ids: string[];
+
+    public constructor(ids: string[]) {
+        this.ids = ids.sort();
+    }
+
+    public adjustAll(chartTypes?: IChartTypeProps, legendLabel?: ILegendLabel, seriesAxis?: ISeriesAxisSides, chartType?: string) {
+
+        this.adjust(chartTypes);
+        this.adjust(legendLabel);
+        this.adjust(seriesAxis);
+        this.applyDefaultChartType(chartTypes, chartType);
+
+    }
+
+    private isPureID(id: string) {
+        return id.indexOf(':') <= -1;
+    }
+
+    private getRoot(id: string) {
+        return id.split(':')[0]
+    }
+
+    private adjust(props?: IPropsPerId) {
+
+        if (props === undefined) {
+            return;
+        }
+
+        const oldProps = Object.assign({}, props);
+
+        const orderedIDs = Object.keys(oldProps);
+        orderedIDs.sort();
+        for (const propId of orderedIDs) {
+            if(this.isPureID(propId)) {
+                for (const currentId of this.ids) {
+                    if (this.getRoot(currentId) === propId) {
+                        props[currentId] = oldProps[propId];
+                    }
+                }
+            }
+            else {
+                props[propId] = oldProps[propId]; 
+            }
+        }
+
+    }
+
+    private applyDefaultChartType(chartTypes?: IChartTypeProps, chartType?: string) {
+
+        if (chartTypes === undefined || chartType === undefined) {
+            return;
+        }
+
+        for (const id of this.ids) {
+            if(chartTypes[id] === undefined) {
+                chartTypes[id] = chartType;
+            }
+        }
+
+    }
+
+}

--- a/src/components/viewpage/graphic/propsAdjuster.ts
+++ b/src/components/viewpage/graphic/propsAdjuster.ts
@@ -8,11 +8,16 @@ export class PropsAdjuster {
         this.ids = ids.sort();
     }
 
-    public adjustAll(chartTypes?: IChartTypeProps, legendLabel?: ILegendLabel, seriesAxis?: ISeriesAxisSides, chartType?: string) {
+    public adjustAll(chartTypes: IChartTypeProps, legendLabel: ILegendLabel, seriesAxis: ISeriesAxisSides, chartType?: string) {
 
         this.adjust(chartTypes);
         this.adjust(legendLabel);
         this.adjust(seriesAxis);
+
+
+        if (chartType === undefined) {
+            return;
+        }
         this.applyDefaultChartType(chartTypes, chartType);
 
     }
@@ -25,11 +30,7 @@ export class PropsAdjuster {
         return id.split(':')[0]
     }
 
-    private adjust(props?: IPropsPerId) {
-
-        if (props === undefined) {
-            return;
-        }
+    private adjust(props: IPropsPerId) {
 
         const oldProps = Object.assign({}, props);
 
@@ -50,11 +51,7 @@ export class PropsAdjuster {
 
     }
 
-    private applyDefaultChartType(chartTypes?: IChartTypeProps, chartType?: string) {
-
-        if (chartTypes === undefined || chartType === undefined) {
-            return;
-        }
+    private applyDefaultChartType(chartTypes: IChartTypeProps, chartType: string) {
 
         for (const id of this.ids) {
             if(chartTypes[id] === undefined) {

--- a/src/indexGraphic.tsx
+++ b/src/indexGraphic.tsx
@@ -20,7 +20,8 @@ export function render(selector: string, config: IGraphicExportableProps) {
                            source={config.source}
                            displayUnits={config.displayUnits}
                            legendLabel={config.legendLabel}
-                           seriesAxis={config.seriesAxis} />,
+                           seriesAxis={config.seriesAxis}
+                           chartType={config.chartType} />,
         document.getElementById(selector) as HTMLElement
     )
 }

--- a/src/indexGraphic.tsx
+++ b/src/indexGraphic.tsx
@@ -15,12 +15,12 @@ export function render(selector: string, config: IGraphicExportableProps) {
                            backgroundColor={config.backgroundColor}
                            datePickerEnabled={config.datePickerEnabled}
                            legendField={config.legendField}
-                           chartTypes={config.chartTypes}
+                           chartTypes={config.chartTypes || {}}
                            title={config.title}
                            source={config.source}
                            displayUnits={config.displayUnits}
-                           legendLabel={config.legendLabel}
-                           seriesAxis={config.seriesAxis}
+                           legendLabel={config.legendLabel  || {}}
+                           seriesAxis={config.seriesAxis  || {}}
                            chartType={config.chartType} />,
         document.getElementById(selector) as HTMLElement
     )

--- a/src/tests/components/exportable/GraphicExportable.test.tsx
+++ b/src/tests/components/exportable/GraphicExportable.test.tsx
@@ -9,8 +9,10 @@ configure({ adapter: new Adapter() });
 describe('GraphicExportable', () => {
     it('renders without crashing', () => {
         const wrapper = mount(<GraphicExportable graphicUrl="https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=116.3_TCRC_0_M_22&last=24"
-                                                    chartOptions={{}}
-                                                    chartTypes={{}} />);
+                                                 chartOptions={{}}
+                                                 legendLabel={{}}
+                                                 seriesAxis={{}}
+                                                 chartTypes={{}} />);
 
         expect(wrapper.find(GraphicExportable).exists()).toBe(true);
     });

--- a/src/tests/components/viewpage/graphic/PropsAdjustment.test.ts
+++ b/src/tests/components/viewpage/graphic/PropsAdjustment.test.ts
@@ -1,5 +1,5 @@
 import { IPropsPerId } from "../../../../components/viewpage/graphic/Graphic";
-import { adjustPropsUponIds } from "../../../../components/exportable/GraphicExportable";
+import { PropsAdjuster } from "../../../../components/viewpage/graphic/propsAdjuster";
 
 describe("Adjustment of different props for multiple IDs", () => {
 
@@ -9,6 +9,8 @@ describe("Adjustment of different props for multiple IDs", () => {
     let commonMotosId: string;
     let ids: string[];
     let props: IPropsPerId;
+    let chartType: string;
+    let adjuster: PropsAdjuster;
 
     beforeAll(() => {
         commonEMAEId = 'EMAE2004';
@@ -24,7 +26,8 @@ describe("Adjustment of different props for multiple IDs", () => {
             props = {
                 'EMAE2004': 'area'
             };
-            adjustPropsUponIds(ids, props);
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props);
             expect(props.EMAE2004).toEqual('area');
         });
         it('ID with modifier, just a basic setter adjusts it', () => {
@@ -32,7 +35,8 @@ describe("Adjustment of different props for multiple IDs", () => {
             props = {
                 'EMAE2004': 'area'
             };
-            adjustPropsUponIds(ids, props);
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props);
             expect(props['EMAE2004:percent_change']).toEqual('area');
         });
 
@@ -48,7 +52,8 @@ describe("Adjustment of different props for multiple IDs", () => {
             props = {
                 'EMAE2004': 'area'
             };
-            adjustPropsUponIds(ids, props);
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props);
             expect(props.EMAE2004).toEqual('area');
             expect(props['EMAE2004:percent_change']).toEqual('area');
         });
@@ -56,7 +61,8 @@ describe("Adjustment of different props for multiple IDs", () => {
             props = {
                 'EMAE2004:percent_change': 'area'
             };
-            adjustPropsUponIds(ids, props);
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props);
             expect(props.EMAE2004).toBeUndefined();
             expect(props['EMAE2004:percent_change']).toEqual('area');
         });
@@ -71,7 +77,8 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004': 'column',
                 'EMAE2004:percent_change': 'area'
             };
-            adjustPropsUponIds(ids, props);
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props);
             expect(props.EMAE2004).toEqual('column');
             expect(props['EMAE2004:percent_change']).toEqual('area');
             expect(props['EMAE2004:percent_change_a_year_ago']).toEqual('column');
@@ -81,7 +88,8 @@ describe("Adjustment of different props for multiple IDs", () => {
             props = {
                 'EMAE2004': 'column'
             };
-            adjustPropsUponIds(ids, props);
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props);
             expect(props.EMAE2004).toEqual('column');
             expect(props['EMAE2004:percent_change']).toEqual('column');
             expect(props['EMAE2004:percent_change_a_year_ago']).toEqual('column');
@@ -100,7 +108,8 @@ describe("Adjustment of different props for multiple IDs", () => {
             props = {
                 'EMAE2004': 'column'
             };
-            adjustPropsUponIds(ids, props);
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props);
             expect(props['EMAE2004:percent_change']).toEqual('column');
             expect(props['EMAE2004:percent_change_a_year_ago']).toEqual('column');
         });
@@ -108,7 +117,8 @@ describe("Adjustment of different props for multiple IDs", () => {
             props = {
                 'EMAE2004:percent_change_a_year_ago': 'column'
             };
-            adjustPropsUponIds(ids, props);
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props);
             expect(props['EMAE2004:percent_change']).toBeUndefined();
             expect(props['EMAE2004:percent_change_a_year_ago']).toEqual('column');
         });
@@ -117,9 +127,53 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004': 'area',
                 'EMAE2004:percent_change_a_year_ago': 'column'
             };
-            adjustPropsUponIds(ids, props);
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props);
             expect(props['EMAE2004:percent_change']).toEqual('area');
             expect(props['EMAE2004:percent_change_a_year_ago']).toEqual('column');
+        });
+
+    })
+
+    describe('With presence of chartType parameter', () => {
+
+        beforeAll(() => {
+            ids = [commonEMAEId, percentageId, commonMotosId];
+        })
+
+        it('Two different series, basic setter affects all from an ID, chartType affects the unspecified', () => {
+            props = {
+                'EMAE2004': 'column'
+            };
+            chartType = 'area';
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props, {}, {}, chartType);
+            expect(props.EMAE2004).toEqual('column');
+            expect(props['EMAE2004:percent_change']).toEqual('column');
+            expect(props.Motos_patentamiento_8myrF9).toEqual('area');
+        });
+        it('Two different series, specific setter only affects its ID, chartType affects the unspecified', () => {
+            props = {
+                'EMAE2004:percent_change': 'column'
+            };
+            chartType = 'area';
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props, {}, {}, chartType);
+            expect(props.EMAE2004).toEqual('area');
+            expect(props['EMAE2004:percent_change']).toEqual('column');
+            expect(props.Motos_patentamiento_8myrF9).toEqual('area');
+        });
+        it('Two different series, chartType does not affect because of existing setters for each serie', () => {
+            props = {
+                'EMAE2004': 'area',
+                'Motos_patentamiento_8myrF9': 'line'
+            };
+            chartType = 'column';
+            adjuster = new PropsAdjuster(ids);
+            adjuster.adjustAll(props, {}, {}, chartType);
+            expect(props.EMAE2004).toEqual('area');
+            expect(props['EMAE2004:percent_change']).toEqual('area');
+            expect(props.Motos_patentamiento_8myrF9).toEqual('line');
         });
 
     })

--- a/src/tests/components/viewpage/graphic/PropsAdjustment.test.ts
+++ b/src/tests/components/viewpage/graphic/PropsAdjustment.test.ts
@@ -27,7 +27,7 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004': 'area'
             };
             adjuster = new PropsAdjuster(ids);
-            adjuster.adjustAll(props);
+            adjuster.adjustAll(props, {}, {});
             expect(props.EMAE2004).toEqual('area');
         });
         it('ID with modifier, just a basic setter adjusts it', () => {
@@ -36,7 +36,7 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004': 'area'
             };
             adjuster = new PropsAdjuster(ids);
-            adjuster.adjustAll(props);
+            adjuster.adjustAll(props, {}, {});
             expect(props['EMAE2004:percent_change']).toEqual('area');
         });
 
@@ -53,7 +53,7 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004': 'area'
             };
             adjuster = new PropsAdjuster(ids);
-            adjuster.adjustAll(props);
+            adjuster.adjustAll(props, {}, {});
             expect(props.EMAE2004).toEqual('area');
             expect(props['EMAE2004:percent_change']).toEqual('area');
         });
@@ -62,7 +62,7 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004:percent_change': 'area'
             };
             adjuster = new PropsAdjuster(ids);
-            adjuster.adjustAll(props);
+            adjuster.adjustAll(props, {}, {});
             expect(props.EMAE2004).toBeUndefined();
             expect(props['EMAE2004:percent_change']).toEqual('area');
         });
@@ -78,7 +78,7 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004:percent_change': 'area'
             };
             adjuster = new PropsAdjuster(ids);
-            adjuster.adjustAll(props);
+            adjuster.adjustAll(props, {}, {});
             expect(props.EMAE2004).toEqual('column');
             expect(props['EMAE2004:percent_change']).toEqual('area');
             expect(props['EMAE2004:percent_change_a_year_ago']).toEqual('column');
@@ -89,7 +89,7 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004': 'column'
             };
             adjuster = new PropsAdjuster(ids);
-            adjuster.adjustAll(props);
+            adjuster.adjustAll(props, {}, {});
             expect(props.EMAE2004).toEqual('column');
             expect(props['EMAE2004:percent_change']).toEqual('column');
             expect(props['EMAE2004:percent_change_a_year_ago']).toEqual('column');
@@ -109,7 +109,7 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004': 'column'
             };
             adjuster = new PropsAdjuster(ids);
-            adjuster.adjustAll(props);
+            adjuster.adjustAll(props, {}, {});
             expect(props['EMAE2004:percent_change']).toEqual('column');
             expect(props['EMAE2004:percent_change_a_year_ago']).toEqual('column');
         });
@@ -118,7 +118,7 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004:percent_change_a_year_ago': 'column'
             };
             adjuster = new PropsAdjuster(ids);
-            adjuster.adjustAll(props);
+            adjuster.adjustAll(props, {}, {});
             expect(props['EMAE2004:percent_change']).toBeUndefined();
             expect(props['EMAE2004:percent_change_a_year_ago']).toEqual('column');
         });
@@ -128,7 +128,7 @@ describe("Adjustment of different props for multiple IDs", () => {
                 'EMAE2004:percent_change_a_year_ago': 'column'
             };
             adjuster = new PropsAdjuster(ids);
-            adjuster.adjustAll(props);
+            adjuster.adjustAll(props, {}, {});
             expect(props['EMAE2004:percent_change']).toEqual('area');
             expect(props['EMAE2004:percent_change_a_year_ago']).toEqual('column');
         });


### PR DESCRIPTION
- Agregado el parámetro opcional `chartType` al `Graphic`, para poder elegir un default de menos especificidad como tipo de chart.
- Movida la lógica de corrección de props a una clase aparte (`PropsAdjuster`), y mejorado el algoritmo para corregir las mismas.

Closes #438 