### PR TITLE
Muevo extractores de URL a un modulo aparte

### DIFF
--- a/src/components/exportable/GraphicExportable.tsx
+++ b/src/components/exportable/GraphicExportable.tsx
@@ -8,6 +8,7 @@ import Graphic, { IChartTypeProps, ILegendLabel, ISeriesAxisSides } from "../vie
 import { chartExtremes } from "../viewpage/graphic/GraphicAndShare";
 import { PropsAdjuster } from "../viewpage/graphic/propsAdjuster";
 import { seriesConfigByUrl } from "../viewpage/ViewPage";
+import { extractUriFromUrl, extractIdsFromUrl } from "../../helpers/URLExtractors";
 
 export interface IGraphicExportableProps {
     graphicUrl: string;
@@ -143,15 +144,6 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
     }
 
 }
-
-function extractIdsFromUrl(url: string): string[] {
-    return url.split('ids=')[1].split('&')[0].split(',')
-}
-
-function extractUriFromUrl(url: string): string {
-    return url.split('series/?')[0];
-}
-
 
 function legendValue(field?: string): ((serie: ISerie) => string) {
     const f = field || 'description';

--- a/src/helpers/URLExtractors.ts
+++ b/src/helpers/URLExtractors.ts
@@ -4,19 +4,19 @@ export function extractIdsFromUrl(url: string): string[] {
     const hasRepModeParam: boolean = url.split('representation_mode=').length > 1;
     const finalIDs: string[] = [];
 
-    if (hasRepModeParam) {
-        const repMode: string = url.split('representation_mode=')[1].split('&')[0];
-        for (const id of paramIDs) {
-            if(id.indexOf(':') <= -1) {
-                finalIDs.push(`${id}:${repMode}`)
-            }
-            else {
-                finalIDs.push(id);
-            }
-        }
-        return finalIDs;
+    if (!hasRepModeParam) {
+        return paramIDs;
     }
-    return paramIDs;
+    const repMode: string = url.split('representation_mode=')[1].split('&')[0];
+    for (const id of paramIDs) {
+        if(id.indexOf(':') <= -1) {
+            finalIDs.push(`${id}:${repMode}`)
+        }
+        else {
+            finalIDs.push(id);
+        }
+    }
+    return finalIDs;
 
 }
 

--- a/src/helpers/URLExtractors.ts
+++ b/src/helpers/URLExtractors.ts
@@ -1,0 +1,25 @@
+export function extractIdsFromUrl(url: string): string[] {
+
+    const paramIDs: string[] = url.split('ids=')[1].split('&')[0].split(',');
+    const hasRepModeParam: boolean = url.split('representation_mode=').length > 1;
+    const finalIDs: string[] = [];
+
+    if (hasRepModeParam) {
+        const repMode: string = url.split('representation_mode=')[1].split('&')[0];
+        for (const id of paramIDs) {
+            if(id.indexOf(':') <= -1) {
+                finalIDs.push(`${id}:${repMode}`)
+            }
+            else {
+                finalIDs.push(id);
+            }
+        }
+        return finalIDs;
+    }
+    return paramIDs;
+
+}
+
+export function extractUriFromUrl(url: string): string {
+    return url.split('series/?')[0];
+}

--- a/src/tests/components/helpers/URLExtractors.test.ts
+++ b/src/tests/components/helpers/URLExtractors.test.ts
@@ -1,0 +1,49 @@
+import { extractIdsFromUrl, extractUriFromUrl } from "../../../helpers/URLExtractors";
+
+describe("Extraction and adjustment of IDs from the URL", () => {
+
+    let url: string;
+    let ids: string[];
+
+    it("Extracting from an invalid URL throws an exception", () => {
+        url = "https://apis.datos.gob.ar/series/api/series/?invalidParam=mySerie,anotherSerie";
+        expect(() => {extractIdsFromUrl(url)}).toThrow(TypeError);
+    });
+    it("A URL with only pure IDs returns an array of them as such", () => {
+        url = "https://apis.datos.gob.ar/series/api/series/?ids=defensa_FAA_0006,99.3_IR_2008_0_9";
+        ids = extractIdsFromUrl(url);
+        expect(ids[0]).toEqual("defensa_FAA_0006");
+        expect(ids[1]).toEqual("99.3_IR_2008_0_9");
+    });
+    it("Composite IDs are copied as such to the returned array", () => {
+        url = "https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=143.3_NO_PR_2004_A_21:percent_change_a_year_ago,116.4_TCRZE_2015_D_36_4&limit=1000";
+        ids = extractIdsFromUrl(url);
+        expect(ids[0]).toEqual("143.3_NO_PR_2004_A_21:percent_change_a_year_ago");
+    });
+    it("The representationMode query param adjusts the pure IDs", () => {
+        url = "https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=148.3_INIVELNAL_DICI_M_26,148.3_INIVELGBA_DICI_M_21&representation_mode=percent_change";
+        ids = extractIdsFromUrl(url);
+        expect(ids[0]).toEqual("148.3_INIVELNAL_DICI_M_26:percent_change");
+        expect(ids[1]).toEqual("148.3_INIVELGBA_DICI_M_21:percent_change");
+    });
+    it("The representationMode query param does not adjust already composite IDs", () => {
+        url = "https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=148.3_INIVELNAL_DICI_M_26:change,148.3_INIVELGBA_DICI_M_21&representation_mode=percent_change";
+        ids = extractIdsFromUrl(url);
+        expect(ids[0]).toEqual("148.3_INIVELNAL_DICI_M_26:change");
+        expect(ids[1]).toEqual("148.3_INIVELGBA_DICI_M_21:percent_change");
+    });
+
+})
+
+describe("Extraction of URI from the URL", () => {
+
+    let url: string;
+    let uri: string;
+
+    it("A valid endpoint URL returns the URI", () => {
+        url = "https://apis.datos.gob.ar/series/api/series/?ids=defensa_FAA_0006,99.3_IR_2008_0_9";
+        uri = extractUriFromUrl(url);
+        expect(uri).toEqual("https://apis.datos.gob.ar/series/api/");
+    });
+
+})

--- a/src/tests/components/helpers/URLExtractors.test.ts
+++ b/src/tests/components/helpers/URLExtractors.test.ts
@@ -19,6 +19,7 @@ describe("Extraction and adjustment of IDs from the URL", () => {
         url = "https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=143.3_NO_PR_2004_A_21:percent_change_a_year_ago,116.4_TCRZE_2015_D_36_4&limit=1000";
         ids = extractIdsFromUrl(url);
         expect(ids[0]).toEqual("143.3_NO_PR_2004_A_21:percent_change_a_year_ago");
+        expect(ids[1]).toEqual("116.4_TCRZE_2015_D_36_4");
     });
     it("The representationMode query param adjusts the pure IDs", () => {
         url = "https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=148.3_INIVELNAL_DICI_M_26,148.3_INIVELGBA_DICI_M_21&representation_mode=percent_change";


### PR DESCRIPTION
Profundizo la función `extractIdsFromURL`, para que pueda ajustar las IDs obtenidas en caso de que exista el query param `representationMode` (modificación implícita de los IDs de series involucradas). Creo los casos de test necesarios.

Closes #438 