### PR TITLE
Corrección de manejo de escalas en el Chart cuando hay "out of scales"

### DIFF
--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -47,7 +47,7 @@ export interface IChartExtremeProps {
     max: number;
 }
 
-interface IYAxis {
+export interface IYAxis {
     opposite: boolean;
     title: {text: string};
     yAxis: number;

--- a/src/components/viewpage/graphic/axisConfiguration.ts
+++ b/src/components/viewpage/graphic/axisConfiguration.ts
@@ -10,7 +10,7 @@ function isOutOfScale(originalSerieId: string, serieId: string, minAndMaxValues:
 
 function getYAxisSide(serieID:string, outOfScale: boolean, axisSideConf?: ISeriesAxisSides, ) {
     
-    if (axisSideConf !== undefined) {
+    if (axisSideConf !== undefined && axisSideConf[serieID] !== undefined) {
         return axisSideConf[serieID];
     }
     if (outOfScale) {

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -78,22 +78,9 @@ describe("Axis Configuration functions", () => {
             }
             yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, axisSides);
         })
-
         it("Series have opposite side each other because outOfScale", () => {
-            const yAxiEmae = yAxisBySeries.EMAE2004;
-            const yAxiMotos = yAxisBySeries.Motos_patentamiento_8myrF9;
-            areInOppositeSides(yAxiEmae, yAxiMotos)
+            areInOppositeSides(yAxisBySeries.EMAE2004, yAxisBySeries.Motos_patentamiento_8myrF9)
         });
-
-        it("Legend labels below the graphic are properly written", () => {
-            legendProps = {
-                axisConf: yAxisBySeries,
-                rightSidedSeries: true
-            }
-            expect(getLegendLabel(mockSerieOne, legendProps)).toEqual("EMAE. Base 2004 (izq)");
-            expect(getLegendLabel(mockSerieTwo, legendProps)).toEqual("Motos: número de patentamientos de motocicletas (der)");
-        });
-
     })
 
     describe("Explicit configuration, one without axis side and without out of scale", () => {
@@ -101,14 +88,12 @@ describe("Axis Configuration functions", () => {
         beforeAll(() => {
             yAxisBySeries = generateYAxisBySeries(percentageSeries, mockConfig, formatUnits, locale, axisSides);
         })
-
         it("Both series goes to the left side because same scale of percentage.", () => {
             expect(yAxisBySeries["EMAE2004:percent_change"].opposite).toBe(false);
             expect(yAxisBySeries["EMAE2004:percent_change"].yAxis).toEqual(0);
             expect(yAxisBySeries["EMAE2004:percent_change_a_year_ago"].opposite).toBe(false);
             expect(yAxisBySeries["EMAE2004:percent_change_a_year_ago"].yAxis).toEqual(0);
         });
-
     })
 
     describe("Explicit configuration, one without axis side and with out of scale", () => {
@@ -117,22 +102,9 @@ describe("Axis Configuration functions", () => {
             axisSides = { 'EMAE2004': 'left' }
             yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, axisSides);
         })
-
         it("Series have opposite side each other", () => {
-            const yAxiEmae = yAxisBySeries.EMAE2004;
-            const yAxiMotos = yAxisBySeries.Motos_patentamiento_8myrF9;
-            areInOppositeSides(yAxiEmae, yAxiMotos)
+            areInOppositeSides(yAxisBySeries.EMAE2004, yAxisBySeries.Motos_patentamiento_8myrF9)
         });
-
-        it("Legend labels below the graphic are properly written", () => {
-            legendProps = {
-                axisConf: yAxisBySeries,
-                rightSidedSeries: true
-            }
-            expect(getLegendLabel(mockSerieOne, legendProps)).toEqual("EMAE. Base 2004 (izq)");
-            expect(getLegendLabel(mockSerieTwo, legendProps)).toEqual("Motos: número de patentamientos de motocicletas (der)");
-        });
-
     })
 
     describe("Explicit configuration, axis empty, each goes to opposite side", () => {
@@ -141,22 +113,9 @@ describe("Axis Configuration functions", () => {
             series = [mockSerieOne, mockSerieTwo];
             yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, {});
         })
-
         it("Series have opposite side each other", () => {
-            const yAxiEmae = yAxisBySeries.EMAE2004;
-            const yAxiMotos = yAxisBySeries.Motos_patentamiento_8myrF9;
-            areInOppositeSides(yAxiEmae, yAxiMotos)
+            areInOppositeSides(yAxisBySeries.EMAE2004, yAxisBySeries.Motos_patentamiento_8myrF9)
         });
-
-        it("Legend labels below the graphic are properly written", () => {
-            legendProps = {
-                axisConf: yAxisBySeries,
-                rightSidedSeries: true
-            }
-            expect(getLegendLabel(mockSerieOne, legendProps)).toEqual("EMAE. Base 2004 (izq)");
-            expect(getLegendLabel(mockSerieTwo, legendProps)).toEqual("Motos: número de patentamientos de motocicletas (der)");
-        });
-
     })
 
     describe("Explicit configuration, both on the left side", () => {

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -81,6 +81,14 @@ describe("Axis Configuration functions", () => {
         it("Series have opposite side each other because outOfScale", () => {
             areInOppositeSides(yAxisBySeries.EMAE2004, yAxisBySeries.Motos_patentamiento_8myrF9)
         });
+        it("Legend labels below the graphic are properly written", () => {
+            legendProps = {
+                axisConf: yAxisBySeries,
+                rightSidedSeries: true
+            }
+            expect(getLegendLabel(mockSerieOne, legendProps)).toContain("(izq)");
+            expect(getLegendLabel(mockSerieTwo, legendProps)).toContain("(der)");
+        });
     })
 
     describe("Explicit configuration, one without axis side and without out of scale", () => {
@@ -93,6 +101,14 @@ describe("Axis Configuration functions", () => {
             expect(yAxisBySeries["EMAE2004:percent_change"].yAxis).toEqual(0);
             expect(yAxisBySeries["EMAE2004:percent_change_a_year_ago"].opposite).toBe(false);
             expect(yAxisBySeries["EMAE2004:percent_change_a_year_ago"].yAxis).toEqual(0);
+        });
+        it("Legend labels below the graphic are properly written", () => {
+            legendProps = {
+                axisConf: yAxisBySeries,
+                rightSidedSeries: true
+            }
+            expect(getLegendLabel(mockSerieOne, legendProps)).toContain("(izq)");
+            expect(getLegendLabel(mockSerieTwo, legendProps)).toContain("(der)");
         });
     })
 
@@ -115,6 +131,14 @@ describe("Axis Configuration functions", () => {
         })
         it("Series have opposite side each other", () => {
             areInOppositeSides(yAxisBySeries.EMAE2004, yAxisBySeries.Motos_patentamiento_8myrF9)
+        });
+        it("Legend labels below the graphic are properly written", () => {
+            legendProps = {
+                axisConf: yAxisBySeries,
+                rightSidedSeries: true
+            }
+            expect(getLegendLabel(mockSerieOne, legendProps)).toContain("(izq)");
+            expect(getLegendLabel(mockSerieTwo, legendProps)).toContain("(der)");
         });
     })
 

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -1,6 +1,6 @@
 import { ISerie } from "../../../../api/Serie";
 import SerieConfig from "../../../../api/SerieConfig";
-import { IYAxisConf, ISeriesAxisSides } from "../../../../components/viewpage/graphic/Graphic";
+import { IYAxisConf, ISeriesAxisSides, IYAxis } from "../../../../components/viewpage/graphic/Graphic";
 import { generateYAxisBySeries } from "../../../../components/viewpage/graphic/axisConfiguration";
 import { generateCommonMockSerieMotos, generateCommonMockSerieEMAE, generatePercentageMockSerie, generatePercentageYearMockSerie } from "../../../support/mockers/seriesMockers";
 import { ILegendConfiguration, getLegendLabel } from "../../../../components/viewpage/graphic/legendConfiguration";
@@ -19,6 +19,14 @@ describe("Axis Configuration functions", () => {
     let legendProps: ILegendConfiguration;
     const locale = 'AR';
     const formatUnits = false;
+
+    function areInOppositeSides(yAxisConfOne: IYAxis, yAxisConfTwo: IYAxis) {
+        expect(yAxisConfOne.opposite).toBe(false);
+        expect(yAxisConfOne.yAxis).toEqual(0);
+
+        expect(yAxisConfTwo.opposite).toBe(true);
+        expect(yAxisConfTwo.yAxis).toEqual(1);
+    }
 
     beforeAll(() => {
         mockSerieOne = generateCommonMockSerieEMAE();
@@ -72,11 +80,9 @@ describe("Axis Configuration functions", () => {
         })
 
         it("Series have opposite side each other because outOfScale", () => {
-            expect(yAxisBySeries.EMAE2004.opposite).toBe(false);
-            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(0);
-
-            expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(true);
-            expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
+            const yAxiEmae = yAxisBySeries.EMAE2004;
+            const yAxiMotos = yAxisBySeries.Motos_patentamiento_8myrF9;
+            areInOppositeSides(yAxiEmae, yAxiMotos)
         });
 
         it("Legend labels below the graphic are properly written", () => {
@@ -113,11 +119,9 @@ describe("Axis Configuration functions", () => {
         })
 
         it("Series have opposite side each other", () => {
-            expect(yAxisBySeries.EMAE2004.opposite).toBe(false);
-            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(0);
-
-            expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(true);
-            expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
+            const yAxiEmae = yAxisBySeries.EMAE2004;
+            const yAxiMotos = yAxisBySeries.Motos_patentamiento_8myrF9;
+            areInOppositeSides(yAxiEmae, yAxiMotos)
         });
 
         it("Legend labels below the graphic are properly written", () => {
@@ -139,11 +143,9 @@ describe("Axis Configuration functions", () => {
         })
 
         it("Series have opposite side each other", () => {
-            expect(yAxisBySeries.EMAE2004.opposite).toBe(false);
-            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(0);
-
-            expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(true);
-            expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
+            const yAxiEmae = yAxisBySeries.EMAE2004;
+            const yAxiMotos = yAxisBySeries.Motos_patentamiento_8myrF9;
+            areInOppositeSides(yAxiEmae, yAxiMotos)
         });
 
         it("Legend labels below the graphic are properly written", () => {

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -102,13 +102,13 @@ describe("Axis Configuration functions", () => {
             expect(yAxisBySeries["EMAE2004:percent_change_a_year_ago"].opposite).toBe(false);
             expect(yAxisBySeries["EMAE2004:percent_change_a_year_ago"].yAxis).toEqual(0);
         });
-        it("Legend labels below the graphic are properly written", () => {
+        it("Legend labels are both on the left side", () => {
             legendProps = {
                 axisConf: yAxisBySeries,
                 rightSidedSeries: true
             }
-            expect(getLegendLabel(mockSerieOne, legendProps)).toContain("(izq)");
-            expect(getLegendLabel(mockSerieTwo, legendProps)).toContain("(der)");
+            expect(getLegendLabel(mockSeriePercentChange, legendProps)).toContain("(izq)");
+            expect(getLegendLabel(mockSeriePercentChangeYearAgo, legendProps)).toContain("(izq)");
         });
     })
 
@@ -131,14 +131,6 @@ describe("Axis Configuration functions", () => {
         })
         it("Series have opposite side each other", () => {
             areInOppositeSides(yAxisBySeries.EMAE2004, yAxisBySeries.Motos_patentamiento_8myrF9)
-        });
-        it("Legend labels below the graphic are properly written", () => {
-            legendProps = {
-                axisConf: yAxisBySeries,
-                rightSidedSeries: true
-            }
-            expect(getLegendLabel(mockSerieOne, legendProps)).toContain("(izq)");
-            expect(getLegendLabel(mockSerieTwo, legendProps)).toContain("(der)");
         });
     })
 

--- a/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
+++ b/src/tests/components/viewpage/graphic/AxisConfiguration.test.ts
@@ -2,14 +2,17 @@ import { ISerie } from "../../../../api/Serie";
 import SerieConfig from "../../../../api/SerieConfig";
 import { IYAxisConf, ISeriesAxisSides } from "../../../../components/viewpage/graphic/Graphic";
 import { generateYAxisBySeries } from "../../../../components/viewpage/graphic/axisConfiguration";
-import { generateCommonMockSerieMotos, generateCommonMockSerieEMAE } from "../../../support/mockers/seriesMockers";
+import { generateCommonMockSerieMotos, generateCommonMockSerieEMAE, generatePercentageMockSerie, generatePercentageYearMockSerie } from "../../../support/mockers/seriesMockers";
 import { ILegendConfiguration, getLegendLabel } from "../../../../components/viewpage/graphic/legendConfiguration";
 
 describe("Axis Configuration functions", () => {
 
     let mockSerieOne: ISerie;
     let mockSerieTwo: ISerie;
+    let mockSeriePercentChange: ISerie;
+    let mockSeriePercentChangeYearAgo: ISerie;
     let series: ISerie[];
+    let percentageSeries: ISerie[];
     let mockConfig: SerieConfig[];
     let axisSides: ISeriesAxisSides;
     let yAxisBySeries: IYAxisConf;
@@ -20,12 +23,16 @@ describe("Axis Configuration functions", () => {
     beforeAll(() => {
         mockSerieOne = generateCommonMockSerieEMAE();
         mockSerieTwo = generateCommonMockSerieMotos();
+        mockSeriePercentChange = generatePercentageMockSerie();
+        mockSeriePercentChangeYearAgo = generatePercentageYearMockSerie();
+        percentageSeries = [mockSeriePercentChange, mockSeriePercentChangeYearAgo]
+
         series = [mockSerieOne, mockSerieTwo];
         mockConfig = [new SerieConfig(mockSerieOne),
-                        new SerieConfig(mockSerieTwo)];
+        new SerieConfig(mockSerieTwo)];
     })
 
-    describe("Default axis configuration, without optional parameter", () => {     
+    describe("Default axis configuration, without optional parameter", () => {
 
         beforeAll(() => {
             yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale);
@@ -57,19 +64,88 @@ describe("Axis Configuration functions", () => {
     describe("Explicit configuration, switching the default sides", () => {
 
         beforeAll(() => {
-            axisSides = { 'EMAE2004': 'left',
-                          'Motos_patentamiento_8myrF9': 'right' }
+            axisSides = {
+                'EMAE2004': 'left',
+                'Motos_patentamiento_8myrF9': 'right'
+            }
             yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, axisSides);
         })
 
-        it("Originally left-sided serie goes to the right", () => {
+        it("Series have opposite side each other because outOfScale", () => {
             expect(yAxisBySeries.EMAE2004.opposite).toBe(false);
             expect(yAxisBySeries.EMAE2004.yAxis).toEqual(0);
-        });
-        it("Originally right-sided serie goes to the left", () => {
+
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(true);
             expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
         });
+
+        it("Legend labels below the graphic are properly written", () => {
+            legendProps = {
+                axisConf: yAxisBySeries,
+                rightSidedSeries: true
+            }
+            expect(getLegendLabel(mockSerieOne, legendProps)).toEqual("EMAE. Base 2004 (izq)");
+            expect(getLegendLabel(mockSerieTwo, legendProps)).toEqual("Motos: número de patentamientos de motocicletas (der)");
+        });
+
+    })
+
+    describe("Explicit configuration, one without axis side and without out of scale", () => {
+
+        beforeAll(() => {
+            yAxisBySeries = generateYAxisBySeries(percentageSeries, mockConfig, formatUnits, locale, axisSides);
+        })
+
+        it("Both series goes to the left side because same scale of percentage.", () => {
+            expect(yAxisBySeries["EMAE2004:percent_change"].opposite).toBe(false);
+            expect(yAxisBySeries["EMAE2004:percent_change"].yAxis).toEqual(0);
+            expect(yAxisBySeries["EMAE2004:percent_change_a_year_ago"].opposite).toBe(false);
+            expect(yAxisBySeries["EMAE2004:percent_change_a_year_ago"].yAxis).toEqual(0);
+        });
+
+    })
+
+    describe("Explicit configuration, one without axis side and with out of scale", () => {
+
+        beforeAll(() => {
+            axisSides = { 'EMAE2004': 'left' }
+            yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, axisSides);
+        })
+
+        it("Series have opposite side each other", () => {
+            expect(yAxisBySeries.EMAE2004.opposite).toBe(false);
+            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(0);
+
+            expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(true);
+            expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
+        });
+
+        it("Legend labels below the graphic are properly written", () => {
+            legendProps = {
+                axisConf: yAxisBySeries,
+                rightSidedSeries: true
+            }
+            expect(getLegendLabel(mockSerieOne, legendProps)).toEqual("EMAE. Base 2004 (izq)");
+            expect(getLegendLabel(mockSerieTwo, legendProps)).toEqual("Motos: número de patentamientos de motocicletas (der)");
+        });
+
+    })
+
+    describe("Explicit configuration, axis empty, each goes to opposite side", () => {
+
+        beforeAll(() => {
+            series = [mockSerieOne, mockSerieTwo];
+            yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, {});
+        })
+
+        it("Series have opposite side each other", () => {
+            expect(yAxisBySeries.EMAE2004.opposite).toBe(false);
+            expect(yAxisBySeries.EMAE2004.yAxis).toEqual(0);
+
+            expect(yAxisBySeries.Motos_patentamiento_8myrF9.opposite).toBe(true);
+            expect(yAxisBySeries.Motos_patentamiento_8myrF9.yAxis).toEqual(1);
+        });
+
         it("Legend labels below the graphic are properly written", () => {
             legendProps = {
                 axisConf: yAxisBySeries,
@@ -82,10 +158,12 @@ describe("Axis Configuration functions", () => {
     })
 
     describe("Explicit configuration, both on the left side", () => {
-
         beforeAll(() => {
-            axisSides = { 'EMAE2004': 'left',
-                          'Motos_patentamiento_8myrF9': 'left' }
+            series = [mockSerieOne, mockSerieTwo];
+            axisSides = {
+                'EMAE2004': 'left',
+                'Motos_patentamiento_8myrF9': 'left'
+            }
             yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, axisSides);
         })
 
@@ -111,8 +189,11 @@ describe("Axis Configuration functions", () => {
     describe("Explicit configuration, both on the right side", () => {
 
         beforeAll(() => {
-            axisSides = { 'EMAE2004': 'right',
-                          'Motos_patentamiento_8myrF9': 'right' }
+            series = [mockSerieOne, mockSerieTwo];
+            axisSides = {
+                'EMAE2004': 'right',
+                'Motos_patentamiento_8myrF9': 'right'
+            }
             yAxisBySeries = generateYAxisBySeries(series, mockConfig, formatUnits, locale, axisSides);
         })
 


### PR DESCRIPTION
closes #447 

Se corrigió el código que verifica si se usa la configuración por defecto o si el id posee algún modificador en los ejes de su serie. En caso de que no exista una configuración de posición entonces se fija si es necesario enviarlo a la derecha en caso de "out of scale"