### PR TITLE
442 - estilos altura grafico leyenda

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -61,8 +61,6 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  overflow: hidden !important;
-  height: 40px !important;
 }
 
 .highcharts-legend-item tspan {

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -58,6 +58,11 @@
   width: 75%;
   text-align: center;
   left: 15% !important;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden !important;
+  height: 40px !important;
 }
 
 .highcharts-legend-item tspan {
@@ -65,6 +70,13 @@
   font-family: "Roboto", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   font-weight: 400;
   font-size: 15px;
+}
+
+.highcharts-subtitle {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 /*---Fin Graphic---*/

--- a/src/components/exportable/GraphicExportable.tsx
+++ b/src/components/exportable/GraphicExportable.tsx
@@ -204,8 +204,7 @@ function titleOptions(componentProps: IGraphicExportableProps) {
         fontSize: "20.8px",
         fontWeight: "500",
         fontFamily: ["Roboto", "Helvetica Neue", "Helvetica", "Arial", "sans-serif"],
-        lineHeight: "0.92",
-        paddingBottom: "40px"
+        lineHeight: "0.92"
     };
 
     if (!componentProps.zoom && !componentProps.datePickerEnabled) { // remove margin between title and chart

--- a/src/components/exportable/GraphicExportable.tsx
+++ b/src/components/exportable/GraphicExportable.tsx
@@ -96,7 +96,7 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
     }
 
     private afterRender(chart: any) {
-        const chartHeight = chart.container.parentElement.clientHeight - chart.subtitle.element.clientHeight;
+        const chartHeight = chart.container.parentElement.clientHeight;
         const zoomEnabled = this.props.zoom || (this.props.zoom === undefined && chart.chartWidth >= 620);
         const navigatorEnabled = this.props.navigator || (this.props.navigator === undefined && chartHeight >= 500);
         const datepickerEnabled = this.props.datePickerEnabled || (this.props.datePickerEnabled === undefined && chart.chartWidth >= 400);
@@ -106,7 +106,6 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
         chart.update({
             chart: {
                 height: chartHeight, // force the settings of container's height,
-                marginBottom: getMarginBottom(this.props, navigatorEnabled),
                 zoomType: zoomEnabled ? 'x' : 'none'
             },
             navigator: { enabled: navigatorEnabled },
@@ -118,8 +117,8 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
             title: {
                 margin: 10,
                 style: {
-                    height: smallChart ? 35 : 'auto',
-                    overflow: smallChart ? 'auto' : 'hidden',
+                    height: 40,
+                    overflow: 'hidden',
                     whiteSpace: 'normal'
                 },
                 useHTML: smallChart,
@@ -261,15 +260,4 @@ function seriesLength(apiCall: string): number {
 
 function multipleSeries(componentProps: IGraphicExportableProps): boolean {
     return seriesLength(componentProps.graphicUrl) > 1
-}
-
-function getMarginBottom(props: IGraphicExportableProps, navigatorEnabled: boolean): number|null {
-    const activeLegend = multipleSeries(props);
-    let marginBottom = activeLegend ? null : 15;
-
-    if (activeLegend && (!navigatorEnabled && props.navigator === undefined)) {
-        marginBottom = 55;
-    }
-
-    return marginBottom;
 }

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -103,7 +103,6 @@ export default class Graphic extends React.Component<IGraphicProps> {
     public afterRender = (chart: any) => {
         this.showLoading(chart);
         this.setExtremes(chart);
-        changeCreditsPosition(chart);
 
         if (this.props.afterRender) {
             this.props.afterRender(chart);
@@ -469,8 +468,4 @@ export function getChartType(serie: ISerie, types?: IChartTypeProps): string {
     if (!types) { return 'line' }
 
     return types[getFullSerieId(serie)];
-}
-
-function changeCreditsPosition(chart: any) {
-    chart.container.getElementsByClassName('highcharts-credits')[0].setAttribute('y', 460); // change position of 'credits'
 }


### PR DESCRIPTION
- Elimino el código que corregía la posición de los `credits` (el "Ver en datos.gob.ar") del componente `Graphic`.
- Elimino el agregado al margen inferior del `chart ` en el componente `Graphic`.
- Hago que el cálculo de la altura del `chart` ya no dependa del tamaño del `subtitles` (la fuente) del componente `Graphic`.
- Mejoro y clampeo el tamaño del título del `Graphic`, para que no se corte.

Closes #442 