### PR TITLE
469 - Corregir codigo web

### DIFF
--- a/src/components/common/webCodeBuilders.ts
+++ b/src/components/common/webCodeBuilders.ts
@@ -1,0 +1,55 @@
+import { IWebSnippetOptions } from "../exportable_card/FullCardDropdown";
+
+export function cardWebCode(options: IWebSnippetOptions): string {
+
+    let htmlScript = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
+<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
+<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
+<div id="root"></div>
+<script>
+    window.onload = function() {
+        TSComponents.Card.render('root', {
+            serieId: "${options.serieId}",
+            color: "${options.color}",
+            links: "${options.links}",
+            hasChart: "${options.hasChart}"`;
+
+    if(options.chartType !== undefined)
+    {
+        htmlScript += `,
+            chartType: "${options.chartType}"`;
+    }
+    if(options.title !== undefined)
+    {
+        htmlScript += `,
+            title: "${options.title}"`;
+    }
+    if(options.source !== undefined)
+    {
+        htmlScript += `,
+            source: "${options.source}"`;
+    }
+    if(options.units !== undefined)
+    {
+        htmlScript += `,
+            units: "${options.units}"`;
+    }
+    if(options.hasFrame !== undefined)
+    {
+        htmlScript += `,
+            hasFrame: ${options.hasFrame}`;
+    }
+    if(options.hasColorBar !== undefined)
+    {
+        htmlScript += `,
+            hasColorBar: ${options.hasColorBar}`;
+    }
+
+    htmlScript += `
+        })
+    }
+</script>
+`;
+
+    return htmlScript;
+}

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -11,6 +11,7 @@ import FullCardUnits from '../style/exportable_card/FullCardUnits';
 import FullCardValue from '../style/exportable_card/FullCardValue';
 import FullCardChart from './FullCardChart';
 import FullCardLinks from './FullCardLinks';
+import { getFullSerieId } from '../viewpage/graphic/Graphic';
 
 
 interface IFullCardProps {
@@ -25,7 +26,7 @@ export default (props: IFullCardProps) => {
     const options = {
         ...props.cardOptions,
         downloadUrl: props.downloadUrl,
-        serieId: props.serie.id
+        serieId: getFullSerieId(props.serie)
     }
     const value = props.serie.data[props.serie.data.length-1].value
     const formatter = new CardValueFormatter(

--- a/src/components/exportable_card/FullCardDropdown.tsx
+++ b/src/components/exportable_card/FullCardDropdown.tsx
@@ -3,13 +3,14 @@ import { formatUrl, viewDatosGobAr } from '../common/linkBuilders';
 import FullCardDropdownContainer from '../style/exportable_card/FullCardDropdownContainer';
 import LinkShareItem from '../style/Share/LinkShareItem';
 import { ICardLinksOptions } from './FullCardLinks';
+import { cardWebCode } from '../common/webCodeBuilders';
 
 export default (props: {options: ICardLinksOptions}) =>
     <FullCardDropdownContainer text="Enlaces">
         <LinkShareItem url={viewDatosGobAr(props.options.serieId)} text="Enlace web" />
         <LinkShareItem url={formatUrl(props.options.downloadUrl, "csv")} text="Enlace CSV" />
         <LinkShareItem url={formatUrl(props.options.downloadUrl, "json")} text="Enlace JSON" />
-        <LinkShareItem url={webCode(props.options)} text="Código web" />
+        <LinkShareItem url={cardWebCode(props.options)} text="Código web" />
     </FullCardDropdownContainer>
 
 export interface IWebSnippetOptions {
@@ -17,64 +18,10 @@ export interface IWebSnippetOptions {
     color: string,
     links: string
     hasChart: string,
-    chartType: string,
-    title: string;
-    source: string;
-    units: string;
-    hasFrame: boolean;
-    hasColorBar: boolean;
-}
-
-function webCode(options: IWebSnippetOptions): string {
-
-    let htmlScript = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
-<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
-<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
-<div id="root"></div>
-<script>
-    window.onload = function() {
-        TSComponents.Card.render('root', {
-            serieId: "${options.serieId}",
-            color: "${options.color}",
-            links: "${options.links}",
-            hasChart: "${options.hasChart}"`;
-
-    if(options.chartType !== undefined)
-    {
-        htmlScript += `,
-            chartType: "${options.chartType}"`;
-    }
-    if(options.title !== undefined)
-    {
-        htmlScript += `,
-            title: "${options.title}"`;
-    }
-    if(options.source !== undefined)
-    {
-        htmlScript += `,
-            source: "${options.source}"`;
-    }
-    if(options.units !== undefined)
-    {
-        htmlScript += `,
-            units: "${options.units}"`;
-    }
-    if(options.hasFrame !== undefined)
-    {
-        htmlScript += `,
-            hasFrame: "${options.hasFrame}"`;
-    }
-    if(options.hasColorBar !== undefined)
-    {
-        htmlScript += `,
-            hasColorBar: "${options.hasColorBar}"`;
-    }
-
-    htmlScript += `
-        })
-    }
-</script>
-`
-
-    return htmlScript
+    chartType?: string,
+    title?: string;
+    source?: string;
+    units?: string;
+    hasFrame?: boolean;
+    hasColorBar?: boolean;
 }

--- a/src/tests/components/common/LinkBuilders.test.ts
+++ b/src/tests/components/common/LinkBuilders.test.ts
@@ -1,0 +1,33 @@
+import { formatUrl, viewDatosGobAr } from "../../../components/common/linkBuilders";
+
+describe('Link building functions for Dropdown components', () => {
+
+    describe('Appendage of desired format to a download URL', () => {
+
+        let url: string;
+        let formatSuffix: string;
+
+        beforeAll(() => {
+            url = 'https://apis.datos.gob.ar/series/api/series/?ids=116.4_TCRZE_2015_D_36_4&last=5000';
+        })
+        
+        it('Appendage of JSON format', () => {
+            formatSuffix = 'json';
+            const finalURL = formatUrl(url, formatSuffix);
+            expect(finalURL).toEqual('https://apis.datos.gob.ar/series/api/series/?ids=116.4_TCRZE_2015_D_36_4&last=5000&format=json')
+        });
+        it('Appendage of CSV format', () => {
+            formatSuffix = 'csv';
+            const finalURL = formatUrl(url, formatSuffix);
+            expect(finalURL).toEqual('https://apis.datos.gob.ar/series/api/series/?ids=116.4_TCRZE_2015_D_36_4&last=5000&format=csv')
+        });
+
+    })
+
+    it('Obtainment of URL to view the serie at datos.gob.ar', () => {
+        const serieID: string = '148.3_INIVELNAL_DICI_M_26:percent_change';
+        const viewURL = viewDatosGobAr(serieID);
+        expect(viewURL).toEqual('https://datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change');
+    })
+
+})

--- a/src/tests/components/common/WebCodeBuilders.test.ts
+++ b/src/tests/components/common/WebCodeBuilders.test.ts
@@ -34,7 +34,7 @@ describe('Generation of copyable web code for components', () => {
             expect(generatedCode).toContain(expectedScript);
         });
         it('ChartType specified as well', () => {
-            options['chartType'] = 'small';
+            options.chartType = 'small';
             expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
@@ -51,7 +51,7 @@ describe('Generation of copyable web code for components', () => {
             expect(generatedCode).toContain(expectedScript);
         });
         it('Title specified as well', () => {
-            options['title'] = 'Desocupacion';
+            options.title = 'Desocupacion';
             expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
@@ -68,7 +68,7 @@ describe('Generation of copyable web code for components', () => {
             expect(generatedCode).toContain(expectedScript);
         });
         it('Source specified as well', () => {
-            options['source'] = 'INDEC';
+            options.source = 'INDEC';
             expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
@@ -85,7 +85,7 @@ describe('Generation of copyable web code for components', () => {
             expect(generatedCode).toContain(expectedScript);
         });
         it('Units specified as well', () => {
-            options['units'] = '';
+            options.units = '';
             expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
@@ -102,7 +102,7 @@ describe('Generation of copyable web code for components', () => {
             expect(generatedCode).toContain(expectedScript);
         });
         it('HasFrame specified as well', () => {
-            options['hasFrame'] = true;
+            options.hasFrame = true;
             expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
@@ -119,7 +119,7 @@ describe('Generation of copyable web code for components', () => {
             expect(generatedCode).toContain(expectedScript);
         });
         it('HasColorBar specified as well', () => {
-            options['hasColorBar'] = false;
+            options.hasColorBar = false;
             expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {

--- a/src/tests/components/common/WebCodeBuilders.test.ts
+++ b/src/tests/components/common/WebCodeBuilders.test.ts
@@ -1,0 +1,168 @@
+import { IWebSnippetOptions } from "../../../components/exportable_card/FullCardDropdown";
+import { cardWebCode } from "../../../components/common/webCodeBuilders";
+
+describe('Generation of copyable web code for components', () => {
+
+    describe('Copyable web code for a Card component', () => {
+
+        let options: IWebSnippetOptions;
+        let expectedCode: string;
+
+        beforeEach(() => {
+            options = {
+                color: 'F9A822',
+                links: 'small',
+                hasChart: 'small',
+                serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            };
+        })
+
+        it('Only mandatory parameters specified', () => {
+            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
+<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
+<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
+<div id="root"></div>
+<script>
+    window.onload = function() {
+        TSComponents.Card.render('root', {
+            serieId: "42.3_EPH_PUNTUATAL_0_M_30",
+            color: "F9A822",
+            links: "small",
+            hasChart: "small"
+        })
+    }
+</script>
+`;
+            const actualCode = cardWebCode(options);
+            expect(actualCode).toEqual(expectedCode);
+        });
+        it('ChartType specified as well', () => {
+            options['chartType'] = 'small';
+            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
+<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
+<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
+<div id="root"></div>
+<script>
+    window.onload = function() {
+        TSComponents.Card.render('root', {
+            serieId: "42.3_EPH_PUNTUATAL_0_M_30",
+            color: "F9A822",
+            links: "small",
+            hasChart: "small",
+            chartType: "small"
+        })
+    }
+</script>
+`;
+            const actualCode = cardWebCode(options);
+            expect(actualCode).toEqual(expectedCode);
+        });
+        it('Title specified as well', () => {
+            options['title'] = 'Desocupacion';
+            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
+<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
+<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
+<div id="root"></div>
+<script>
+    window.onload = function() {
+        TSComponents.Card.render('root', {
+            serieId: "42.3_EPH_PUNTUATAL_0_M_30",
+            color: "F9A822",
+            links: "small",
+            hasChart: "small",
+            title: "Desocupacion"
+        })
+    }
+</script>
+`;
+            const actualCode = cardWebCode(options);
+            expect(actualCode).toEqual(expectedCode);
+        });
+        it('Source specified as well', () => {
+            options['source'] = 'INDEC';
+            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
+<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
+<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
+<div id="root"></div>
+<script>
+    window.onload = function() {
+        TSComponents.Card.render('root', {
+            serieId: "42.3_EPH_PUNTUATAL_0_M_30",
+            color: "F9A822",
+            links: "small",
+            hasChart: "small",
+            source: "INDEC"
+        })
+    }
+</script>
+`;
+            const actualCode = cardWebCode(options);
+            expect(actualCode).toEqual(expectedCode);
+        });
+        it('Units specified as well', () => {
+            options['units'] = '';
+            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
+<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
+<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
+<div id="root"></div>
+<script>
+    window.onload = function() {
+        TSComponents.Card.render('root', {
+            serieId: "42.3_EPH_PUNTUATAL_0_M_30",
+            color: "F9A822",
+            links: "small",
+            hasChart: "small",
+            units: ""
+        })
+    }
+</script>
+`;
+            const actualCode = cardWebCode(options);
+            expect(actualCode).toEqual(expectedCode);
+        });
+        it('HasFrame specified as well', () => {
+            options['hasFrame'] = true;
+            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
+<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
+<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
+<div id="root"></div>
+<script>
+    window.onload = function() {
+        TSComponents.Card.render('root', {
+            serieId: "42.3_EPH_PUNTUATAL_0_M_30",
+            color: "F9A822",
+            links: "small",
+            hasChart: "small",
+            hasFrame: true
+        })
+    }
+</script>
+`;
+            const actualCode = cardWebCode(options);
+            expect(actualCode).toEqual(expectedCode);
+        });
+        it('HasColorBar specified as well', () => {
+            options['hasColorBar'] = false;
+            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
+<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
+<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
+<div id="root"></div>
+<script>
+    window.onload = function() {
+        TSComponents.Card.render('root', {
+            serieId: "42.3_EPH_PUNTUATAL_0_M_30",
+            color: "F9A822",
+            links: "small",
+            hasChart: "small",
+            hasColorBar: false
+        })
+    }
+</script>
+`;
+            const actualCode = cardWebCode(options);
+            expect(actualCode).toEqual(expectedCode);
+        });
+
+    })
+
+})

--- a/src/tests/components/common/WebCodeBuilders.test.ts
+++ b/src/tests/components/common/WebCodeBuilders.test.ts
@@ -6,7 +6,8 @@ describe('Generation of copyable web code for components', () => {
     describe('Copyable web code for a Card component', () => {
 
         let options: IWebSnippetOptions;
-        let expectedCode: string;
+        let expectedScript: string;
+        let generatedCode: string;
 
         beforeEach(() => {
             options = {
@@ -18,11 +19,7 @@ describe('Generation of copyable web code for components', () => {
         })
 
         it('Only mandatory parameters specified', () => {
-            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
-<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
-<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
-<div id="root"></div>
-<script>
+            expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
             serieId: "42.3_EPH_PUNTUATAL_0_M_30",
@@ -33,16 +30,12 @@ describe('Generation of copyable web code for components', () => {
     }
 </script>
 `;
-            const actualCode = cardWebCode(options);
-            expect(actualCode).toEqual(expectedCode);
+            generatedCode = cardWebCode(options);
+            expect(generatedCode).toContain(expectedScript);
         });
         it('ChartType specified as well', () => {
             options['chartType'] = 'small';
-            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
-<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
-<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
-<div id="root"></div>
-<script>
+            expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
             serieId: "42.3_EPH_PUNTUATAL_0_M_30",
@@ -54,16 +47,12 @@ describe('Generation of copyable web code for components', () => {
     }
 </script>
 `;
-            const actualCode = cardWebCode(options);
-            expect(actualCode).toEqual(expectedCode);
+            generatedCode = cardWebCode(options);
+            expect(generatedCode).toContain(expectedScript);
         });
         it('Title specified as well', () => {
             options['title'] = 'Desocupacion';
-            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
-<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
-<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
-<div id="root"></div>
-<script>
+            expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
             serieId: "42.3_EPH_PUNTUATAL_0_M_30",
@@ -75,16 +64,12 @@ describe('Generation of copyable web code for components', () => {
     }
 </script>
 `;
-            const actualCode = cardWebCode(options);
-            expect(actualCode).toEqual(expectedCode);
+            generatedCode = cardWebCode(options);
+            expect(generatedCode).toContain(expectedScript);
         });
         it('Source specified as well', () => {
             options['source'] = 'INDEC';
-            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
-<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
-<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
-<div id="root"></div>
-<script>
+            expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
             serieId: "42.3_EPH_PUNTUATAL_0_M_30",
@@ -96,16 +81,12 @@ describe('Generation of copyable web code for components', () => {
     }
 </script>
 `;
-            const actualCode = cardWebCode(options);
-            expect(actualCode).toEqual(expectedCode);
+            generatedCode = cardWebCode(options);
+            expect(generatedCode).toContain(expectedScript);
         });
         it('Units specified as well', () => {
             options['units'] = '';
-            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
-<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
-<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
-<div id="root"></div>
-<script>
+            expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
             serieId: "42.3_EPH_PUNTUATAL_0_M_30",
@@ -117,16 +98,12 @@ describe('Generation of copyable web code for components', () => {
     }
 </script>
 `;
-            const actualCode = cardWebCode(options);
-            expect(actualCode).toEqual(expectedCode);
+            generatedCode = cardWebCode(options);
+            expect(generatedCode).toContain(expectedScript);
         });
         it('HasFrame specified as well', () => {
             options['hasFrame'] = true;
-            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
-<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
-<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
-<div id="root"></div>
-<script>
+            expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
             serieId: "42.3_EPH_PUNTUATAL_0_M_30",
@@ -138,16 +115,12 @@ describe('Generation of copyable web code for components', () => {
     }
 </script>
 `;
-            const actualCode = cardWebCode(options);
-            expect(actualCode).toEqual(expectedCode);
+            generatedCode = cardWebCode(options);
+            expect(generatedCode).toContain(expectedScript);
         });
         it('HasColorBar specified as well', () => {
             options['hasColorBar'] = false;
-            expectedCode = `<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/js/components.js'></script>
-<link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.2.1/dist/css/components.css'/>
-<link type='text/css' rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css' media='all' />"
-<div id="root"></div>
-<script>
+            expectedScript = `<script>
     window.onload = function() {
         TSComponents.Card.render('root', {
             serieId: "42.3_EPH_PUNTUATAL_0_M_30",
@@ -159,8 +132,8 @@ describe('Generation of copyable web code for components', () => {
     }
 </script>
 `;
-            const actualCode = cardWebCode(options);
-            expect(actualCode).toEqual(expectedCode);
+            generatedCode = cardWebCode(options);
+            expect(generatedCode).toContain(expectedScript);
         });
 
     })


### PR DESCRIPTION
- Corrijo ID de la serie que se le está pasando a los componentes de la `Card`, para que siempre tome el ID completo (con modificador incluido).
- Corrijo valores de parámetros `hasFrame` y `hasColorBar` que se estaban copiando en el código web, ya que son booleanos y se estaban copiando como cadenas.
- Extraigo función generadora de código web para la `Card` a un archivo aparte
- Agrego casos de prueba para generación de código web para la `Card`, así como para las funciones que generan sus enlaces (el _Enlace Web_ y los _Enlace CSV_ y _Enlace JSON_).

Closes #469 