### PR TITLE
466 - Agregar formas alternativas de especificar el color, además de pasar el hexadecimal 

### DIFF
--- a/src/components/style/Colors/Color.ts
+++ b/src/components/style/Colors/Color.ts
@@ -18,6 +18,8 @@ const Colors = {
     a9Green2: new Color("green2", "#6EA100"),
 };
 
+const hexaColorRegex = /^#[0-9a-f]{6}$/i
+
 export default Colors;
 
 export function getColorBySerieId(series: ISerie[], serieId: string): string {
@@ -32,8 +34,20 @@ export function colorFor(series: ISerie[], fullSerieId: string, colors?: Color[]
 }
 
 export function getColorArray(colors?: string[]): Color[] {
+    const defaultColors = (Object as any).values(Colors)
     if (colors === undefined) {
-        return (Object as any).values(Colors)
+        return defaultColors
     }
-    return colors.map(colorString => new Color(colorString, colorString))
+    return colors.map((color): Color => {
+        if (isHexaColor(color)) {
+            return new Color(color, color)
+        } else {
+            const index = +color % defaultColors.length
+            return defaultColors[index]
+        }
+    });
+}
+
+export function isHexaColor(color: string): boolean {
+    return hexaColorRegex.test(color)
 }

--- a/src/tests/components/style/Color.test.ts
+++ b/src/tests/components/style/Color.test.ts
@@ -75,30 +75,42 @@ describe("Colors", () => {
     });
 
     it("Create array of colors from index array", () => {
-        const colorsString = ["3", "4", "9", "11"]
+        const colorsString = ["3", "4", "9"]
         const colors = getColorArray(colorsString)
         expect(colors).toBeDefined()
         if (colors !== undefined) {
             const expectedColors = [
                 new Color("orange", "#F9A822"), 
                 new Color("violet", "#6A1B99"),
-                new Color("blue1", "#0072BB"), 
-                new Color("red", "#C62828")
+                new Color("blue1", "#0072BB")
             ]
             expect(colors).toEqual(expectedColors)
         }
     });
 
     it("Create array of colors from an array of hexas and indexes", () => {
-        const colorsString = ["3", "#f2fe05", "9", "11"]
+        const colorsString = ["3", "#f2fe05", "9"]
         const colors = getColorArray(colorsString)
         expect(colors).toBeDefined()
         if (colors !== undefined) {
             const expectedColors = [
                 new Color("orange", "#F9A822"), 
                 new Color("#f2fe05", "#f2fe05"), 
-                new Color("blue1", "#0072BB"), 
-                new Color("red", "#C62828")
+                new Color("blue1", "#0072BB")
+            ]
+            expect(colors).toEqual(expectedColors)
+        }
+    });
+
+    it("Create array of colors from an array of indexes out of range", () => {
+        const colorsString = ["1015", "11", "42"]
+        const colors = getColorArray(colorsString)
+        expect(colors).toBeDefined()
+        if (colors !== undefined) {
+            const expectedColors = [
+                new Color("blue2", "#039BE5"), 
+                new Color("red", "#C62828"),
+                new Color("purple", "#C2185B")
             ]
             expect(colors).toEqual(expectedColors)
         }

--- a/src/tests/components/style/Color.test.ts
+++ b/src/tests/components/style/Color.test.ts
@@ -1,6 +1,6 @@
 import { ISerie } from "../../../api/Serie";
 import { generateCommonMockSerieEMAE, generateCommonMockSerieMotos, generatePercentageMockSerie } from "../../support/mockers/seriesMockers";
-import Colors, { colorFor, Color, getColorArray } from "../../../components/style/Colors/Color";
+import Colors, { colorFor, Color, getColorArray, isHexaColor } from "../../../components/style/Colors/Color";
 import { getFullSerieId } from "../../../components/viewpage/graphic/Graphic";
 
 describe("Colors", () => {
@@ -59,7 +59,7 @@ describe("Colors", () => {
     });
 
     it("Create array of colors from string array", () => {
-        const colorsString = ["#aaeeff", "#f2fe05f", "#06f140"]
+        const colorsString = ["#aaeeff", "#f2fe05", "#06f140"]
         const colors = getColorArray(colorsString)
         expect(colors).toBeDefined()
         if (colors !== undefined) {            
@@ -72,5 +72,46 @@ describe("Colors", () => {
         const colorsString = undefined
         const colors = getColorArray(colorsString)
         expect(colors).toEqual((Object as any).values(Colors))
+    });
+
+    it("Create array of colors from index array", () => {
+        const colorsString = ["3", "4", "9", "11"]
+        const colors = getColorArray(colorsString)
+        expect(colors).toBeDefined()
+        if (colors !== undefined) {
+            const expectedColors = [
+                new Color("orange", "#F9A822"), 
+                new Color("violet", "#6A1B99"),
+                new Color("blue1", "#0072BB"), 
+                new Color("red", "#C62828")
+            ]
+            expect(colors).toEqual(expectedColors)
+        }
+    });
+
+    it("Create array of colors from an array of hexas and indexes", () => {
+        const colorsString = ["3", "#f2fe05", "9", "11"]
+        const colors = getColorArray(colorsString)
+        expect(colors).toBeDefined()
+        if (colors !== undefined) {
+            const expectedColors = [
+                new Color("orange", "#F9A822"), 
+                new Color("#f2fe05", "#f2fe05"), 
+                new Color("blue1", "#0072BB"), 
+                new Color("red", "#C62828")
+            ]
+            expect(colors).toEqual(expectedColors)
+        }
+    });
+
+    it("isHexaColor works", () => {
+        const validHexaColors = ["#ffaaee", Colors.a4Orange.code, "#123456"]
+        const invalidHexaColors = ["#ffaee", "#1y34aj", "#ffaeeae", "#f", "asd", "123456", ".", "#"]
+        for (const validColor of validHexaColors) {
+            expect(isHexaColor(validColor)).toEqual(true)
+        }
+        for (const invalidColor of invalidHexaColors) {
+            expect(isHexaColor(invalidColor)).toEqual(false)
+        }
     });
 });


### PR DESCRIPTION
closes #466 

Se agrega la funcionalidad de que al pasar la lista de colores al Graph, también se pueda enviar numeros (ej: "1", "42", etc) y el algoritmo te busca ese color por indice en la tabla de colores por defecto. Se decidio que se puede hacer una mezcla de colores hexadecimales y colores por indice para hacer el sistema mas robusto.