### PR TITLE
468 - Agrego parametro collapse y sus casos de prueba

### DIFF
--- a/src/components/common/linkBuilders.ts
+++ b/src/components/common/linkBuilders.ts
@@ -2,6 +2,13 @@ export function formatUrl(url: string, format: string): string {
     return `${url}&format=${format}`
 }
 
-export function viewDatosGobAr(serieId: string): string {
-    return `https://datos.gob.ar/series/api/series/?ids=${serieId}`
+export function viewDatosGobAr(serieId: string, collapse?: string): string {
+
+    const viewURL = `https://datos.gob.ar/series/api/series/?ids=${serieId}`
+    if (collapse === undefined) {
+        return viewURL;
+    }
+    const finalURL = `${viewURL}&collapse=${collapse}`;
+    return finalURL;
+
 }

--- a/src/components/common/webCodeBuilders.ts
+++ b/src/components/common/webCodeBuilders.ts
@@ -44,6 +44,11 @@ export function cardWebCode(options: IWebSnippetOptions): string {
         htmlScript += `,
             hasColorBar: ${options.hasColorBar}`;
     }
+    if(options.collapse !== undefined)
+    {
+        htmlScript += `,
+            collapse: '${options.collapse}'`;
+    }
 
     htmlScript += `
         })

--- a/src/components/exportable/CardExportable.tsx
+++ b/src/components/exportable/CardExportable.tsx
@@ -37,6 +37,9 @@ export default class CardExportable extends React.Component<ICardExportableProps
 
     public componentDidMount() {
         const params = new QueryParams([this.props.serieId]);
+        if(this.props.collapse !== undefined) {
+            params.setCollapse(this.props.collapse);
+        }
         params.setLast(higherLaps());
         this.fetchSeries(params);
     }
@@ -51,6 +54,7 @@ export default class CardExportable extends React.Component<ICardExportableProps
         return {
             cardOptions: {
                 chartType: this.props.chartType,
+                collapse: this.props.collapse,
                 color: this.props.color,
                 explicitSign: this.props.explicitSign,
                 hasChart: this.props.hasChart,
@@ -81,8 +85,12 @@ export default class CardExportable extends React.Component<ICardExportableProps
     private getDownloadUrl(): string {
         const params = new QueryParams([this.props.serieId]);
         params.setLast(5000);
+        if(this.props.collapse !== undefined) {
+            params.setCollapse(this.props.collapse);
+        }
         return this.props.seriesApi.downloadDataURL(params)
     }
+
 }
 
 

--- a/src/components/exportable_card/FullCardDropdown.tsx
+++ b/src/components/exportable_card/FullCardDropdown.tsx
@@ -7,7 +7,7 @@ import { cardWebCode } from '../common/webCodeBuilders';
 
 export default (props: {options: ICardLinksOptions}) =>
     <FullCardDropdownContainer text="Enlaces">
-        <LinkShareItem url={viewDatosGobAr(props.options.serieId)} text="Enlace web" />
+        <LinkShareItem url={viewDatosGobAr(props.options.serieId, props.options.collapse)} text="Enlace web" />
         <LinkShareItem url={formatUrl(props.options.downloadUrl, "csv")} text="Enlace CSV" />
         <LinkShareItem url={formatUrl(props.options.downloadUrl, "json")} text="Enlace JSON" />
         <LinkShareItem url={cardWebCode(props.options)} text="Código web" />
@@ -24,4 +24,5 @@ export interface IWebSnippetOptions {
     units?: string;
     hasFrame?: boolean;
     hasColorBar?: boolean;
+    collapse?: string;
 }

--- a/src/components/exportable_card/FullCardViewMore.tsx
+++ b/src/components/exportable_card/FullCardViewMore.tsx
@@ -2,5 +2,5 @@ import * as React from 'react';
 import { viewDatosGobAr } from '../common/linkBuilders';
 
 
-export default (props: {serieId: string}) =>
-    <a href={viewDatosGobAr(props.serieId)} target="_blank">Ver más</a>
+export default (props: {serieId: string, collapse?: string}) =>
+    <a href={viewDatosGobAr(props.serieId, props.collapse)} target="_blank">Ver más</a>

--- a/src/components/exportable_card/links/FullLinks.tsx
+++ b/src/components/exportable_card/links/FullLinks.tsx
@@ -8,6 +8,6 @@ import FullCardViewMore from '../FullCardViewMore';
 export default (props: {options: ICardLinksOptions}) =>
     <div className="c-foot">
         <div className="c-download"><FullCardDownload downloadUrl={props.options.downloadUrl} /></div>
-        <div className="c-viewmore"><FullCardViewMore serieId={props.options.serieId} /></div>
+        <div className="c-viewmore"><FullCardViewMore serieId={props.options.serieId} collapse={props.options.collapse}/></div>
         <div className="enlaces"><FullCardDropdown options={props.options} /></div>
     </div>

--- a/src/indexCard.tsx
+++ b/src/indexCard.tsx
@@ -16,6 +16,7 @@ export interface ICardBaseConfig {
     units: string;
     hasFrame?: boolean;
     hasColorBar?: boolean;
+    collapse?: string;
 }
 
 export interface ICardExportableConfig extends ICardBaseConfig {
@@ -38,6 +39,7 @@ export function render(selector: string, config: ICardExportableConfig) {
                         units={config.units}
                         hasFrame={config.hasFrame}
                         hasColorBar={config.hasColorBar}
+                        collapse={config.collapse}
                         seriesApi={seriesApi} />,
         document.getElementById(selector) as HTMLElement
     )

--- a/src/tests/components/common/LinkBuilders.test.ts
+++ b/src/tests/components/common/LinkBuilders.test.ts
@@ -24,10 +24,24 @@ describe('Link building functions for Dropdown components', () => {
 
     })
 
-    it('Obtainment of URL to view the serie at datos.gob.ar', () => {
-        const serieID: string = '148.3_INIVELNAL_DICI_M_26:percent_change';
-        const viewURL = viewDatosGobAr(serieID);
-        expect(viewURL).toEqual('https://datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change');
+    describe('Obtainment of URL to view the serie at datos.gob.ar', () => {
+
+        let serieID: string;
+
+        beforeAll(() => {
+            serieID = '148.3_INIVELNAL_DICI_M_26:percent_change';
+        })
+
+        it('Basic serie, without collapse query param', () => {
+            const viewURL = viewDatosGobAr(serieID);
+            expect(viewURL).toEqual('https://datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change');
+        });
+        it('Serie without collapse parameter', () => {
+            const collapse = 'year';
+            const viewURL = viewDatosGobAr(serieID, collapse);
+            expect(viewURL).toEqual('https://datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change&collapse=year');
+        });
+
     })
 
 })

--- a/src/tests/components/common/WebCodeBuilders.test.ts
+++ b/src/tests/components/common/WebCodeBuilders.test.ts
@@ -135,6 +135,23 @@ describe('Generation of copyable web code for components', () => {
             generatedCode = cardWebCode(options);
             expect(generatedCode).toContain(expectedScript);
         });
+        it('Collapse specified as well', () => {
+            options.collapse = 'month';
+            expectedScript = `<script>
+    window.onload = function() {
+        TSComponents.Card.render('root', {
+            serieId: "42.3_EPH_PUNTUATAL_0_M_30",
+            color: "F9A822",
+            links: "small",
+            hasChart: "small",
+            collapse: 'month'
+        })
+    }
+</script>
+`;
+            generatedCode = cardWebCode(options);
+            expect(generatedCode).toContain(expectedScript);
+        });
 
     })
 


### PR DESCRIPTION
Agrego parámetro opcional `collapse` a la Card, para que le pegue a la API con la serie indicada y ese agregado como query param. A su vez, agrego el copiado del mismo a los códigos Web y enlaces del desplegable 

Closes #468 