### PR TITLE
482 (R) - Restauro propiedad serieId para arreglar el tooltip 

### DIFF
--- a/src/components/viewpage/graphic/highcharts.ts
+++ b/src/components/viewpage/graphic/highcharts.ts
@@ -26,6 +26,7 @@ export interface IHCSerie {
     yAxis: number;
     showInNavigator: boolean;
     navigatorOptions: { type: string };
+    serieId: string;
 }
 
 export interface IHConfig {

--- a/src/helpers/graphic/hcSerieFromISerie.ts
+++ b/src/helpers/graphic/hcSerieFromISerie.ts
@@ -50,6 +50,7 @@ export class HighchartsSerieBuilder {
             data,
             name: this.getLegendLabel(serie, legendProps),
             navigatorOptions: { type: chartType },
+            serieId: getFullSerieId(serie),
             type: chartType,
             yAxis: this.yAxisIndex(this.options.yAxisArray, getFullSerieId(serie))
         }


### PR DESCRIPTION
Restauro la propiedad `serieId` de la interfaz `IHCSerie`, para que pueda corregirse el tooltip (actualmente no muestra nombres de series ni valores de puntos).

Closes #482 