### PR TITLE
461 - Flexibilizo la regex de URL de Graphic

### DIFF
--- a/src/helpers/graphic/URLValidation.ts
+++ b/src/helpers/graphic/URLValidation.ts
@@ -1,6 +1,6 @@
 export class GraphicURLValidator {
 
-    private urlRegex: RegExp = /https:\/\/apis\.datos\.gob\.ar\/series\/api\/series(\/?)\?(\w+=\w+&)*ids=([^&=]+)(&\w+=\w+)*$/i;
+    private urlRegex: RegExp = /.*\/api\/series(\/?)\?(\w+=\w+&)*ids=([^&=]+)(&\w+=\w+)*$/i;
 
     public isValidURL(url: string): boolean {
         return this.urlRegex.test(url);

--- a/src/tests/components/helpers/URLValidation.test.ts
+++ b/src/tests/components/helpers/URLValidation.test.ts
@@ -9,8 +9,25 @@ describe("URL Validation for the Graphic exportable component", () => {
         validator = new GraphicURLValidator();
     })
 
-    it("Having the wrong URI root makes it an invalid URL", () => {
-        url = "https://apis.mydata.com/api?ids=116.4_TCRZE_2015_D_34";
+    describe("URLs with wrong endpoints", () => {
+
+        it("Missing the /api endpoint substring makes it an invalid URL", () => {
+            url = "https://apis.datos.gob.ar/series?ids=116.4_TCRZE_2015_D_34";
+            expect(validator.isValidURL(url)).toBe(false);
+        });
+        it("Missing the /series endpoint substring makes it an invalid URL", () => {
+            url = "https://apis.datos.gob.ar/api?ids=116.4_TCRZE_2015_D_34";
+            expect(validator.isValidURL(url)).toBe(false);
+        });
+        it("Having the /api endpoint after the /series one makes it an invalid URL", () => {
+            url = "https://apis.datos.gob.ar/series/api?ids=116.4_TCRZE_2015_D_34";
+            expect(validator.isValidURL(url)).toBe(false);
+        });
+
+    })
+
+    it("The URI root does not matter, as long as it has both endpoints in order", () => {
+        url = "https://apis.mydata.com/series/api?ids=116.4_TCRZE_2015_D_34";
         expect(validator.isValidURL(url)).toBe(false);
     });
     it("Missing the param starter question mark makes it an invalid URL", () => {


### PR DESCRIPTION
Modifico la regex de validación del parámetro `graphicUrl` del componente `Graphic`, para que no valide la URI raíz sino los endpoints, es decir, que tome como válida cualquier URL siempre y cuando esta contenga una substring de `/api/series` como endpoint, y luego los query params que ya se validaban (mínimamente, un `ids` y cualquier otro param, siempre y cuando tenga un valor definido).
Agrego casos de prueba para testear las nuevas validaciones.

Closes #461 