### PR TITLE
506 - Metadato enriquecido valor card

### DIFF
--- a/src/api/Serie.ts
+++ b/src/api/Serie.ts
@@ -33,7 +33,8 @@ export interface ISerie {
 }
 
 export const DEFAULT_SIGNIFICANT_FIGURES = 2;
-export const MAX_SIGNIFICANT_FIGURES = 4;
+export const GRAPHIC_MAX_SIGNIFICANT_FIGURES = 4;
+export const CARD_MAX_SIGNIFICANT_FIGURES = 2;
 
 export default class Serie implements ISerie {
 

--- a/src/api/Serie.ts
+++ b/src/api/Serie.ts
@@ -33,6 +33,7 @@ export interface ISerie {
 }
 
 export const DEFAULT_SIGNIFICANT_FIGURES = 2;
+export const MAX_SIGNIFICANT_FIGURES = 4;
 
 export default class Serie implements ISerie {
 

--- a/src/components/exportable/CardExportable.tsx
+++ b/src/components/exportable/CardExportable.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { ApiClient } from '../../api/ApiClient';
 import QueryParams from '../../api/QueryParams';
-import { ISerie, MAX_SIGNIFICANT_FIGURES } from '../../api/Serie';
-import SerieApi from '../../api/SerieApi';
+import { CARD_MAX_SIGNIFICANT_FIGURES, ISerie } from '../../api/Serie';
+import SerieApi, { METADATA } from '../../api/SerieApi';
 import { valuesFromObject } from '../../helpers/common/commonFunctions';
 import { ICardExportableConfig } from '../../indexCard';
 import FullCard from '../exportable_card/FullCard';
@@ -43,6 +43,7 @@ export default class CardExportable extends React.Component<ICardExportableProps
             params.setCollapse(this.props.collapse);
         }
         params.setLast(higherLaps());
+        params.setMetadata(METADATA.FULL);
         this.fetchSeries(params);
     }
 
@@ -65,7 +66,7 @@ export default class CardExportable extends React.Component<ICardExportableProps
 
         let decimals = this.props.decimals;
         if(decimals === undefined && this.state.serie) {
-            decimals = Math.min(this.state.serie.significantFigures, MAX_SIGNIFICANT_FIGURES);
+            decimals = Math.min(this.state.serie.significantFigures, CARD_MAX_SIGNIFICANT_FIGURES);
         }
 
         return {

--- a/src/components/exportable/CardExportable.tsx
+++ b/src/components/exportable/CardExportable.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ApiClient } from '../../api/ApiClient';
 import QueryParams from '../../api/QueryParams';
-import { ISerie } from '../../api/Serie';
+import { ISerie, MAX_SIGNIFICANT_FIGURES } from '../../api/Serie';
 import SerieApi from '../../api/SerieApi';
 import { valuesFromObject } from '../../helpers/common/commonFunctions';
 import { ICardExportableConfig } from '../../indexCard';
@@ -62,12 +62,18 @@ export default class CardExportable extends React.Component<ICardExportableProps
     }
 
     private cardOptions() {
+
+        let decimals = this.props.decimals;
+        if(decimals === undefined && this.state.serie) {
+            decimals = Math.min(this.state.serie.significantFigures, MAX_SIGNIFICANT_FIGURES);
+        }
+
         return {
             cardOptions: {
                 chartType: this.props.chartType,
                 collapse: this.props.collapse,
                 color: this.props.color,
-                decimals: this.props.decimals,
+                decimals,
                 explicitSign: this.props.explicitSign,
                 hasChart: this.props.hasChart,
                 hasColorBar: this.props.hasColorBar,

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -30,7 +30,7 @@ export default (props: IFullCardProps) => {
     }
     const value = props.serie.data[props.serie.data.length-1].value
     const formatterProps: ICardValueFormatterConf = {
-        decimals: options.decimals || DEFAULT_SIGNIFICANT_FIGURES,
+        decimals: options.decimals !== undefined && options.decimals >= 0 ? options.decimals : DEFAULT_SIGNIFICANT_FIGURES,
         explicitSign: options.explicitSign,
         isPercentage: props.serie.isPercentage,
         locale: options.locale

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IDataPoint } from '../../api/DataPoint';
-import { ISerie } from '../../api/Serie';
+import { ISerie, DEFAULT_SIGNIFICANT_FIGURES } from '../../api/Serie';
 import { CardValueFormatter, ICardValueFormatterConf } from '../../helpers/card/cardValueFormatter';
 import { fullLocaleDate } from '../../helpers/common/dateFunctions';
 import { ICardBaseConfig } from '../../indexCard';
@@ -30,7 +30,7 @@ export default (props: IFullCardProps) => {
     }
     const value = props.serie.data[props.serie.data.length-1].value
     const formatterProps: ICardValueFormatterConf = {
-        decimals: options.decimals,
+        decimals: options.decimals || DEFAULT_SIGNIFICANT_FIGURES,
         explicitSign: options.explicitSign,
         isPercentage: props.serie.isPercentage,
         locale: options.locale

--- a/src/helpers/common/fullSerieID.ts
+++ b/src/helpers/common/fullSerieID.ts
@@ -1,4 +1,4 @@
-import { ISerie, DEFAULT_SIGNIFICANT_FIGURES, MAX_SIGNIFICANT_FIGURES } from "../../api/Serie";
+import { ISerie, DEFAULT_SIGNIFICANT_FIGURES, GRAPHIC_MAX_SIGNIFICANT_FIGURES } from "../../api/Serie";
 import SerieConfig from "../../api/SerieConfig";
 import { IChartTypeProps, INumberPropsPerId } from "../../components/viewpage/graphic/Graphic";
 
@@ -40,9 +40,7 @@ export function getTooltipDecimals(serieID: string, significantFigures?: number,
     if(significantFigures === undefined) {
         return DEFAULT_SIGNIFICANT_FIGURES;
     }
+
+    return Math.min(significantFigures, GRAPHIC_MAX_SIGNIFICANT_FIGURES);
     
-    if (significantFigures > MAX_SIGNIFICANT_FIGURES) {
-        return MAX_SIGNIFICANT_FIGURES;
-    }
-    return significantFigures;
 }

--- a/src/helpers/common/fullSerieID.ts
+++ b/src/helpers/common/fullSerieID.ts
@@ -1,4 +1,4 @@
-import { ISerie, DEFAULT_SIGNIFICANT_FIGURES } from "../../api/Serie";
+import { ISerie, DEFAULT_SIGNIFICANT_FIGURES, MAX_SIGNIFICANT_FIGURES } from "../../api/Serie";
 import SerieConfig from "../../api/SerieConfig";
 import { IChartTypeProps, INumberPropsPerId } from "../../components/viewpage/graphic/Graphic";
 
@@ -41,8 +41,8 @@ export function getTooltipDecimals(serieID: string, significantFigures?: number,
         return DEFAULT_SIGNIFICANT_FIGURES;
     }
     
-    if (significantFigures > 4) {
-        return 4;
+    if (significantFigures > MAX_SIGNIFICANT_FIGURES) {
+        return MAX_SIGNIFICANT_FIGURES;
     }
     return significantFigures;
 }

--- a/src/indexCard.tsx
+++ b/src/indexCard.tsx
@@ -16,7 +16,7 @@ export interface ICardBaseConfig {
     hasColorBar?: boolean;
     collapse?: string;
     apiBaseUrl?: string;
-    decimals: number;
+    decimals?: number;
 }
 
 export interface ICardExportableConfig extends ICardBaseConfig {
@@ -39,7 +39,7 @@ export function render(selector: string, config: ICardExportableConfig) {
                         hasColorBar={config.hasColorBar}
                         collapse={config.collapse}
                         apiBaseUrl={config.apiBaseUrl}
-                        decimals={config.decimals >= 0 ? config.decimals : 2} />,
+                        decimals={config.decimals} />,
         document.getElementById(selector) as HTMLElement
     )
 }

--- a/src/tests/components/exportable/FullCard.test.tsx
+++ b/src/tests/components/exportable/FullCard.test.tsx
@@ -36,28 +36,28 @@ describe('FullCard', () => {
             mountFullCard();
         })
 
-        it('renders without crashing', () => {
+        it('Renders without crashing', () => {
             expect(wrapper.find(FullCard).exists()).toBe(true);
         });
-        it('renders the border', () => {
+        it('Renders the border', () => {
             expect(wrapper.find('.card .full').exists()).toBe(true);
         });
-        it('renders a full chart', () => {
+        it('Renders a full chart', () => {
             expect(wrapper.find('.card .wide').exists()).toBe(true);
         });
-        it('renders the links footer', () => {
+        it('Renders the links footer', () => {
             expect(wrapper.find('div .c-links').exists()).toBe(true);
         });
-        it('renders the tooltips', () => {
+        it('Renders the tooltips', () => {
             expect(wrapper.find(ReactTooltip).exists()).toBe(true);
         });
-        it('renders the default title header', () => {
+        it('Renders the default title header', () => {
             expect(wrapper.find('p .c-title').text()).toContain("EMAE. Base 2004")
         });
-        it('renders the default source', () => {
+        it('Renders the default source', () => {
             expect(wrapper.find('p .c-source').text()).toContain("Fuente: Instituto Nacional de Estadística y Censos (INDEC)");
         });
-        it('renders the default units', () => {
+        it('Renders the default units', () => {
             expect(wrapper.find('p .c-units').text()).toContain("Índice 2004=100");
         });
 
@@ -65,12 +65,12 @@ describe('FullCard', () => {
 
     describe('Graphic rendering', () => {
         
-        it('renders a small graphic chart', () => {
+        it('Renders a small graphic chart', () => {
             mockCardOptions.hasChart = "small";
             mountFullCard();
             expect(wrapper.find('.card .normal').exists()).toBe(true);
         });
-        it('does not render any chart', () => {
+        it('Does not render any chart', () => {
             mockCardOptions.hasChart = "none";
             mountFullCard();
             expect(wrapper.find('.card .no-graph').exists()).toBe(true);
@@ -80,27 +80,27 @@ describe('FullCard', () => {
 
     describe('Shown overriden attributes', () => {
 
-        it('does not render the links footer', () => {
+        it('Does not render the links footer', () => {
             mockCardOptions.links = "none";
             mountFullCard();
             expect(wrapper.find('div .c-links').exists()).toBe(false);
         });
-        it('does not render the tooltips', () => {
+        it('Does not render the tooltips', () => {
             mockCardOptions.links = "none";
             mountFullCard();
             expect(wrapper.find(ReactTooltip).exists()).toBe(false);
         });
-        it('renders the overriden title header', () => {
+        it('Renders the overriden title header', () => {
             mockCardOptions.title = "Lorem ipsum dolor sit amet";
             mountFullCard();
             expect(wrapper.find('p .c-title').text()).toContain("Lorem ipsum dolor sit amet")
         });
-        it('renders the overriden source', () => {
+        it('Renders the overriden source', () => {
             mockCardOptions.source = "Lorem ipsum dolor sit amet";
             mountFullCard();
             expect(wrapper.find('p .c-source').text()).toContain("Lorem ipsum dolor sit amet");
         });
-        it('renders the overriden units', () => {
+        it('Renders the overriden units', () => {
             mockCardOptions.units = "Lorem ipsum dolor sit amet";
             mountFullCard();
             expect(wrapper.find('p .c-units').text()).toContain("Lorem ipsum dolor sit amet");
@@ -110,21 +110,40 @@ describe('FullCard', () => {
 
     describe('Hidden overrideable attributes', () => {
   
-        it('does not render the title header', () => {
+        it('Does not render the title header', () => {
             mockCardOptions.title = "";
             mountFullCard();
             expect(wrapper.find('div .c-head').exists()).toBe(false)
         });
-        it('does not render the source', () => {
+        it('Does not render the source', () => {
             mockCardOptions.source = "";
             mountFullCard();
             expect(wrapper.find('p .c-source').exists()).toBe(false);
         });
-        it('does not render the units', () => {
+        it('Does not render the units', () => {
             mockCardOptions.units = "";
             mountFullCard();
             expect(wrapper.find('p .c-units').exists()).toBe(false);
         });
+
+    })
+
+    describe('Decimal handling upon main value', () => {
+
+        it('If decimals are not specified, default amount is used', () => {
+            mountFullCard();
+            expect(wrapper.find('.c-data p.c-main').text()).toEqual("+151,04");
+        });
+        it('If decimals are not specified, default amount is used', () => {
+            mockCardOptions.decimals = 5;
+            mountFullCard();
+            expect(wrapper.find('.c-data p.c-main').text()).toEqual("+151,03562");
+        });
+        it('If specified decimals were negative, default amount is used instead', () => {
+            mockCardOptions.decimals = -1;
+            mountFullCard();
+            expect(wrapper.find('.c-data p.c-main').text()).toEqual("+151,04");
+        })
 
     })
 


### PR DESCRIPTION
Agrego la consideración del metadato enriquecido, provisto por la API, en el valor a mostrar del componente `Card`. El mismo será tenido en cuenta sólo si es provisto y si no se le setea ningún valor al parámetro opcional `decimals` del componente. Para ello:

- Modifico la llamada a la API para que traiga todos los metadatos (con el query param `metadata=full`).
- Atrapo su valor en `CardExportable`, que es quien hace la llamada a la API y recibe la response. En caso de ser mayor a un máximo de decimales establecido para la Card, lo piso con tal valor.
- Agrego casos de tests para el componente `FullCard`, que verifican si la cantidad de decimales está en las opciones de componente o si se debe usar el valor por default.

Closes #506 