### PR TITLE
501 - Fix de uso de chartType en URL del Explorer

### DIFF
--- a/src/api/ChartTypeSelector.ts
+++ b/src/api/ChartTypeSelector.ts
@@ -1,5 +1,6 @@
 import { IChartTypeProps } from "../components/viewpage/graphic/Graphic";
 import { ISerie } from "./Serie";
+import { getFullSerieId } from "../helpers/common/fullSerieID";
 
 
 const DEFAULT_TYPE = "line";
@@ -28,7 +29,8 @@ export default class ChartTypeSelector {
 
     public getChartTypesBySeries(): IChartTypeProps {
         return this.series.reduce((result: {}, serie: ISerie) => {
-            result[serie.id] = this.chartTypeTo(serie.id);
+            const fullId = getFullSerieId(serie);
+            result[fullId] = this.chartTypeTo(fullId);
             return result;
         }, {})
     }

--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -24,6 +24,7 @@ import GraphicAndShare from "./graphic/GraphicAndShare";
 import MetaData from './metadata/MetaData';
 import SeriesPicker from './seriespicker/SeriesPicker';
 import SeriesTags from './SeriesTags';
+import { getFullSerieId } from '../../helpers/common/fullSerieID';
 
 interface IViewPageProps extends RouterProps {
     seriesApi: ISerieApi;
@@ -252,8 +253,8 @@ export function seriesConfigByUrl(url: string): (series: ISerie[]) => SerieConfi
 
     return (series: ISerie[]) => series.map((serie: ISerie) => {
         const seriesConfig = new SerieConfig(serie);
-        seriesConfig.setPercentChange(search.some((value: string) => value.includes(serie.id) && value.includes('percent_change')));
-        seriesConfig.setPercentChangeAYearAgo(search.some((value: string) => value.includes(serie.id) && value.includes('percent_change_a_year_ago')));
+        seriesConfig.setPercentChange(search.some((value: string) => value.includes(getFullSerieId(serie)) && value.includes('percent_change')));
+        seriesConfig.setPercentChangeAYearAgo(search.some((value: string) => value.includes(getFullSerieId(serie)) && value.includes('percent_change_a_year_ago')));
         return seriesConfig;
     });
 }

--- a/src/tests/api/ChartTypeSelector.test.ts
+++ b/src/tests/api/ChartTypeSelector.test.ts
@@ -6,61 +6,64 @@ describe("ChartTypeSelector", () => {
     let chartTypeSelector: ChartTypeSelector;
 
     describe("chartTypeTo", () => {
-        it("returns 'line' as default chart type", () => {
+
+        it("Returns 'line' as default chart type", () => {
             chartTypeSelector = buildChartTypeSelector('?ids=serie01,serie02');
 
             expect(chartTypeSelector.chartTypeTo('serie01')).toEqual('line');
         });
-
-        it("returns 'line' as default chart type because invalid was specified", () => {
+        it("Returns 'line' as default chart type because invalid was specified", () => {
             chartTypeSelector = buildChartTypeSelector('?ids=serie01,serie02&chartType=asda');
 
             expect(chartTypeSelector.chartTypeTo('serie01')).toEqual('line');
         });
-
-        it("returns 'column' as valid chart type", () => {
+        it("Returns 'column' as valid chart type", () => {
             chartTypeSelector = buildChartTypeSelector('?ids=serie01,serie02&chartType=column');
 
             expect(chartTypeSelector.chartTypeTo('serie01')).toEqual('column');
         });
-
-        it("returns 'area' as valid chart type", () => {
+        it("Returns 'area' as valid chart type", () => {
             chartTypeSelector = buildChartTypeSelector('?ids=serie01,serie02&chartType=area');
 
             expect(chartTypeSelector.chartTypeTo('serie01')).toEqual('area');
         });
-
-        it("returns 'line' as default chart type", () => {
+        it("Returns 'line' as default chart type", () => {
             chartTypeSelector = buildChartTypeSelector('?ids=serie01,serie02&chartType=default');
 
             expect(chartTypeSelector.chartTypeTo('serie01')).toEqual('line');
         });
+
     });
 
     describe("getChartTypesBySeries", () => {
-        it("returns specified chart types by series and default to the other one", () => {
+
+        it("Returns specified chart types by series and default to the other one", () => {
             chartTypeSelector = buildChartTypeSelector('?ids=serie01,serie02&chartTypes=serie01:area,serie02:column');
 
             expect(chartTypeSelector.getChartTypesBySeries()).toEqual({'serie01': 'area', 'serie02': 'column'});
         });
-
-        it("returns default chartType to the invalid specified", () => {
+        it("Returns default chartType to the invalid specified", () => {
             chartTypeSelector = buildChartTypeSelector('?ids=serie01,serie02&chartTypes=serie01:area,serie02:asdasd');
 
             expect(chartTypeSelector.getChartTypesBySeries()).toEqual({'serie01': 'area', 'serie02': 'line'});
         });
-
-        it("returns 'column' as default", () => {
+        it("Returns 'column' as default", () => {
             chartTypeSelector = buildChartTypeSelector('?ids=serie01,serie02&chartType=column&chartTypes=serie01:area,serie02:asd');
 
             expect(chartTypeSelector.getChartTypesBySeries()).toEqual({'serie01': 'area', 'serie02': 'column'});
         });
+        it("Using the chartType general query param, it takes into account series with representationMode modifiers", () => {
+            chartTypeSelector = buildChartTypeSelector('?ids=serie01,serie01:change&chartType=area', ["serie01", "serie01:change"]);
+
+            expect(chartTypeSelector.getChartTypesBySeries()).toEqual({'serie01': 'area', 'serie01:change': 'area'});
+        });
+
     });
 
 });
 
 
-function buildChartTypeSelector(search: string): ChartTypeSelector {
+function buildChartTypeSelector(search: string, seriesIds = ["serie01", "serie02"]): ChartTypeSelector {
     const params = new URLSearchParams(search)
-    return new ChartTypeSelector(generateSeries(), params);
+    return new ChartTypeSelector(generateSeries(seriesIds), params);
 }


### PR DESCRIPTION
Arreglo el bug de que el Explorer ignoraba el query param `chartType` en su URL, rendereando las series siempre como `line`s. Esto ocurría sólo con aquellas series de ID _compuesta_, es decir, de la forma `idSerie:representationMode`, con lo cual implementé el uso de la funcion `getFullSerieID` (que tiene en cuenta también el `representationMode`) en los métodos del componente `ViewPage` que tomaban el tipo de gráfico a renderear por cada serie. 
A su vez, agrego un caso de test a la función `getChartTypesBySeries`, que prueba dicha funcionalidad; e implemento el uso de `getFullSerieID` también en el agregado de representationModes por query param.

Closes #501 