### PR TITLE
493 - Bugs de Graphic documentacion

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -54,6 +54,10 @@ div.highcharts-tooltip-box span table {
   white-space: normal;
 }
 
+.highcharts-tooltip-box:hover {
+  z-index: 1 !important;
+}
+
 div.highcharts-tooltip-box span br {
 	font-feature-settings: normal;
 	margin-top: 0 !important;

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -717,7 +717,7 @@ main a[href^="https://"][target^="_blank"]::after {
 
 /*---Docs---*/
 
-header .md-header {
+header.md-header {
   z-index: 100;
 }
 

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -40,16 +40,16 @@
 /* Tooltip styles for iframing or third-party pages */
 
 div.highcharts-tooltip-box span table {
-  border-radius: 0;
+  border-radius: 0 !important;
   border-collapse: collapse;
   background-color: rgba(0, 0, 0, 0);
-  box-shadow: none;
-  display: table;
+  box-shadow: none !important;
+  display: table !important;
   font-feature-settings: normal;
-  font-size: 13px;
+  font-size: 13px !important;
   line-height: 15px;
-  max-width: none;
-  overflow: visible;
+  max-width: none !important;
+  overflow: visible !important;
   text-align: start;
   white-space: normal;
 }
@@ -72,20 +72,20 @@ div.highcharts-tooltip-box span table tbody tr {
   font-size: 13px;
   line-height: 15px;
   text-align: start;
-  transition-duration: 0s;
-  transition-property: all;
+  transition-duration: 0s !important;
+  transition-property: all !important;
   white-space: normal;
 }
 
 div.highcharts-tooltip-box span table tbody tr td {
   border-collapse: collapse;
-  border-top-width: medium;
+  border-top-width: medium !important;
   font-feature-settings: normal;
   font-size: 13px;
-  font-weight: 400;
+  font-weight: 400 !important;
   line-height: 15px;
-  padding: 0;
-  text-align: start;
+  padding: 0 !important;
+  text-align: start !important;
   white-space: normal;
 }
 
@@ -97,7 +97,7 @@ div.highcharts-tooltip-box span table tbody tr td div.tooltip-content {
   max-height: 30px;
   line-height: 15px;
   text-align: start;
-  white-space: normal;
+  white-space: normal !important;
 }
 
 div.highcharts-tooltip-box span table tbody tr td div.tooltip-content span {

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -54,6 +54,11 @@ div.highcharts-tooltip-box span table {
   white-space: normal;
 }
 
+div.highcharts-tooltip-box span br {
+	font-feature-settings: normal;
+	margin-top: 0;
+}
+
 div.highcharts-tooltip-box span table tbody {
   border-collapse: collapse;
   display: table-row-group;

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -130,11 +130,6 @@ div.highcharts-tooltip-box span table tbody tr td span.tooltip-value {
   overflow: visible !important;
 }
 
-/* show tooltip over other elements. Without this, tooltip has full transparency */
-.highcharts-container:hover {
-  z-index: 99 !important;
-}
-
 .highcharts-subtitle {
   width: 70% !important;
   white-space: pre-wrap !important;

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -56,7 +56,7 @@ div.highcharts-tooltip-box span table {
 
 div.highcharts-tooltip-box span br {
 	font-feature-settings: normal;
-	margin-top: 0;
+	margin-top: 0 !important;
 }
 
 div.highcharts-tooltip-box span table tbody {

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -719,11 +719,3 @@ main a[href^="https://"][target^="_blank"]::after {
 }
 
 /*---Fin Iconos---*/
-
-/*---Docs---*/
-
-header.md-header {
-  z-index: 100;
-}
-
-/*---Fin Docs---*/

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -54,8 +54,8 @@ div.highcharts-tooltip-box span table {
   white-space: normal;
 }
 
-.highcharts-tooltip-box:hover {
-  z-index: 1 !important;
+div.highcharts-tooltip-box:hover {
+  z-index: 99 !important;
 }
 
 div.highcharts-tooltip-box span br {

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -37,6 +37,89 @@
   font-size: 13px;
 }
 
+/* Tooltip styles for iframing or third-party pages */
+
+div.highcharts-tooltip-box span table {
+  border-radius: 0;
+  border-collapse: collapse;
+  background-color: rgba(0, 0, 0, 0);
+  box-shadow: none;
+  display: table;
+  font-feature-settings: normal;
+  font-size: 13px;
+  line-height: 15px;
+  max-width: none;
+  overflow: visible;
+  text-align: start;
+  white-space: normal;
+}
+
+div.highcharts-tooltip-box span table tbody {
+  border-collapse: collapse;
+  display: table-row-group;
+  font-feature-settings: normal;
+  font-size: 13px;
+  line-height: 15px;
+  max-width: none;
+  text-align: start;
+  white-space: normal;
+}
+
+div.highcharts-tooltip-box span table tbody tr {
+  background-color: transparent;
+  border-collapse: collapse;
+  font-feature-settings: normal;
+  font-size: 13px;
+  line-height: 15px;
+  text-align: start;
+  transition-duration: 0s;
+  transition-property: all;
+  white-space: normal;
+}
+
+div.highcharts-tooltip-box span table tbody tr td {
+  border-collapse: collapse;
+  border-top-width: medium;
+  font-feature-settings: normal;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 15px;
+  padding: 0;
+  text-align: start;
+  white-space: normal;
+}
+
+div.highcharts-tooltip-box span table tbody tr td div.tooltip-content {
+  border-collapse: collapse;
+  font-feature-settings: normal;
+  font-size: 13px;
+  font-weight: 400;
+  max-height: 30px;
+  line-height: 15px;
+  text-align: start;
+  white-space: normal;
+}
+
+div.highcharts-tooltip-box span table tbody tr td div.tooltip-content span {
+  border-collapse: collapse;
+  font-feature-settings: normal;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 15px;
+  text-align: start;
+  white-space: normal;
+}
+
+div.highcharts-tooltip-box span table tbody tr td span.tooltip-value {
+  border-collapse: collapse;
+  font-feature-settings: normal;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 15px;
+  text-align: right;
+  white-space: normal;
+}
+
 /* tooltip overlaps other elements */
 .highcharts-container, svg:not(:root) {
   overflow: visible !important;
@@ -631,3 +714,11 @@ main a[href^="https://"][target^="_blank"]::after {
 }
 
 /*---Fin Iconos---*/
+
+/*---Docs---*/
+
+header .md-header {
+  z-index: 100;
+}
+
+/*---Fin Docs---*/


### PR DESCRIPTION
### Descripcion:
Corrijo los dos grandes bugs que presentaba el componente ´Graphic´ en las secciones de documentación en las que aparecía: 
- Se superponía al header de la página al scrollear y hacer foco sobre él.
- Rendereaba el tooltip de valores distinto a su forma original.
Para resolver estas cuestiones, cree varios selectores en el `components.css` que poseen mayor especificidad que los insertados por `mkdocs` (el paquete que se encarga de convertir los .md en HTMLs), haciendo uso de atributos `!important` sólo cuando sea imprescindible para prevalecerlos.

### Cómo testearlo:
1. En los archivos `examples.md` y `graphic.md` de `/docs/reference/ts-components/`, cambiar las versiones de los archivos `components.css` y `components.js` importadas por CDN por aquellas obtenidas del tag `test-prioridad-docs-9` (en lugar de `ts_components_2.6.3`).
2. Parado en el repo del proyecto, ejecutar `make servedocs` (para correr el watcher que compila los .md en HTMLs y poder verlo).
3. Desde el browser, ir a http://127.0.0.1:8000/reference/ts-components/examples/ o a http://127.0.0.1:8000/reference/ts-components/graphic/ para ver el HTML rendereado.
4. Si se quisiese ver la renderización productiva, incorrecta, visitar las secciones de https://datosgobar.github.io/series-tiempo-ar-explorer/reference/ts-components/graphic/ y https://datosgobar.github.io/series-tiempo-ar-explorer/reference/ts-components/examples/.

Closes #493 