### PR TITLE
528 - Estilo para que el Graphic siempre ocupe la totalidad de su div contenedor

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -3,6 +3,10 @@
 
 /*---Graphic---*/
 
+.exportable-graph {
+  width: 100%;
+}
+
 .exportable-graph div { /* Force highcharts to set the height from container */
   height: 100%;
 }


### PR DESCRIPTION
#### Contexto:
Agregué al componente `Graphic` el selector de estilo necesario para que siempre intente ocupar la totalidad del ancho del div que lo wrappea.

#### Cómo probarlo:
En el `components.html`, insertar `div`s que tengan distintos anchos y asignarles componentes `Graphic` para que se les rendericen, observando cómo el componente siempre respeta el ancho del `div` padre.

Closes #528 