### PR TITLE
531 - Fecha de Cards con collapse

### DIFF
--- a/src/api/utils/periodicityManager.ts
+++ b/src/api/utils/periodicityManager.ts
@@ -21,7 +21,7 @@ const PERIODICITY_DATE_FORMAT = {
     'R/P6M': 'YYYY-MM',
 };
 
-const PERIODICITY_LANG = {
+export const PERIODICITY_LANG = {
     'day': 'Diaria',
     'month': 'Mensual',
     'quarter': 'Trimestral',

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { IDataPoint } from '../../api/DataPoint';
-import { ISerie, DEFAULT_SIGNIFICANT_FIGURES } from '../../api/Serie';
+import { DEFAULT_SIGNIFICANT_FIGURES, ISerie } from '../../api/Serie';
 import { CardValueFormatter, ICardValueFormatterConf } from '../../helpers/card/cardValueFormatter';
-import { fullLocaleDate } from '../../helpers/common/dateFunctions';
+import { lastSerieDate } from '../../helpers/common/dateFunctions';
+import { getFullSerieId } from "../../helpers/common/fullSerieID";
 import { ICardBaseConfig } from '../../indexCard';
 import FullCardContainer from '../style/exportable_card/FullCardContainer';
 import FullCardHeader from '../style/exportable_card/FullCardHeader';
@@ -11,8 +12,6 @@ import FullCardUnits from '../style/exportable_card/FullCardUnits';
 import FullCardValue from '../style/exportable_card/FullCardValue';
 import FullCardChart from './FullCardChart';
 import FullCardLinks from './FullCardLinks';
-import { getFullSerieId } from "../../helpers/common/fullSerieID";
-import { PERIODICITY_LANG } from '../../api/utils/periodicityManager';
 
 
 interface IFullCardProps {
@@ -66,11 +65,4 @@ function shortDataList(data: IDataPoint[], laps: number): IDataPoint[] {
 
 function notNullData(data: IDataPoint[]): IDataPoint[] {
     return data.filter((d: IDataPoint) => d.value !== null);
-}
-
-function lastSerieDate(serie: ISerie): string {
-
-    const langFrequency = serie.frequency !== undefined ? PERIODICITY_LANG[serie.frequency] : serie.accrualPeriodicity;
-    return fullLocaleDate(langFrequency, serie.data[serie.data.length-1].date);
-
 }

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -12,6 +12,7 @@ import FullCardValue from '../style/exportable_card/FullCardValue';
 import FullCardChart from './FullCardChart';
 import FullCardLinks from './FullCardLinks';
 import { getFullSerieId } from "../../helpers/common/fullSerieID";
+import { PERIODICITY_LANG } from '../../api/utils/periodicityManager';
 
 
 interface IFullCardProps {
@@ -68,5 +69,8 @@ function notNullData(data: IDataPoint[]): IDataPoint[] {
 }
 
 function lastSerieDate(serie: ISerie): string {
-    return fullLocaleDate(serie.accrualPeriodicity, serie.data[serie.data.length-1].date);
+
+    const langFrequency = serie.frequency !== undefined ? PERIODICITY_LANG[serie.frequency] : serie.accrualPeriodicity;
+    return fullLocaleDate(langFrequency, serie.data[serie.data.length-1].date);
+
 }

--- a/src/helpers/common/dateFunctions.ts
+++ b/src/helpers/common/dateFunctions.ts
@@ -1,6 +1,8 @@
 import * as moment from "moment";
-import 'moment/locale/es'
-import {capitalize} from "./commonFunctions";
+import 'moment/locale/es';
+import { ISerie } from "../../api/Serie";
+import { PERIODICITY_LANG } from "../../api/utils/periodicityManager";
+import { capitalize } from "./commonFunctions";
 
 export function timestamp(date: string): number {
     return new Date(date).getTime()
@@ -11,8 +13,10 @@ export function timestamp(date: string): number {
 // '2010-03' or '2010/03' => '2010/03/01'
 // '2010-03-01' or '2010/03/01' => '2010/03/01'
 export function formattedDateString(date: string): string {
+
     const parsedDate  = date.replace(/([\/\-])/g, '-');
     return parsedDate.split('-').length === 1 ? `${parsedDate}-01` : parsedDate;
+    
 }
 
 export function formattedMoment(date: any): string {
@@ -24,6 +28,7 @@ export function localTimestamp(timestmp: number): number {
 }
 
 export function fullLocaleDate(frequency: string, datetime: string|number) {
+    
     moment.locale('es');
     const date = moment(datetime).utcOffset('+00:00');
     let result = 'Frecuencia no soportada';
@@ -36,14 +41,14 @@ export function fullLocaleDate(frequency: string, datetime: string|number) {
         const numberOfMonth = parseInt(date.format('M'), 10);
         const semester = Math.ceil(numberOfMonth / 6);
 
-        result = semester + '° semestre ' + date.format('YYYY');
+        result = `${semester}° semestre ${date.format('YYYY')}`;
     }
 
     if (frequency === 'Trimestral') {
         const numberOfMonth = parseInt(date.format('M'), 10);
         const trimester = Math.ceil(numberOfMonth / 3);
 
-        result = trimester + '° trimestre ' + date.format('YYYY');
+        result = `${trimester}° trimestre ${date.format('YYYY')}`;
     }
 
     if (frequency === 'Mensual') {
@@ -58,6 +63,7 @@ export function fullLocaleDate(frequency: string, datetime: string|number) {
 }
 
 export function shortLocaleDate(format: string, dateString: string) {
+
     const date = moment(dateString, 'YYYY-MM-DD').utcOffset('+00:00');
     let result = 'Frecuencia no soportada';
 
@@ -69,14 +75,14 @@ export function shortLocaleDate(format: string, dateString: string) {
         const numberOfMonth = parseInt(date.format('M'), 10);
         const semester = Math.ceil(numberOfMonth / 6);
 
-        result = semester + 'S ' + date.format('YY');
+        result = `${semester}S ${date.format('YY')}`;
     }
 
     if (format === 'Trimestral') {
         const numberOfMonth = parseInt(date.format('M'), 10);
         const trimester = Math.ceil(numberOfMonth / 3);
 
-        result = trimester + 'T ' + date.format('YY');
+        result = `${trimester}T ${date.format('YY')}`;
     }
 
     if (format === 'Mensual') {
@@ -88,4 +94,11 @@ export function shortLocaleDate(format: string, dateString: string) {
     }
 
     return result;
+}
+
+export function lastSerieDate(serie: ISerie): string {
+
+    const langFrequency = serie.frequency !== undefined ? PERIODICITY_LANG[serie.frequency] : serie.accrualPeriodicity;
+    return fullLocaleDate(langFrequency, serie.data[serie.data.length-1].date);
+
 }

--- a/src/tests/components/helpers/DateFunctions.test.ts
+++ b/src/tests/components/helpers/DateFunctions.test.ts
@@ -1,38 +1,138 @@
-import {formattedDateString, fullLocaleDate, shortLocaleDate} from "../../../helpers/common/dateFunctions";
+import { formattedDateString, fullLocaleDate, shortLocaleDate, lastSerieDate } from "../../../helpers/common/dateFunctions";
+import { ISerie } from "../../../api/Serie";
+import { generateCommonMockSerieEMAE } from "../../support/mockers/seriesMockers";
 
+describe("Tests for date handling functions", () => {
 
-describe("QueryParams", () => {
-    it("returns 2018-01", () => {
-        const date = '2018';
-        expect(formattedDateString(date)).toEqual('2018-01');
-    });
+    describe("Formatting of a date string", () => {
 
-    it("returns 2018-01", () => {
-        const date = '2018/01';
-        expect(formattedDateString(date)).toEqual('2018-01');
-    });
+        let dateString: string;
+        let formattedString: string;
 
-    it("returns 2018-03", () => {
-        const date = '2018/03';
-        expect(formattedDateString(date)).toEqual('2018-03');
-    });
+        it("Replaces slashes with dashes", () => {
+            dateString = "2017/04/12";
+            formattedString = formattedDateString(dateString);
+            expect(formattedString).toEqual("2017-04-12");
+        });
+        it("A string with no slashes is kept the same", () => {
+            dateString = "2005-03-09";
+            formattedString = formattedDateString(dateString);
+            expect(formattedString).toEqual(dateString);
+        });
+        it("If only one term is specified, a '-01' is appended", () => {
+            dateString = "1996";
+            formattedString = formattedDateString(dateString);
+            expect(formattedString).toEqual("1996-01");
+        });
 
-    it("tests fullLocaleDate", () => {
-        const date = new Date('2018/04/25').setHours(3);
-        expect(fullLocaleDate('Anual', date)).toEqual('2018');
-        expect(fullLocaleDate('Semestral', date)).toEqual('1° semestre 2018');
-        expect(fullLocaleDate('Trimestral', date)).toEqual('2° trimestre 2018');
-        expect(fullLocaleDate('Mensual', date)).toEqual('Abril 2018');
-        expect(fullLocaleDate('Diaria', date)).toEqual('25 Abril, 2018');
-    });
+    })
 
-    it("tests shortLocaleDate", () => {
-        const date = '2018/04/25';
-        expect(shortLocaleDate('Anual', date)).toEqual('2018');
-        expect(shortLocaleDate('Semestral', date)).toEqual('1S 18');
-        expect(shortLocaleDate('Trimestral', date)).toEqual('2T 18');
-        expect(shortLocaleDate('Mensual', date)).toEqual('abr. 18');
-        expect(shortLocaleDate('Diaria', date)).toEqual('25 abr. 18');
-    });
+    describe("Obtainment of a full Locale-wise date", () => {
 
-});
+        let datetime: string;
+        let frequency: string;
+        let fullDate: string;
+
+        beforeAll(() => {
+            datetime = "2016-07-26";
+        })
+
+        it("'Anual' frequency returns only the year", () => {
+            frequency = "Anual";
+            fullDate = fullLocaleDate(frequency, datetime);
+            expect(fullDate).toEqual("2016");
+        });
+        it("'Semestral' frequency returns both year and semester", () => {
+            frequency = "Semestral";
+            fullDate = fullLocaleDate(frequency, datetime);
+            expect(fullDate).toEqual("2° semestre 2016");
+        });
+        it("'Trimestral' frequency returns both year and quarter", () => {
+            frequency = "Trimestral";
+            fullDate = fullLocaleDate(frequency, datetime);
+            expect(fullDate).toEqual("3° trimestre 2016");
+        });
+        it("'Mensual' frequency returns both year and a verbose month", () => {
+            frequency = "Mensual";
+            fullDate = fullLocaleDate(frequency, datetime);
+            expect(fullDate).toEqual("Julio 2016");
+        });
+        it("'Diaria' frequency returns year, a verbose month and the day", () => {
+            frequency = "Diaria";
+            fullDate = fullLocaleDate(frequency, datetime);
+            expect(fullDate).toEqual("26 Julio, 2016");
+        });
+        it("Other frequencies are not supported, hence they return a failure message", () => {
+            frequency = "Bimestral";
+            fullDate = fullLocaleDate(frequency, datetime);
+            expect(fullDate).toEqual("Frecuencia no soportada");
+        });
+
+    })
+
+    describe("Obtainment of a shortened Locale-wise date", () => {
+
+        let datetime: string;
+        let frequency: string;
+        let shortDate: string;
+
+        beforeAll(() => {
+            datetime = "2018-12-09";
+        })
+
+        it("'Anual' frequency returns only the year", () => {
+            frequency = "Anual";
+            shortDate = shortLocaleDate(frequency, datetime);
+            expect(shortDate).toEqual("2018");
+        });
+        it("'Semestral' frequency returns both year's last two numbers and semester number", () => {
+            frequency = "Semestral";
+            shortDate = shortLocaleDate(frequency, datetime);
+            expect(shortDate).toEqual("2S 18");
+        });
+        it("'Trimestral' frequency returns both year's last two numbers and quarter number", () => {
+            frequency = "Trimestral";
+            shortDate = shortLocaleDate(frequency, datetime);
+            expect(shortDate).toEqual("4T 18");
+        });
+        it("'Mensual' frequency returns both year's last two numbers and a shortened month", () => {
+            frequency = "Mensual";
+            shortDate = shortLocaleDate(frequency, datetime);
+            expect(shortDate).toEqual("dic. 18");
+        });
+        it("'Diaria' frequency returns year's last two numbers, a shortened month and the day", () => {
+            frequency = "Diaria";
+            shortDate = shortLocaleDate(frequency, datetime);
+            expect(shortDate).toEqual("9 dic. 18");
+        });
+        it("Other frequencies are not supported, hence they return a failure message", () => {
+            frequency = "Quincenal";
+            shortDate = shortLocaleDate(frequency, datetime);
+            expect(shortDate).toEqual("Frecuencia no soportada");
+        });
+
+    })
+
+    describe("Obtainment of the last date of a Serie, for a Card's header", () => {
+
+        let serie: ISerie;
+        let lastDate: string;
+
+        beforeAll(() => {
+            serie = generateCommonMockSerieEMAE();
+        })
+
+        it("If specified, the serie's frequency is used for formatting", () => {
+            lastDate = lastSerieDate(serie);
+            expect(lastDate).toEqual("Abril 2019");
+        });
+        it("If no frequency is specified, accrual periodicity is usde", () => {
+            serie.frequency = undefined;
+            serie.accrualPeriodicity = "Semestral"
+            lastDate = lastSerieDate(serie);
+            expect(lastDate).toEqual("1° semestre 2019");
+        });
+
+    })
+
+})

--- a/src/tests/support/mockers/seriesMockers.ts
+++ b/src/tests/support/mockers/seriesMockers.ts
@@ -1,7 +1,7 @@
 export function generateCommonMockSerieEMAE() {
 
     return {
-        accrualPeriodicity: "Mensual",
+        accrualPeriodicity: "R/P1M",
         collapseAggregation: "CollapseAgregation",
         data: [{ date: "2018-07-01", value: 145.30019275372558 },
         { date: "2018-08-01", value: 145.96423636915267 },
@@ -19,7 +19,7 @@ export function generateCommonMockSerieEMAE() {
         distributionTitle: "EMAE. Índice Base 2004.Valores mensuales.",
         downloadURL: "https://apis.datos.gob.ar/series/api/series?ids=143.3_NO_PR_2004_A_21&last=10&format=csv",
         endDate: "2018-07-01",
-        frequency: "Mensual",
+        frequency: "month",
         id: "EMAE2004",
         isPercentage: false,
         issued: "2017-09-28",
@@ -47,7 +47,7 @@ export function generateCommonMockSerieEMAE() {
 export function generateCommonMockSerieMotos() {
 
     return {
-        accrualPeriodicity: "Mensual",
+        accrualPeriodicity: "R/P1M",
         collapseAggregation: "CollapseAgregation",
         data: [{ date: "2018-09-01", value: 33896 },
         { date: "2018-10-01", value: 35567 },
@@ -65,7 +65,7 @@ export function generateCommonMockSerieMotos() {
         distributionTitle: "Motos: número de patentamientos por categoría de motocicleta (series)",
         downloadURL: "https://apis.datos.gob.ar/series/api/series/?ids=Motos_patentamiento_8myrF9&last=10&format=csv",
         endDate: "2018-09-01",
-        frequency: "Mensual",
+        frequency: "month",
         id: "Motos_patentamiento_8myrF9",
         isPercentage: false,
         issued: "2018-06-12",


### PR DESCRIPTION
#### Contexto
Corrijo la fecha mostrada en los headers de las `Card`s que tienen un valor para su argumento `collapse`, y que tenga en cuenta el período temporal del agregado (año, semestre, trimestre, mes o día) y no la frecuencia original de la serie. Para ello:
- Uso el parámetro `frequency` (propio por la API call) en lugar del `accrualPeriodicity` (siempre y cuando esté definido).
- Creo casos de prueba necesarios para esta función y las demás relacionadas a manejo de fechas. Las referidas a timestamps (ya existentes) no las probé ya que eran puro comportamiento de otras bibliotecas.
- Cambio la concatenación de strings por su interpolación en las funciones de manejo de fechas.
- Corrijo mocks de series que tenían valores inválidos de `accrualPeriodicity` y `frequency`.

#### Cómo probarlo
En el `components.html` de `public/`, agregarle el parámetro `collapse` a alguna `Card`, probando los distintos valores del mismo. Ejecutar `make components-watch` y verificar desde el browser que las fechas del header sean las correctas.

Closes #531 