### PR TITLE
532 - Flexibilizo RegEx para URLs, asi acepta query params con caracteres '-'

### DIFF
--- a/src/helpers/graphic/URLValidation.ts
+++ b/src/helpers/graphic/URLValidation.ts
@@ -1,6 +1,6 @@
 export class GraphicURLValidator {
 
-    private urlRegex: RegExp = /.*\/api\/series(\/?)\?(\w+=\w+&)*ids=([^&=]+)(&\w+=\w+)*$/i;
+    private urlRegex: RegExp = /.*\/api\/series(\/?)\?(\w+=\w+&)*ids=([^&=]+)(&(\w|-)+=(\w|-)+)*$/i;
 
     public isValidURL(url: string): boolean {
         return this.urlRegex.test(url);

--- a/src/tests/components/helpers/URLValidation.test.ts
+++ b/src/tests/components/helpers/URLValidation.test.ts
@@ -83,6 +83,10 @@ describe("URL Validation for the Graphic exportable component", () => {
             url = "https://apis.datos.gob.ar/series/api/series/?ids=143.3_NO_PR_2004_A_21&collapse=month&limit=1000";
             expect(validator.isValidURL(url)).toBe(true);
         });
+        it("Optional query params may have dashes at both their keys or values", () => {
+            url = "https://apis.datos.gob.ar/series/api/series/?collapse=month&collapse_aggregation=avg&ids=168.1_T_CAMBIOR_D_0_0_26&limit=5000&start_date=2017-02-01";
+            expect(validator.isValidURL(url)).toBe(true);
+        });
         it("Having the ids param not as first param still makes it a valid URL", () => {
             url = "https://apis.datos.gob.ar/series/api/series/?collapse=month&limit=1000&ids=116.4_TCRZE_2015_D_36_4";
             expect(validator.isValidURL(url)).toBe(true);


### PR DESCRIPTION
#### Contexto
Hago que la RegEx que valida el parámetro `graphicUrl` del componente `Graphic` sea un poco más flexible y permita poner query params con guiones medios (`-`) en su key o su value, y no sólo caracteres alfanuméricos y guiones bajos.

#### Cómo probarlo
Desde el `components.html` watcheable, probar renderizar `Graphic`s con URLs que contengan guiones medios; deberían verse sin problemas. Un query param con un caracter que no sea letra, número, `_` ni `-` debería lanzar un error por consola.

Closes #532 