### PR TITLE
533 - Selectores para layout de componentes

### DIFF
--- a/docs/reference/ts-components/examples.md
+++ b/docs/reference/ts-components/examples.md
@@ -22,7 +22,7 @@ Para conocer la forma de implementar correctamente cada componente, referirse a 
 
 
 ## Ejemplos Card:
-### Indicadores destacado (mínimo):
+### Indicadores destacados (mínimo):
 #### Ejemplo:
 <div class="container">
     <div class="row panels-row">
@@ -58,7 +58,7 @@ window.onload = function () {
 </script>
 ```
 
-### Indicadores destacado (con mini-gráfico):
+### Indicadores destacados (con mini-gráfico):
 #### Ejemplo:
 <div class="container">
     <div class="row panels-row">
@@ -91,7 +91,7 @@ window.onload = function () {
 </script>
 ```
 
-### Indicadores destacado (con tarjeta clickeable):
+### Indicadores destacados (con tarjeta clickeable):
 #### Ejemplo:
 <div class="container">
     <div class="row panels-row">
@@ -124,7 +124,7 @@ window.onload = function () {
 </script>
 ```
 
-### Indicadores destacado (con enlaces de descarga):
+### Indicadores destacados (con enlaces de descarga):
 #### Ejemplo:
 <div class="container">
     <div class="row panels-row">

--- a/docs/reference/ts-components/layout.md
+++ b/docs/reference/ts-components/layout.md
@@ -1,0 +1,162 @@
+<link type="text/css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css" media="all" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.6.7/dist/css/components.css" type="text/css">
+<script type='text/javascript' src='https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@ts_components_2.6.7/dist/js/components.js'></script>
+
+<style>
+.btn-primary {
+    color: #ffffff;
+    background-color: #0072bb;
+}
+</style>
+
+# Layout de componentes:
+
+La hoja de estilos `components.css` incluye también selectores de clases aplicables a elementos HTML, 
+inherentes al layout del dashboard o página donde se inserten los componentes.
+
+
+### Fila para componentes:
+Selector cuyos elementos internos serán equiespaciados y dispuestos horizontalmente.
+#### Ejemplo:
+<div class="ts-components-row">
+    <div id="card-en-row-1"></div>
+    <div id="card-en-row-2"></div>
+    <div id="card-en-row-3"></div>
+</div>
+
+
+#### Código:
+
+```html
+<div class="ts-components-row">
+    <div id="card-en-row-1"></div>
+    <div id="card-en-row-2"></div>
+    <div id="card-en-row-3"></div>
+</div>
+
+<script>
+window.onload = function () {
+
+        TSComponents.Card.render('card-en-row-1', {
+            serieId: '46.2_ECTSTG_0_T_40',
+            color: '#0072BB',
+            hasChart: 'none',
+            title: "Tasa Subocupación GBA",
+            links: "none",
+            hasFrame: true,
+            source: "Fuente: SSPM"
+        }) 
+        TSComponents.Card.render('card-en-row-2', {
+            serieId: '46.2_ECTSTSL_0_T_45',
+            color: '#6B8E23',
+            hasChart: 'none',
+            title: "Tasa Subocupación San Luis",
+            links: "none",
+            hasFrame: true,
+            source: "Fuente: SSPM"
+        })
+        TSComponents.Card.render('card-en-row-3', {
+            serieId: '46.2_ECTSTC_0_T_47',
+            color: '#FFA500',
+            hasChart: 'none',
+            title: "Tasa Subocupación Corrientes",
+            links: "none",
+            hasFrame: true,
+            source: "Fuente: SSPM"
+        })
+
+}
+</script>
+```
+
+### Contenedor de Card:
+Selector para `div` de una Card, con un pequeño margen abajo y óptimo para diversos viewports.
+#### Ejemplo:
+<div class="card-wrapper" id="card-superior"></div>
+<div class="card-wrapper" id="card-inferior"></div>
+
+
+#### Código:
+
+```html
+<div class="card-wrapper" id="card-superior"></div>
+<div class="card-wrapper" id="card-inferior"></div>
+
+<script>
+window.onload = function () {
+
+        TSComponents.Card.render('card-superior', {
+            serieId: '105.1_I2L_2016_M_16',
+            hasChart: 'none',
+            color:'#5ED613',
+            title: "IPC Lechuga",
+            links: "none",
+            hasFrame: true,
+            source: "Fuente: SSPM"
+        })
+        TSComponents.Card.render('card-inferior', {
+            serieId: '105.1_I2BAT_2016_M_15',
+            hasChart: 'none',
+            color:'#969009',
+            title: "IPC Batata",
+            links: "none",
+            hasFrame: true,
+            source: "Fuente: SSPM"
+        })
+
+}
+</script>
+```
+
+<script>
+    window.onload = function() {
+
+        TSComponents.Card.render('card-en-row-1', {
+            serieId: '46.2_ECTSTG_0_T_40',
+            color: '#0072BB',
+            hasChart: 'none',
+            title: "Tasa Subocupación GBA",
+            links: "none",
+            hasFrame: true,
+            source: "Fuente: SSPM"
+        })  
+        TSComponents.Card.render('card-en-row-2', {
+            serieId: '46.2_ECTSTSL_0_T_45',
+            color: '#6B8E23',
+            hasChart: 'none',
+            title: "Tasa Subocupación San Luis",
+            links: "none",
+            hasFrame: true,
+            source: "Fuente: SSPM"
+        })
+        TSComponents.Card.render('card-en-row-3', {
+            serieId: '46.2_ECTSTC_0_T_47',
+            color: '#FFA500',
+            hasChart: 'none',
+            title: "Tasa Subocupación Corrientes",
+            links: "none",
+            hasFrame: true,
+            source: "Fuente: SSPM"
+        })
+
+        TSComponents.Card.render('card-superior', {
+            serieId: '105.1_I2L_2016_M_16',
+            hasChart: 'none',
+            color:'#5ED613',
+            title: "IPC Lechuga",
+            links: "none",
+            hasFrame: true,
+            source: "Fuente: SSPM"
+        })
+        TSComponents.Card.render('card-inferior', {
+            serieId: '105.1_I2BAT_2016_M_15',
+            hasChart: 'none',
+            color:'#969009',
+            title: "IPC Batata",
+            links: "none",
+            hasFrame: true,
+            source: "Fuente: SSPM"
+        })
+        
+}
+</script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,9 +10,10 @@ nav:
     - Referencia:
       - TSExplorer: 'reference/ts-explorer.md'
       - TSComponents: 'reference/ts-components.md'
-      - "TSComponents: graphic": 'reference/ts-components/graphic.md'
-      - "TSComponents: card": 'reference/ts-components/card.md'
+      - "TSComponents: Graphic": 'reference/ts-components/graphic.md'
+      - "TSComponents: Card": 'reference/ts-components/card.md'
       - "TSComponents: Ejemplos": 'reference/ts-components/examples.md'
+      - "TSComponents: Layout": 'reference/ts-components/layout.md'
   #   - Condiciones de uso: terms.md
   # - Aplicaciones: applications.md
   - Desarrolladores:

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -722,3 +722,18 @@ main a[href^="https://"][target^="_blank"]::after {
 }
 
 /*---Fin Iconos---*/
+
+/*---Layout Externo---*/
+
+.ts-components-row {
+  display: flex;
+  justify-content: space-around;
+  margin: auto;
+}
+  
+.card-wrapper {
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+/*---Fin Layout Externo---*/


### PR DESCRIPTION
#### Contexto
Agrego selectores `card-wrapper` y `ts-components-row` a la hoja de estilos `components.css`, para que quien la importe con el fin de usar los componentes `Graphic` y `Card` pueda también emplear esas clases para los `divs` donde se insertan las cards, y para armar filas de componentes equiespaciados. A su vez, agrego una sección de documentación con ejemplos de uso de ambas clases, llamada _TSComponents: Layout_.

#### Cómo probarlo
Al no haber un tag productivo con los selectores incorporados a la hoja de estilos, no es posible verificarlo en la documentación con un `make servedocs`. De todos modos, puede ejecutarse el comando y copiar los nuevos selectores en el tag de `<style>` del .md.

Closes #533 