### PR TITLE
549 - Arreglo scroll de la barra lateral de búsqueda de ViewPage

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1358,6 +1358,10 @@ section#detalle #detalle-content #detalle-panel .dp-body .tab-content .tab-pane 
   transition: 0.25s;
   border-radius: 0;
 }
+section#detalle div#detalle-content div#detalle-panel .dp-body .tab-content form#form-hero-search .form-group .form-autocomplete > div {
+  /* Hide the unnecesary, misplaced div below the searchbar at the right-sided panel of ViewPage */
+  display: none;
+}
 section#detalle #detalle-content #detalle-panel .dp-body .tab-content .tab-pane .dp-form-search .form-group .form-control::-moz-placeholder {
   color: #686868;
   opacity: 1;

--- a/src/components/style/Common/AutoComplete.tsx
+++ b/src/components/style/Common/AutoComplete.tsx
@@ -2,13 +2,6 @@ import * as AutoComplete from 'react-autocomplete';
 
 import * as React from 'react';
 
-const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-    event.preventDefault();
-};
-
 export default (props: AutoComplete.Props) =>
 
-    <AutoComplete inputProps={{ className: "form-control",
-                                onFocus: (handleFocus) }}
-                  wrapperStyle={{}}
-                  {...props} />
+    <AutoComplete inputProps={{ className: "form-control" }} wrapperStyle={{}} {...props} />

--- a/src/components/style/Common/AutoComplete.tsx
+++ b/src/components/style/Common/AutoComplete.tsx
@@ -2,6 +2,13 @@ import * as AutoComplete from 'react-autocomplete';
 
 import * as React from 'react';
 
+const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+    event.preventDefault();
+};
+
 export default (props: AutoComplete.Props) =>
 
-    <AutoComplete inputProps={{ className: "form-control" }} wrapperStyle={{}} {...props} />
+    <AutoComplete inputProps={{ className: "form-control",
+                                onFocus: (handleFocus) }}
+                  wrapperStyle={{}}
+                  {...props} />


### PR DESCRIPTION
#### Contexto
Arreglo el panel lateral desplegable de la ViewPage, el cual se muestra al querer agregar series al gráfico, y que rendereaba un cuadro de búsqueda adicional y un scroll fuera de lugar al hacer `focus` sobre el searchbox (componente `SearchBox` también usado como buscador en el header y en la `MainPage` y `SearchPage`). Para ello, escondo ese `div` en particular (autoagregado por la biblioteca de React `AutoComplete`), de modo que no desborde del contenedor y no fuerce la existencia de un scroll.

#### Cómo probarlo
Ejecutar el `make watch` en la consola, para ver un `Explorer` watcheable en localhost:3000, abrir/buscar alguna serie en particular, abrir su gráfico y desplegar el panel haciendo click en _Agregar Series_. Hacer click sobre el searchbox, y comprobar que no se puede scrollear horizontalmente dentro del panel.

Closes #549