### PR TITLE
563 - Agrego estilos CSS para corregir label de Ordenar series

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1185,7 +1185,7 @@ section#listado #listado-list #list .search-conditions .title-and-sorting {
   display: flex;
   justify-content: space-between;
 }
-section#listado #listado-list #list .search-conditions .title-and-sorting .sort-by-label {
+section#listado #listado-list #list .search-conditions .title-and-sorting label.sort-by-label {
   color: rgb(118,118,118);
   cursor: pointer;
   font-family: "Medium";
@@ -1195,6 +1195,9 @@ section#listado #listado-list #list .search-conditions .title-and-sorting .sort-
   padding-right: 10px;
   text-align: right;
   text-rendering: auto;
+}
+section#listado #listado-list #list .search-conditions .title-and-sorting label.sort-by-label::after {
+  content: "";
 }
 section#listado #listado-list #list .search-conditions .title-and-sorting .search-sorting {
   margin-bottom: 10px;


### PR DESCRIPTION
#### Contexto
Agrego a la hoja de estilos `main.css` un selector específico para el `label` de `sort-by-label`, que fuerce a que no tenga un caracter `:` appendeado al insertarse en el plugin de CKANext (este selector ganará por especificidad).

#### Cómo probarlo
Actualmente no puede probarse, ya que es algo que recién debería verse en el plugin de CKANext y su posterior aplicación al portal de búsqueda de Series de Andino.

Closes #563 