### PR TITLE
556 - Selector Tipo de Gráfico en ViewPage

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1,7 +1,7 @@
 .g-complement {
   margin-right: 10px;
   float: right;
-  width: 20%;
+  width: 11%;
 }
 
 @media (max-width: 990px) {
@@ -110,6 +110,10 @@
 }
 
 .highcharts-legend {
+  display: none;
+}
+
+.highcharts-credits {
   display: none;
 }
 

--- a/src/components/common/picker/OptionsPicker.tsx
+++ b/src/components/common/picker/OptionsPicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import FrequencyPickerContainer from "../../style/picker/OptionsPickerContainer";
+import OptionsPickerContainer from "../../style/picker/OptionsPickerContainer";
 
 
 export interface IPickerOptionsProps {
@@ -8,12 +8,17 @@ export interface IPickerOptionsProps {
     available: boolean;
 }
 
+export interface IPickerStyle {
+    width: string;
+}
+
 interface IOptionsPickerProps {
     label: string;
     onChangeOption: (value: string) => void;
     selected: string;
     availableOptions: IPickerOptionsProps[];
     className?: string;
+    style?: IPickerStyle;
 }
 
 export default class OptionsPicker extends React.Component<IOptionsPickerProps, any> {
@@ -29,13 +34,13 @@ export default class OptionsPicker extends React.Component<IOptionsPickerProps, 
 
     public render() {
         return (
-            <FrequencyPickerContainer labelText={this.props.label} className={this.props.className}>
+            <OptionsPickerContainer labelText={this.props.label} className={this.props.className} style={this.props.style}>
                 <select name="frequencyList" className="form-control" onChange={this.handleChangeOption} value={this.props.selected}>
                     {this.props.availableOptions.map((option: IPickerOptionsProps) =>
                         <option key={option.value} value={option.value} disabled={!option.available}>{option.title}</option>
                     )}
                 </select>
-            </FrequencyPickerContainer>
+            </OptionsPickerContainer>
         )
     }
 }

--- a/src/components/style/picker/OptionsPickerContainer.tsx
+++ b/src/components/style/picker/OptionsPickerContainer.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import FormHorizontal from "../Common/FormHorizontal";
+import { IPickerStyle } from '../../common/picker/OptionsPicker';
 
 interface IOptionsContainerProps extends React.Props<any> {
     labelText: string;
     className?: string;
+    style?: IPickerStyle;
 }
 
 export default (props: IOptionsContainerProps) => {
@@ -13,7 +15,7 @@ export default (props: IOptionsContainerProps) => {
     delete auxProps.className;
 
     return (
-        <div className={`g-complement col-xs-4 ${props.className}`}>
+        <div className={`g-complement col-xs-4 ${props.className}`} style={props.style}>
             <FormHorizontal>
                 <label>{labelText}</label>
                 <span {...auxProps} />

--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -10,6 +10,8 @@ import { ISerieApi } from '../../api/SerieApi';
 import SerieConfig from '../../api/SerieConfig';
 import { getId, removeDuplicates } from "../../helpers/common/commonFunctions";
 import { getMaxDecimalsAmount } from '../../helpers/common/decimalsAmountHandling';
+import { getFullSerieId } from '../../helpers/common/fullSerieID';
+import { buildAbbreviationProps } from '../../helpers/common/numberAbbreviation';
 import { emptySerie, serieWithData } from '../../helpers/common/seriesClassification';
 import { IStore } from '../../store/initialState';
 import SearchBox from '../common/searchbox/SearchBox';
@@ -24,8 +26,6 @@ import GraphicAndShare from "./graphic/GraphicAndShare";
 import MetaData from './metadata/MetaData';
 import SeriesPicker from './seriespicker/SeriesPicker';
 import SeriesTags from './SeriesTags';
-import { getFullSerieId } from '../../helpers/common/fullSerieID';
-import { buildAbbreviationProps } from '../../helpers/common/numberAbbreviation';
 
 interface IViewPageProps extends RouterProps {
     seriesApi: ISerieApi;
@@ -43,7 +43,6 @@ interface IViewPageState {
     emptySeries: string[];
     failedSeries: string[];
     lastSuccessQueryParams: URLSearchParams;
-    chartType: string;
 }
 
 export class ViewPage extends React.Component<IViewPageProps, IViewPageState> {
@@ -63,7 +62,6 @@ export class ViewPage extends React.Component<IViewPageProps, IViewPageState> {
         this.setQueryParams = this.setQueryParams.bind(this);
         const params = getQueryParams(this.props.location);
         this.state = {
-            chartType: params.get('chartType') || 'line',
             emptySeries: [],
             failedSeries: [],
             lastSuccessQueryParams: params
@@ -151,8 +149,7 @@ export class ViewPage extends React.Component<IViewPageProps, IViewPageState> {
                                          maxDecimals={maxDecimals}
                                          numbersAbbreviate={abbreviationProps.numbersAbbreviate}
                                          decimalsBillion={abbreviationProps.decimalsBillion}
-                                         decimalsMillion={abbreviationProps.decimalsMillion}
-                                         chartType={this.state.chartType} />
+                                         decimalsMillion={abbreviationProps.decimalsMillion} />
                         <MetaData onRemove={this.removeSerie} />
                     </Container>
                     <DetallePanel seriesPicker={ <SeriesPicker onPick={this.addPickedSerie}

--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -43,6 +43,7 @@ interface IViewPageState {
     emptySeries: string[];
     failedSeries: string[];
     lastSuccessQueryParams: URLSearchParams;
+    chartType: string;
 }
 
 export class ViewPage extends React.Component<IViewPageProps, IViewPageState> {
@@ -60,10 +61,12 @@ export class ViewPage extends React.Component<IViewPageProps, IViewPageState> {
         this.removeSerie = this.removeSerie.bind(this);
         this.addPickedSerie = this.addPickedSerie.bind(this);
         this.setQueryParams = this.setQueryParams.bind(this);
+        const params = getQueryParams(this.props.location);
         this.state = {
+            chartType: params.get('chartType') || 'line',
             emptySeries: [],
             failedSeries: [],
-            lastSuccessQueryParams: getQueryParams(this.props.location),
+            lastSuccessQueryParams: params
         }
     }
 
@@ -148,7 +151,8 @@ export class ViewPage extends React.Component<IViewPageProps, IViewPageState> {
                                          maxDecimals={maxDecimals}
                                          numbersAbbreviate={abbreviationProps.numbersAbbreviate}
                                          decimalsBillion={abbreviationProps.decimalsBillion}
-                                         decimalsMillion={abbreviationProps.decimalsMillion} />
+                                         decimalsMillion={abbreviationProps.decimalsMillion}
+                                         chartType={this.state.chartType} />
                         <MetaData onRemove={this.removeSerie} />
                     </Container>
                     <DetallePanel seriesPicker={ <SeriesPicker onPick={this.addPickedSerie}

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -118,7 +118,8 @@ export default class Graphic extends React.Component<IGraphicProps> {
     };
 
     public shouldComponentUpdate(nextProps: IGraphicProps) {
-        return this.props.series.every((serie1: ISerie) => {
+        const changedChartType: boolean = this.props.chartTypes !== nextProps.chartTypes;
+        return changedChartType || this.props.series.every((serie1: ISerie) => {
             return nextProps.series.every((serie2: ISerie) => serie1.id !== serie2.id)
         });
     }

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -118,10 +118,15 @@ export default class Graphic extends React.Component<IGraphicProps> {
     };
 
     public shouldComponentUpdate(nextProps: IGraphicProps) {
-        const changedChartType: boolean = this.props.chartTypes !== nextProps.chartTypes;
-        return changedChartType || this.props.series.every((serie1: ISerie) => {
+
+        if (this.props.chartTypes !== nextProps.chartTypes) {
+            return true;
+        }
+
+        return this.props.series.every((serie1: ISerie) => {
             return nextProps.series.every((serie2: ISerie) => serie1.id !== serie2.id)
         });
+
     }
 
     private hasSmallTooltip() {

--- a/src/components/viewpage/graphic/GraphicAndShare.tsx
+++ b/src/components/viewpage/graphic/GraphicAndShare.tsx
@@ -32,7 +32,6 @@ export interface IGraphicAndShareProps {
     numbersAbbreviate: boolean;
     decimalsBillion: number;
     decimalsMillion: number;
-    chartType: string;
 }
 
 class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
@@ -44,9 +43,10 @@ class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
         this.handleChangeUnits = this.handleChangeUnits.bind(this);
         this.handleChangeAggregation = this.handleChangeAggregation.bind(this);
         this.removeDateParams = this.removeDateParams.bind(this);
+        this.handleChangeChartType = this.handleChangeChartType.bind(this);
 
         this.state = {
-            chartType: this.props.chartType
+            chartType: {}
         }
     }
 
@@ -86,6 +86,17 @@ class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
         this.props.updateParamsInUrl(params);
     }
 
+    public handleChangeChartType(value: string) {
+        const params = getQueryParams(this.props.location);
+        params.set('chartType', value);
+
+        this.props.updateParamsInUrl(params);
+    }
+
+    public getSelectedChartType(): string {
+        return getQueryParams(this.props.location).get('chartType') || 'line';
+    }
+
     public render() {
         return (
             <GraphContainer>
@@ -107,7 +118,9 @@ class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
                                     series={this.props.series}
                                     handleChangeFrequency={this.handleChangeFrequency}
                                     handleChangeUnits={this.handleChangeUnits}
-                                    handleChangeAggregation={this.handleChangeAggregation} />
+                                    handleChangeAggregation={this.handleChangeAggregation}
+                                    handleChangeChartType={this.handleChangeChartType}
+                                    selectedChartType={this.getSelectedChartType()} />
             </GraphContainer>
         )
     }
@@ -173,7 +186,7 @@ class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
     private generateChartTypes(): any {
         return this.props.series.reduce((result: {}, serie: ISerie) => {
             const fullId = getFullSerieId(serie);
-            result[fullId] = this.props.chartType;
+            result[fullId] = this.getSelectedChartType();
             return result;
         }, {})
     }

--- a/src/components/viewpage/graphic/GraphicAndShare.tsx
+++ b/src/components/viewpage/graphic/GraphicAndShare.tsx
@@ -18,6 +18,8 @@ import Graphic, { IChartExtremeProps } from "./Graphic";
 import GraphicComplements from "./GraphicComplements";
 
 
+const DEFAULT_CHART_TYPE: string = 'line';
+
 export interface IGraphicAndShareProps {
     series: ISerie[];
     date: IDateRange;
@@ -94,7 +96,7 @@ class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
     }
 
     public getSelectedChartType(): string {
-        return getQueryParams(this.props.location).get('chartType') || 'line';
+        return getQueryParams(this.props.location).get('chartType') || DEFAULT_CHART_TYPE;
     }
 
     public render() {

--- a/src/components/viewpage/graphic/GraphicAndShare.tsx
+++ b/src/components/viewpage/graphic/GraphicAndShare.tsx
@@ -3,7 +3,6 @@ import * as moment from "moment";
 import * as React from 'react';
 import { connect } from "react-redux";
 import { setDate } from "../../../actions/seriesActions";
-import ChartTypeSelector from '../../../api/ChartTypeSelector';
 import { IDataPoint } from "../../../api/DataPoint";
 import { IDateRange } from "../../../api/DateSerie";
 import QueryParams from '../../../api/QueryParams';
@@ -11,6 +10,7 @@ import { ISerie } from "../../../api/Serie";
 import { ISerieApi } from "../../../api/SerieApi";
 import SerieConfig from "../../../api/SerieConfig";
 import { formattedMoment, localTimestamp } from "../../../helpers/common/dateFunctions";
+import { getFullSerieId } from '../../../helpers/common/fullSerieID';
 import { IStore } from "../../../store/initialState";
 import GraphContainer from "../../style/Graphic/GraphContainer";
 import { getQueryParams } from '../ViewPage';
@@ -32,6 +32,7 @@ export interface IGraphicAndShareProps {
     numbersAbbreviate: boolean;
     decimalsBillion: number;
     decimalsMillion: number;
+    chartType: string;
 }
 
 class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
@@ -45,7 +46,7 @@ class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
         this.removeDateParams = this.removeDateParams.bind(this);
 
         this.state = {
-            chartType: {}
+            chartType: this.props.chartType
         }
     }
 
@@ -170,9 +171,11 @@ class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
     }
 
     private generateChartTypes(): any {
-        const params = getQueryParams(this.props.location);
-        const chartTypeSelector = new ChartTypeSelector(this.props.series, params)
-        return chartTypeSelector.getChartTypesBySeries();
+        return this.props.series.reduce((result: {}, serie: ISerie) => {
+            const fullId = getFullSerieId(serie);
+            result[fullId] = this.props.chartType;
+            return result;
+        }, {})
     }
 
 }

--- a/src/components/viewpage/graphic/GraphicComplements.tsx
+++ b/src/components/viewpage/graphic/GraphicComplements.tsx
@@ -10,7 +10,9 @@ export interface IGraphicComplementsProps {
     handleChangeFrequency: (value: string) => void;
     handleChangeUnits: (value: string) => void;
     handleChangeAggregation: (value: string) => void;
+    handleChangeChartType: (value: string) => void;
     url: string;
+    selectedChartType: string;
 }
 
 export default class GraphicComplements extends React.Component<IGraphicComplementsProps, any> {
@@ -29,7 +31,7 @@ export default class GraphicComplements extends React.Component<IGraphicCompleme
         return (
             <div className="row graphic-complements">
                 <ShareLinks url={this.props.url} series={this.props.series} />
-                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeFrequency} selected={this.frequency()} availableOptions={this.chartTypeOptions()} label="Tipo de Gráfico" />
+                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeChartType} selected={this.props.selectedChartType} availableOptions={this.chartTypeOptions()} label="Tipo de Gráfico" />
                 <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeAggregation} selected={this.selectedAggregation()} availableOptions={this.aggregationOptions()} label="Agregación" style={aggregationPickerStyle} />
                 <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeUnits} selected={this.selectedUnit()} availableOptions={this.unitOptions()} label="Unidades" style={unitsPickerStyle} />
                 <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeFrequency} selected={this.frequency()} availableOptions={this.frequencyOptions()} label="Frecuencia" />

--- a/src/components/viewpage/graphic/GraphicComplements.tsx
+++ b/src/components/viewpage/graphic/GraphicComplements.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ISerie } from "../../../api/Serie";
 import { isHigherFrequency } from "../../../api/utils/periodicityManager";
-import OptionsPicker, { IPickerOptionsProps } from '../../common/picker/OptionsPicker';
+import OptionsPicker, { IPickerOptionsProps, IPickerStyle } from '../../common/picker/OptionsPicker';
 import ShareLinks from '../ShareLinks';
 
 
@@ -16,13 +16,22 @@ export interface IGraphicComplementsProps {
 export default class GraphicComplements extends React.Component<IGraphicComplementsProps, any> {
 
     public render() {
+
         if (this.props.series.length === 0) { return null }
+
+        const unitsPickerStyle: IPickerStyle = {
+            width: '20.5%'
+        }
+        const aggregationPickerStyle: IPickerStyle = {
+            width: '16.5%'
+        }
 
         return (
             <div className="row graphic-complements">
                 <ShareLinks url={this.props.url} series={this.props.series} />
-                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeAggregation} selected={this.selectedAggregation()} availableOptions={this.aggregationOptions()} label="Agregación" />
-                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeUnits} selected={this.selectedUnit()} availableOptions={this.unitOptions()} label="Unidades" />
+                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeFrequency} selected={this.frequency()} availableOptions={this.chartTypeOptions()} label="Tipo de Gráfico" />
+                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeAggregation} selected={this.selectedAggregation()} availableOptions={this.aggregationOptions()} label="Agregación" style={aggregationPickerStyle} />
+                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeUnits} selected={this.selectedUnit()} availableOptions={this.unitOptions()} label="Unidades" style={unitsPickerStyle} />
                 <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeFrequency} selected={this.frequency()} availableOptions={this.frequencyOptions()} label="Frecuencia" />
             </div>
         )
@@ -47,6 +56,14 @@ export default class GraphicComplements extends React.Component<IGraphicCompleme
 
     public selectedAggregation(): string {
         return this.props.series[0].collapseAggregation;
+    }
+
+    public chartTypeOptions(): IPickerOptionsProps[] {
+        return [
+            { value: "line", title: "Líneas", available: true },
+            { value: "column", title: "Columnas", available: true },
+            { value: "area", title: "Áreas", available: true }
+        ];
     }
 
     public unitOptions(): IPickerOptionsProps[] {


### PR DESCRIPTION
#### Contexto
Agrego a la página de _Detalle_ del `Explorer` otro selector, debajo de los gráficos, para poder elegir el tipo de gráfico a emplear para representar los valores de las series (ya sea Líneas, Columnas o Áreas). La selección del mismo es análoga a emplear el query param `chartType` en la URL. Para ello:

- Aplico distintos anchos (por CSS) a los demás selectores existentes y que comparten el espacio horizontal con el nuevo selector, para que entren y se adecúen al largo del texto de sus opciones.
- Renombro el subcomponente que contiene a los selectores a `OptionsPickerContainer`, en términos de importación al subcomponente `OptionsPicker`.
- Agrego al subcomponente `GraphicComplements` propiedades para tener el tipo de gráfico elegido y un handler de evento al cambiar el mismo. A su vez, agrego un nuevo `OptionsPicker` para representar al selector de tipo de gráfico en sí.
- Cambio la lógica del life-cycle hook de React `ShouldComponentUpdate`, de modo que el `Graphic` se re-renderee también al cambiar lost tipos de gráfico.

#### Cómo probarlo
Ejecutar `make watch` y observar cómo se renderea el `index.html`, probando que se pueda cambiar de tipo de gráfico al entrar al detalle de una serie.

Closes #556