### PR TITLE
557 - Agrego modos de representacion acumulados anuales al selector de unidades

### DIFF
--- a/src/components/style/Share/ShareContainer.tsx
+++ b/src/components/style/Share/ShareContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
 export default (props: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>) =>
-    <div className="share col-xs-12 col-md-4">
+    <div className="share col-xs-12 col-md-3">
         <div {...props} />
     </div>

--- a/src/components/viewpage/graphic/GraphicComplements.tsx
+++ b/src/components/viewpage/graphic/GraphicComplements.tsx
@@ -22,7 +22,7 @@ export default class GraphicComplements extends React.Component<IGraphicCompleme
         if (this.props.series.length === 0) { return null }
 
         const unitsPickerStyle: IPickerStyle = {
-            width: '20.5%'
+            width: '24.5%'
         }
         const aggregationPickerStyle: IPickerStyle = {
             width: '16.5%'
@@ -73,8 +73,10 @@ export default class GraphicComplements extends React.Component<IGraphicCompleme
             { value: "value", title: "Unidades originales", available: true },
             { value: "change", title: "Variación", available: true },
             { value: "change_a_year_ago", title: "Variación interanual", available: true },
+            { value: "change_since_beginning_of_year", title: "Variación acumulada anual", available: true },
             { value: "percent_change", title: "Variación porcentual", available: true },
-            { value: "percent_change_a_year_ago", title: "Variación porcentual interanual", available: true }
+            { value: "percent_change_a_year_ago", title: "Variación porcentual interanual", available: true },
+            { value: "percent_change_since_beginning_of_year", title: "Variación porcentual acumulada anual", available: true }
         ];
     }
 


### PR DESCRIPTION
#### Contexto
Agrego al selector de unidades de la página de detalle de una serie los últimos modos de representación agregados a la API: **Variación acumulada anual** y **Variación porcentual acumulada anual**, los cuales responden a los valores de `change_since_beginning_of_year` y  `percent_change_since_beginning_of_year` para el query param `representation_mode`. Para ello:
- Agrando el ancho del selector de unidades, para que entre el nuevo label, más largo.
- Disminuyo el ancho del contenedor del botón de _Compartir_, para que pueda cohabitar en la fila con todos los selectores.
- Agrego las nuevas opciones al selector, con su mapeo a los valores de query param correspondientes.

#### Cómo probarlo
Ejecutar el `index.html` watcheable y abrir el detalle de alguna serie, para verificar que las nuevas dos opciones sean mostradas y puedan ser elegidas.

Closes #557 