### PR TITLE
434 - Retoco ancho de elementos de la card de preview para viewports mobile

### DIFF
--- a/src/components/style/Card/Serie/SerieCardWithChart.tsx
+++ b/src/components/style/Card/Serie/SerieCardWithChart.tsx
@@ -28,7 +28,7 @@ export default (props: ISerieCardProps) => {
             </div>
         </Row>
         <Row>
-            <div className="col-xs-8">
+            <div className="col-sm-8 col-xs-12">
                 <CardSubtitle><strong>Publicador: </strong>{props.serie.publisher.name}</CardSubtitle>
                 <CardSubtitle><strong>Fuente: </strong>{props.serie.datasetSource}</CardSubtitle>
                 <CardSubtitle><strong>Período: </strong>{props.serie.startDate}-{props.serie.endDate}</CardSubtitle>
@@ -38,7 +38,7 @@ export default (props: ISerieCardProps) => {
                 <CardSubtitle><strong>ID: </strong>{props.serie.id}</CardSubtitle>
             </div>
 
-            <div className="col-xs-4 d3-line-chart-container">
+            <div className="col-sm-4 col-xs-12 d3-line-chart-container">
                 <D3SeriesChart serie={props.serie}
                                frequency={props.serie.accrualPeriodicity} 
                                maxDecimals={props.maxDecimals} 


### PR DESCRIPTION
#### Contexto
Modifico el ancho de columnas (grid system) de los datos de la tarjeta de previsualización de series (las de las secciones de _Búsqueda_ y _Destacados_), para que puedan ajustarse correctamente en viewports mobile y se use horizontalmente todo el ancho de la tarjeta para los textos. Para ello:
- Hago que los textos ocupen dos tercios del ancho (8/12) y el gráfico el cuarto restante (4/12) en viewports no mobile (`sm` en adelante, según el modelo de viewports de Poncho/Bootstrap).
- Hago que los textos ocupen otdo el ancho de una fila (12/12), y el gráfico todo el ancho de otra fila en viewports mobile (`xs` únicamente).

#### Cómo probarlo
Ejecutando `make watch`, abrir la página principal del `index.html`, o bien realizar una búsqueda de series, y, haciendo uso de las DevTools (Firefox o Chrome) probar que se respeten los anchos adecuados también en pantallas mobile.

Closes #434 