### PR TITLE
574 - Arreglo dropdown de compartir y selectores en viewports más chicos

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -4,17 +4,27 @@
   width: 11%;
 }
 
-@media (max-width: 990px) {
+@media (max-width: 990px) {   /* iPad viewport */
   .g-complement {
-    width: 30%;
+    width: 40% !important;
+    float: left !important;
+  }
+  .g-chartType-selector, .g-units-selector {
+    margin-left: 65px;
+  }
+  .share {
+    text-align: center;
+  }
+  .g-social-container, .dropdown {
+    display: inline-block;
   }
 }
 
-@media (max-width: 526px) {
+@media (max-width: 526px) {   /* Mobile viewport */
   .g-complement {
     width: 90% !important;
     margin-left: 15px;
-    float: none !important;
+    float: left !important;
   }
 }
 

--- a/src/components/style/Share/ShareContainer.tsx
+++ b/src/components/style/Share/ShareContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
 export default (props: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>) =>
-    <div className="share col-xs-12 col-md-3">
+    <div className="share col-xs-12 col-sm-12 col-md-3">
         <div {...props} />
     </div>

--- a/src/components/style/Share/SocialNetworkShareContainer.tsx
+++ b/src/components/style/Share/SocialNetworkShareContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
 export default (props: React.DetailedHTMLProps<React.HTMLAttributes<HTMLUListElement>, HTMLUListElement>) =>
-    <span>
+    <span className="g-social-container">
         <ul className="social" {...props}/>
     </span>

--- a/src/components/style/picker/OptionsPickerContainer.tsx
+++ b/src/components/style/picker/OptionsPickerContainer.tsx
@@ -15,7 +15,7 @@ export default (props: IOptionsContainerProps) => {
     delete auxProps.className;
 
     return (
-        <div className={`g-complement col-xs-4 ${props.className}`} style={props.style}>
+        <div className={`g-complement col-xs-12 ${props.className}`} style={props.style}>
             <FormHorizontal>
                 <label>{labelText}</label>
                 <span {...auxProps} />

--- a/src/components/viewpage/graphic/GraphicComplements.tsx
+++ b/src/components/viewpage/graphic/GraphicComplements.tsx
@@ -31,9 +31,9 @@ export default class GraphicComplements extends React.Component<IGraphicCompleme
         return (
             <div className="row graphic-complements">
                 <ShareLinks url={this.props.url} series={this.props.series} />
-                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeChartType} selected={this.props.selectedChartType} availableOptions={this.chartTypeOptions()} label="Tipo de Gráfico" />
+                <OptionsPicker className="col-sm-2 g-chartType-selector" onChangeOption={this.props.handleChangeChartType} selected={this.props.selectedChartType} availableOptions={this.chartTypeOptions()} label="Tipo de Gráfico" />
                 <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeAggregation} selected={this.selectedAggregation()} availableOptions={this.aggregationOptions()} label="Agregación" style={aggregationPickerStyle} />
-                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeUnits} selected={this.selectedUnit()} availableOptions={this.unitOptions()} label="Unidades" style={unitsPickerStyle} />
+                <OptionsPicker className="col-sm-2 g-units-selector" onChangeOption={this.props.handleChangeUnits} selected={this.selectedUnit()} availableOptions={this.unitOptions()} label="Unidades" style={unitsPickerStyle} />
                 <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeFrequency} selected={this.frequency()} availableOptions={this.frequencyOptions()} label="Frecuencia" />
             </div>
         )


### PR DESCRIPTION
#### Contexto
Soluciono el comportamiento errático de los selectores de gráfico y el desplegable de enlaces para compartir al visualizar el Explorer en viewports más pequeños (como iPads o celulares). Para ello, hago algunos retoques:
- Agrego propiedades CSS a aplicar en viewports de tipo iPad.
- Retoco propiedad `float` de CSS para viewports de tipo celular, de modo que los selectores busquen ubicarse a la izquierda y no libremente (lo cual haría que, espacialmente, solapen al desplegable de enlaces para compartir, y lo inutilicen).
- Especifico anchos de columnas del grid system de Bootstrap/Poncho para más viewports, teniendo en cuenta iPads y celulares.

#### Cómo probarlo
Ejecutar `make watch` para probar el `index.html` y, desde algún browser, abrirlo con el viewport deseado desde las Mobile DevTools que provea. Fijarse que los enlaces y los selectores sean útiles en todo tipo de pantalla.

Closes #574 