### PR TITLE
578 - Fix borrar series grafico y estilos para viewports

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -2759,7 +2759,9 @@ RESPONSIVE:
   .mg-xlg-b {
     margin-bottom: 30px;
   }
-  section#home #hero {
+  section#home #hero,
+  section#listado #hero,
+  section#detalle #hero {
     height: 210px;
   }
   section#home #hero,

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -2615,59 +2615,49 @@ ANIMACIÓN:
 RESPONSIVE:
 ------------------------------------------------------------------------------------
 */
-@media (max-width: 460px) {
-  .share {
-    width: 100%;
-    display: block;
-  }
-
-  .d3-line-chart-container {
-    display: block;
-    width: 100%;
-  }
-
-  .d3-line-chart {
-    float: none !important;
-    margin-top: 15px !important;
-  }
-
-  .series-card {
-    height: auto !important;
-  }
-}
-
-@media (max-width: 526px) {   /* Mobile viewport */
+@media (max-width: 767px) {   /* Mobile viewport */
   .g-complement {
     width: 90% !important;
     margin-left: 15px;
     float: left !important;
   }
-  section#home #hero {
+  section#home #hero,
+  section#listado #hero {
     height: 250px;
   }
-  section#home #hero div.hero-caption {
-    height: auto;
-    padding-top: 0px;
+  section#home #hero div.hero-caption .container div.row h1.title-xxlg,
+  section#listado #hero div.hero-caption .container div.row h1.title-xlg {
+    font-size: 35px;
   }
-  section#listado #hero .container h1.title-xlg {
-    margin-bottom: 20px;
+  section#home #hero div.hero-caption .container div.row p.larger.color-w.mg-b,
+  section#listado #hero div.hero-caption .container div.row p.large.color-w.mg-b {
+    font-size: 15px;
   }
-  section#listado #hero .container div.row p.large.color-w.mg-b {
-    display: none;
+  section#home #hero .container #form-hero-search .form-group i,
+  section#listado #hero .container #form-hero-search .form-group i {
+    font-size: 26px;
+  }
+  section#listado #hero .container #form-hero-search .form-group .form-autocomplete input.form-control {
+    height: 68.15px;
   }
   section#listado #listado-list .container #list div.search-conditions div.title-and-sorting {
     display: block;
   }
-}
-
-@media (max-width: 600px) and (min-width: 461px) {
   .share {
-    width: 57%;
-    display: inline-block;
+    width: 100%;
+    display: block;
   }
-}
-
-@media (max-width: 767px) {
+  .d3-line-chart-container {
+    display: block;
+    width: 100%;
+  }
+  .d3-line-chart {
+    float: none !important;
+    margin-top: 15px !important;
+  }
+  .series-card {
+    height: auto !important;
+  }
   section#listado #listado-list #filters {
     height: auto !important;
     margin-top: 15px;
@@ -2709,7 +2699,7 @@ RESPONSIVE:
   }
 }
 
-@media (max-width: 990px) { /* iPad viewport */
+@media (max-width: 992px) and (min-width: 768px) { /* Tablet viewport */
   .g-complement {
     width: 40% !important;
     float: left !important;

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -2709,7 +2709,7 @@ RESPONSIVE:
   }
 }
 
-@media (max-width: 992px) and (min-width: 768px) { /* Tablet viewport */
+@media (max-width: 1281px) and (min-width: 768px) { /* Tablet viewport */
   .g-complement {
     width: 40% !important;
     float: left !important;

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -2622,22 +2622,27 @@ RESPONSIVE:
     float: left !important;
   }
   section#home #hero,
-  section#listado #hero {
+  section#listado #hero,
+  section#detalle #hero {
     height: 250px;
   }
   section#home #hero div.hero-caption .container div.row h1.title-xxlg,
-  section#listado #hero div.hero-caption .container div.row h1.title-xlg {
+  section#listado #hero div.hero-caption .container div.row h1.title-xlg,
+  section#detalle #hero div.hero-caption .container div.row h1.title-xlg {
     font-size: 35px;
   }
   section#home #hero div.hero-caption .container div.row p.larger.color-w.mg-b,
-  section#listado #hero div.hero-caption .container div.row p.large.color-w.mg-b {
+  section#listado #hero div.hero-caption .container div.row p.large.color-w.mg-b,
+  section#detalle #hero div.hero-caption .container div.row p.large.color-w.mg-b {
     font-size: 15px;
   }
   section#home #hero .container #form-hero-search .form-group i,
-  section#listado #hero .container #form-hero-search .form-group i {
+  section#listado #hero .container #form-hero-search .form-group i,
+  section#detalle #hero .container #form-hero-search .form-group i {
     font-size: 26px;
   }
-  section#listado #hero .container #form-hero-search .form-group .form-autocomplete input.form-control {
+  section#listado #hero .container #form-hero-search .form-group .form-autocomplete input.form-control,
+  section#detalle #hero .container #form-hero-search .form-group .form-autocomplete input.form-control {
     height: 68.15px;
   }
   section#listado #listado-list .container #list div.search-conditions div.title-and-sorting {
@@ -2646,6 +2651,7 @@ RESPONSIVE:
   .share {
     width: 100%;
     display: block;
+    text-align: center;
   }
   .d3-line-chart-container {
     display: block;
@@ -2672,8 +2678,12 @@ RESPONSIVE:
   section#listado #listado-list #list .series-card .card-title {
     font-size: 18px;
   }
-  section#detalle #detalle-content .tag {
+  section#detalle #detalle-content #btn-config {
+    margin-right: 15px;
+  }
+  section#detalle #detalle-content span.tag {
     margin-bottom: 7.5px;
+    margin-left: 15px;
   }
   section#detalle #detalle-content .detalle-serie .dl-horizontal dt,
   section#detalle #detalle-content .detalle-serie .dl-horizontal dd {

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -4,30 +4,6 @@
   width: 11%;
 }
 
-@media (max-width: 990px) {   /* iPad viewport */
-  .g-complement {
-    width: 40% !important;
-    float: left !important;
-  }
-  .g-chartType-selector, .g-units-selector {
-    margin-left: 65px;
-  }
-  .share {
-    text-align: center;
-  }
-  .g-social-container, .dropdown {
-    display: inline-block;
-  }
-}
-
-@media (max-width: 526px) {   /* Mobile viewport */
-  .g-complement {
-    width: 90% !important;
-    margin-left: 15px;
-    float: left !important;
-  }
-}
-
 .pointer {
   cursor: pointer;
 }
@@ -165,34 +141,6 @@
   .highcharts-root,
   .highcharts-background {
     width: 700px;
-  }
-}
-
-@media (max-width: 600px) and (min-width: 461px) {
-  .share {
-    width: 57%;
-    display: inline-block;
-  }
-}
-
-@media (max-width: 460px) {
-  .share {
-    width: 100%;
-    display: block;
-  }
-
-  .d3-line-chart-container {
-    display: block;
-    width: 100%;
-  }
-
-  .d3-line-chart {
-    float: none !important;
-    margin-top: 15px !important;
-  }
-
-  .series-card {
-    height: auto !important;
   }
 }
 
@@ -2667,6 +2615,58 @@ ANIMACIÓN:
 RESPONSIVE:
 ------------------------------------------------------------------------------------
 */
+@media (max-width: 460px) {
+  .share {
+    width: 100%;
+    display: block;
+  }
+
+  .d3-line-chart-container {
+    display: block;
+    width: 100%;
+  }
+
+  .d3-line-chart {
+    float: none !important;
+    margin-top: 15px !important;
+  }
+
+  .series-card {
+    height: auto !important;
+  }
+}
+
+@media (max-width: 526px) {   /* Mobile viewport */
+  .g-complement {
+    width: 90% !important;
+    margin-left: 15px;
+    float: left !important;
+  }
+  section#home #hero {
+    height: 250px;
+  }
+  section#home #hero div.hero-caption {
+    height: auto;
+    padding-top: 0px;
+  }
+  section#listado #hero .container h1.title-xlg {
+    margin-bottom: 20px;
+  }
+  section#listado #hero .container div.row p.large.color-w.mg-b {
+    display: none;
+  }
+  section#listado #listado-list .container #list div.search-conditions div.title-and-sorting {
+    display: block;
+  }
+}
+
+@media (max-width: 600px) and (min-width: 461px) {
+  .share {
+    width: 57%;
+    display: inline-block;
+  }
+}
+
 @media (max-width: 767px) {
   section#listado #listado-list #filters {
     height: auto !important;
@@ -2708,7 +2708,21 @@ RESPONSIVE:
     white-space: nowrap;
   }
 }
-@media (max-width: 992px) {
+
+@media (max-width: 990px) { /* iPad viewport */
+  .g-complement {
+    width: 40% !important;
+    float: left !important;
+  }
+  .g-chartType-selector, .g-units-selector {
+    margin-left: 65px;
+  }
+  .share {
+    text-align: center;
+  }
+  .g-social-container, .dropdown {
+    display: inline-block;
+  }
   .mg-b-xs {
     margin-bottom: 15px !important;
   }
@@ -2745,11 +2759,13 @@ RESPONSIVE:
   .mg-xlg-b {
     margin-bottom: 30px;
   }
+  section#home #hero {
+    height: 210px;
+  }
   section#home #hero,
   section#listado #hero,
   section#detalle #hero {
     width: 100%;
-    height: auto;
   }
   section#home #hero .container,
   section#listado #hero .container,
@@ -2760,7 +2776,6 @@ RESPONSIVE:
     -ms-transform: translateY(0);
     -o-transform: translateY(0);
     transform: translateY(0);
-    padding: 30px 0;
   }
   section#home #hero .container .title-xxlg,
   section#listado #hero .container .title-xxlg,

--- a/src/components/style/Hero/CompactSeriesHero.tsx
+++ b/src/components/style/Hero/CompactSeriesHero.tsx
@@ -14,10 +14,10 @@ export default (props: IFinalSeriesHeroProps) =>
             </div>
         </Row>
         <Row>
-            <div className="col-sm-8 col-md-7">
+            <div className="col-sm-12 col-md-10">
                 <PLarge>{props.paragraph}</PLarge>
             </div>
-            <div className="col-sm-4 col-md-5">
+            <div className="col-sm-12 col-md-10">
                 {props.searchBox}
             </div>
         </Row>

--- a/src/components/viewpage/SeriesTags.tsx
+++ b/src/components/viewpage/SeriesTags.tsx
@@ -21,10 +21,16 @@ interface ISeriesTagsProps extends React.Props<any> {
 function seriesTags(props: ISeriesTagsProps, state: any) {
     return (
         <span>
-            {props.serieTags.map((serieTag: ISerieTag, index: number) =>
-                <Tag key={index} pegColor={getSerieColor(props.series, getFullSerieId(serieTag))} onClose={getOnCloseFor(props.serieTags, serieTag.id, props.onTagClose)}>
+            {props.serieTags.map((serieTag: ISerieTag, index: number) => {
+                const fullSerieID = getFullSerieId(serieTag);
+                return(
+                <Tag key={index} 
+                     pegColor={getSerieColor(props.series, fullSerieID)} 
+                     onClose={getOnCloseFor(props.serieTags, fullSerieID, props.onTagClose)}>
                     {serieTag.title}
                 </Tag>
+                );
+            }
             )}
         </span>
     )

--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -106,7 +106,7 @@ export class ViewPage extends React.Component<IViewPageProps, IViewPageState> {
     }
 
     public removeSerie(serieId: string) {
-        const ids = getIDs(this.props.location as Location).filter((val) => serieIdSanitizer(val) !== serieId);
+        const ids = getIDs(this.props.location as Location).filter((val) => val !== serieId);
         if (ids.length) {
             this.viewSeries(ids);
         }
@@ -275,10 +275,6 @@ export function seriesConfigByUrl(url: string): (series: ISerie[]) => SerieConfi
         seriesConfig.setPercentChangeAYearAgo(search.some((value: string) => value.includes(getFullSerieId(serie)) && value.includes('percent_change_a_year_ago')));
         return seriesConfig;
     });
-}
-
-function serieIdSanitizer(serieId: string): string {
-    return serieId.split(':')[0];
 }
 
 function mapStateToProps(state: IStore) {


### PR DESCRIPTION
#### Contexto
Arreglo el bug de la página de visualización de Series que no permitía borrarlas del gráfico cuando se mostraba más de una y ambas partían de la misma ID pura. Para ello:
- Empiezo a distinguir las series involucradas por su **idCompleto** (obtenido con `getFullSerieId`).
- Obtengo las series que deben permanecer por medio del id completo, y no sólo por el prefijo de id pura (el cual se obtenía con `serieIdSanitizer`).

A su vez, estandarizo los estilos CSS de las distitnas páginas del componente `Explorer` en viewports más pequeños. Trabajando en los viewports de **mobile** (celulares) y **tablet** (iPads):
- Reorganicé el código del archivo `main.css` para que todos los estilos aplicables al trabajar con cada viewport estén juntos según el tamaño.
- Estandarizo el tamaño y fuentes del hero con barra de búsqueda en ambos viewports, para cada una de sus páginas (_Principal_, _Búsqueda_ y _Detalle_).
- Centrado el desplegable de enlaces para _Compartir_ en la página de _Detalle_ del viewport mobile.
- Agregados márgenes laterales a los tags de series y el activador de _Agregar Series_ en la página de _Detalle_ del viewport mobile.

#### Cómo probarlo
Ejecutando el `make watch` para visualizar localmente los cambios, verificar los detalles estéticos de cada sección de ambos viewports (haciendo uso de las Dev Tools del navegador, en su modo Mobile). A su vez, en el viewport normal, probar una sección de detalle con estos query params: `?ids=143.3_NO_PR_2004_A_21,143.3_NO_PR_2004_A_21:percent_change_since_beginning_of_year&start_date=2016-01-01`, y verificar que puedan eliminarse ambas series por separado.

Closes #578 