### PR TITLE
581 - Corrijo intervalos de ancho y anchos de columna para cada viewport

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -2618,8 +2618,18 @@ RESPONSIVE:
 @media (max-width: 767px) {   /* Mobile viewport */
   .g-complement {
     width: 90% !important;
-    margin-left: 15px;
+    margin-left: 18px;
+    margin-right: 15px;
     float: left !important;
+  }
+  .g-complement > * {
+    display: inline;
+    float: none;
+  }
+  @media (min-width: 576px) { /* Only for landscaped mobile viewports */
+    .g-complement {
+      margin-left: 32px;
+    }
   }
   section#home #hero,
   section#listado #hero,
@@ -2712,13 +2722,18 @@ RESPONSIVE:
   }
 }
 
-@media (max-width: 1281px) and (min-width: 768px) { /* Tablet viewport */
+@media (max-width: 1199px) and (min-width: 768px) { /* Tablet viewport */
   .g-complement {
     width: 40% !important;
     float: left !important;
   }
   .g-chartType-selector, .g-units-selector {
     margin-left: 65px;
+  }
+  @media (min-width: 1024px) { /* Only for landscaped iPad viewports */
+    .g-chartType-selector, .g-units-selector {
+      margin-left: 90px;
+    }
   }
   .share {
     text-align: center;

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <title>Explorador de la API de Series de Tiempo | Ministerio de Modernización</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport" content="width=device-width, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0" />
     <meta name="format-detection" content="telephone=no">
 
     <meta name="twitter:card" content="summary"></meta>

--- a/src/components/style/Share/ShareContainer.tsx
+++ b/src/components/style/Share/ShareContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
 export default (props: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>) =>
-    <div className="share col-xs-12 col-sm-12 col-md-3">
+    <div className="share col-xs-12 col-lg-3">
         <div {...props} />
     </div>

--- a/src/components/viewpage/graphic/GraphicComplements.tsx
+++ b/src/components/viewpage/graphic/GraphicComplements.tsx
@@ -31,10 +31,28 @@ export default class GraphicComplements extends React.Component<IGraphicCompleme
         return (
             <div className="row graphic-complements">
                 <ShareLinks url={this.props.url} series={this.props.series} />
-                <OptionsPicker className="col-sm-2 g-chartType-selector" onChangeOption={this.props.handleChangeChartType} selected={this.props.selectedChartType} availableOptions={this.chartTypeOptions()} label="Tipo de Gráfico" />
-                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeAggregation} selected={this.selectedAggregation()} availableOptions={this.aggregationOptions()} label="Agregación" style={aggregationPickerStyle} />
-                <OptionsPicker className="col-sm-2 g-units-selector" onChangeOption={this.props.handleChangeUnits} selected={this.selectedUnit()} availableOptions={this.unitOptions()} label="Unidades" style={unitsPickerStyle} />
-                <OptionsPicker className="col-sm-2" onChangeOption={this.props.handleChangeFrequency} selected={this.frequency()} availableOptions={this.frequencyOptions()} label="Frecuencia" />
+                <OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-chartType-selector"
+                               onChangeOption={this.props.handleChangeChartType} 
+                               selected={this.props.selectedChartType} 
+                               availableOptions={this.chartTypeOptions()} 
+                               label="Tipo de Gráfico" />
+                <OptionsPicker className="col-xs-12 col-md-3 col-lg-3" 
+                               onChangeOption={this.props.handleChangeAggregation} 
+                               selected={this.selectedAggregation()} 
+                               availableOptions={this.aggregationOptions()} 
+                               label="Agregación" 
+                               style={aggregationPickerStyle} />
+                <OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-units-selector" 
+                               onChangeOption={this.props.handleChangeUnits} 
+                               selected={this.selectedUnit()} 
+                               availableOptions={this.unitOptions()} 
+                               label="Unidades" 
+                               style={unitsPickerStyle} />
+                <OptionsPicker className="col-xs-12 col-md-3 col-lg-3" 
+                               onChangeOption={this.props.handleChangeFrequency} 
+                               selected={this.frequency()} 
+                               availableOptions={this.frequencyOptions()} 
+                               label="Frecuencia" />
             </div>
         )
     }


### PR DESCRIPTION
#### Contexto
Defino los intervalos de ancho de los viewports existentes, para normalizar los anchos de componentes y grid-columns aplicados a los mismos, de modo que se corrija su visualización. Dichos intervalos son:
- De 0 a 767 px, **mobile**; utiliza los grid-width `xs` y `sm`.
  - De 576 a 767 px, **mobile apaisado** exclusivamente.
- De 768 a 1199 px, **tablet**; utiliza el grid-width `md`.
  - De 1024 a 1199 px, **iPad apaisado** exclusivamente; no incluye Kindle Fire apaisado.
- De 1200 px en adelante, **PC** (y Kindle Fire apaisado) ; utiliza el grid-width `lg` y mayores.
A su vez, agrego al `index.html` usado para watchear el atributo `initial-scale` del tag `meta-viewport`, para que pueda reescalarse fácilmente en viewports menores al del dispositivo.

#### Cómo probarlo
Ejecutar el watcher y probar la disposición y ancho de las secciones del `Explorer` en los distintos viewports posibles, apaisados y no apaisados, con las DevTools de cuantos navegadores se quiera/pueda.

Closes #581  