### PR TITLE
583 - Arreglo series tags no clickeables en página de Detalle

### DIFF
--- a/src/components/style/Hero/CompactSeriesHero.tsx
+++ b/src/components/style/Hero/CompactSeriesHero.tsx
@@ -14,10 +14,10 @@ export default (props: IFinalSeriesHeroProps) =>
             </div>
         </Row>
         <Row>
-            <div className="col-sm-12 col-md-10">
+            <div className="col-sm-12 col-md-10 col-lg-7">
                 <PLarge>{props.paragraph}</PLarge>
             </div>
-            <div className="col-sm-12 col-md-10">
+            <div className="col-sm-12 col-md-10 col-lg-5">
                 {props.searchBox}
             </div>
         </Row>


### PR DESCRIPTION
#### Contexto
Arreglo el bug de los `SeriesTag` no clickeables en la página de _Detalle_ del `Explorer`, el cual se debía al tamaño inapropaido que tomaban la descripción y el searchbox del hero en viewports grandes (de 1200 px en adelante). Para ello, cambio los grid-width de los renglones del `CompactSeriesHero` usado en dicha sección del viewport grande, para que ambos puedan entrar en una fila y no se vayan del tamaño del hero en sí.

#### Cómo probarlo
Ejecutando el HTML watcheable con `make watch`, verificar que el hero se vea bien en las secciones de _Búsqueda_ y _Detalle_, y, en esta última, que se puedan eliminar series agregadas al gráfico al clickear en sus tags.

Closes #583