### PR TITLE
570 - CSS de filtros de tiempo en viewports chicos

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1265,6 +1265,7 @@ section#detalle #detalle-content .detalle-serie .title-and-actions .title {
   border-left-width: 5px;
   border-left-style: solid;
   border-left-color: #999999;
+  word-break: break-word;
 }
 section#detalle #detalle-content .detalle-serie .title-and-actions .action {
   font-size: 12px;

--- a/src/helpers/graphic/chartConfigBuilder.ts
+++ b/src/helpers/graphic/chartConfigBuilder.ts
@@ -10,6 +10,7 @@ import { dateFormatByPeriodicity } from "./dateFormatting";
 import { HighchartsSerieBuilder, IHighchartsSerieBuilderOptions } from "./hcSerieFromISerie";
 import { tooltipDateValue, tooltipFormatter } from "./tooltipHandling";
 import LocaleValueFormatter, { ILocaleValueFormatterConfig } from "../common/LocaleValueFormatter";
+import { RESPONSIVE_FILTERS_ALIGNMENT_RULES } from "./responsiveFiltersAlignment";
 
 export class ChartConfigBuilder {
 
@@ -143,75 +144,7 @@ export class ChartConfigBuilder {
                 minRange: 2
             },
             responsive: {
-                rules: [
-                    {
-                        condition: {
-                            maxWidth: 359
-                        },
-                        chartOptions: {
-                            rangeSelector: {
-                                buttonPosition: {
-                                    x: -30
-                                },
-                                inputPosition: {
-                                    align: 'center',
-                                    x: 35
-                                }
-                            },
-                        }
-                    },
-                    {
-                        condition: {
-                            maxWidth: 400,
-                            minWidth: 360
-                        },
-                        chartOptions: {
-                            rangeSelector: {
-                                buttonPosition: {
-                                    x: 10
-                                },
-                                inputPosition: {
-                                    align: 'center',
-                                    x: 25
-                                }
-                            },
-                        }
-                    },
-                    {
-                        condition: {
-                            maxWidth: 500,
-                            minWidth: 401
-                        },
-                        chartOptions: {
-                            rangeSelector: {
-                                buttonPosition: {
-                                    align: 'right',
-                                    x: 80
-                                },
-                                inputPosition: {
-                                    align: 'center',
-                                    x: 25
-                                }
-                            }
-                        }
-                    },
-                    {
-                        condition: {
-                            maxWidth: 767,
-                            minWidth: 551
-                        },
-                        chartOptions: {
-                            rangeSelector: {
-                                buttonPosition: {
-                                    align: 'left',
-                                    x: -30
-                                },
-                                inputPosition: {
-                                    align: 'right'
-                                }
-                            },
-                        }
-                    }]
+                rules: RESPONSIVE_FILTERS_ALIGNMENT_RULES
             },
 
             yAxis: yAxisArray,

--- a/src/helpers/graphic/chartConfigBuilder.ts
+++ b/src/helpers/graphic/chartConfigBuilder.ts
@@ -31,7 +31,7 @@ export class ChartConfigBuilder {
 
         const yAxisArray = generateYAxisArray(this.yAxisBySeries);
         const seriesValues = this.seriesValues(yAxisArray);
-        
+
         return {
 
             legend: {
@@ -51,9 +51,9 @@ export class ChartConfigBuilder {
             title: {
                 text: ''
             },
-            plotOptions : { series: { dataGrouping: { enabled: false } } },
-            tooltip:{
-                formatter () {
+            plotOptions: { series: { dataGrouping: { enabled: false } } },
+            tooltip: {
+                formatter() {
                     const self: any = this;
                     // @ts-ignore
                     const builder: ChartConfigBuilder = _this;
@@ -68,11 +68,11 @@ export class ChartConfigBuilder {
 
                             let significantFigures = serieConfig.getSerieSignificantFigures();
 
-                            if(builder.props.maxDecimals !== undefined) {
+                            if (builder.props.maxDecimals !== undefined) {
                                 significantFigures = Math.min(builder.props.maxDecimals, serieConfig.getSerieSignificantFigures());
                             }
 
-                            const decimalPlaces = getTooltipDecimals(serieConfig.getFullSerieId(), 
+                            const decimalPlaces = getTooltipDecimals(serieConfig.getFullSerieId(),
                                 significantFigures, builder.props.decimalTooltips);
 
                             const localeFormatterConfig: ILocaleValueFormatterConfig = {
@@ -87,10 +87,10 @@ export class ChartConfigBuilder {
                             value = localeFormatter.formatValue(value);
 
                             contentTooltip += tooltipFormatter(point, value, builder.smallTooltip);
-                            
+
                         }
 
-                        if (index < self.points.length -1) {
+                        if (index < self.points.length - 1) {
                             contentTooltip += "<br>";
                         }
                     });
@@ -128,7 +128,7 @@ export class ChartConfigBuilder {
                         const zoomBtnClicked = e.min === undefined && e.max === undefined && e.trigger === 'zoom';
                         const viewAllClicked = e.trigger === 'rangeSelectorButton' && e.rangeSelectorButton.type === 'all';
 
-                        if((zoomBtnClicked || viewAllClicked) && this.props.onReset) {
+                        if ((zoomBtnClicked || viewAllClicked) && this.props.onReset) {
                             this.props.onReset();
                         } else if (this.props.onZoom) {
                             const defaultMin = e.min === 0 || e.min === this.props.range.min;
@@ -136,40 +136,111 @@ export class ChartConfigBuilder {
                             if (e.min === e.max || defaultMin && defaultMax) { return }
 
 
-                            this.props.onZoom({min: Math.ceil(e.min), max: Math.ceil(e.max)});
+                            this.props.onZoom({ min: Math.ceil(e.min), max: Math.ceil(e.max) });
                         }
                     }
                 },
                 minRange: 2
             },
+            responsive: {
+                rules: [
+                    {
+                        condition: {
+                            maxWidth: 359
+                        },
+                        chartOptions: {
+                            rangeSelector: {
+                                buttonPosition: {
+                                    x: -30
+                                },
+                                inputPosition: {
+                                    align: 'center',
+                                    x: 35
+                                }
+                            },
+                        }
+                    },
+                    {
+                        condition: {
+                            maxWidth: 400,
+                            minWidth: 360
+                        },
+                        chartOptions: {
+                            rangeSelector: {
+                                buttonPosition: {
+                                    x: 10
+                                },
+                                inputPosition: {
+                                    align: 'center',
+                                    x: 25
+                                }
+                            },
+                        }
+                    },
+                    {
+                        condition: {
+                            maxWidth: 500,
+                            minWidth: 401
+                        },
+                        chartOptions: {
+                            rangeSelector: {
+                                buttonPosition: {
+                                    align: 'right',
+                                    x: 80
+                                },
+                                inputPosition: {
+                                    align: 'center',
+                                    x: 25
+                                }
+                            }
+                        }
+                    },
+                    {
+                        condition: {
+                            maxWidth: 767,
+                            minWidth: 551
+                        },
+                        chartOptions: {
+                            rangeSelector: {
+                                buttonPosition: {
+                                    align: 'left',
+                                    x: -30
+                                },
+                                inputPosition: {
+                                    align: 'right'
+                                }
+                            },
+                        }
+                    }]
+            },
 
             yAxis: yAxisArray,
             series: seriesValues
         };
-        
+
     }
 
     private exporting() {
         return {
             buttons: {
                 contextButton: {
-                    menuItems: ['printChart', 'downloadPNG','downloadJPEG', 'downloadPDF', 'downloadSVG']
+                    menuItems: ['printChart', 'downloadPNG', 'downloadJPEG', 'downloadPDF', 'downloadSVG']
                 },
             },
             chartOptions: {
                 legend: { itemStyle: { width: 300 } },
-                navigator: {enabled: false},
-                rangeSelector: {enabled: false},
+                navigator: { enabled: false },
+                rangeSelector: { enabled: false },
                 scrollbar: { enabled: false },
             }
         }
     }
 
     private rangeSelector() {
-        return  {
+        return {
             buttons: [
-                { count: 1, text: '1m', type: 'month'},
-                { count: 3, text: '3m', type: 'month'},
+                { count: 1, text: '1m', type: 'month' },
+                { count: 3, text: '3m', type: 'month' },
                 { count: 6, text: '6m', type: 'month' },
                 { text: 'YTD', type: 'ytd' },
                 { count: 1, text: '1y', type: 'year' },
@@ -202,7 +273,7 @@ export class ChartConfigBuilder {
             yAxisArray,
         }
         return series.map((serie) => new HighchartsSerieBuilder(options)
-                                            .buildFromSerie(serie));
+            .buildFromSerie(serie));
     }
 
 }

--- a/src/helpers/graphic/responsiveFiltersAlignment.ts
+++ b/src/helpers/graphic/responsiveFiltersAlignment.ts
@@ -1,0 +1,154 @@
+export const RESPONSIVE_FILTERS_ALIGNMENT_RULES = [
+    {
+        condition: {
+            maxWidth: 300
+        },
+        chartOptions: {
+            rangeSelector: {
+                buttonPosition: {
+                    x: -30
+                },
+                inputPosition: {
+                    align: 'center',
+                    x: 40
+                }
+            },
+        }
+    },
+    {
+        condition: {
+            maxWidth: 330,
+            minWidth: 301
+        },
+        chartOptions: {
+            rangeSelector: {
+                buttonPosition: {
+                    x: -15
+                },
+                inputPosition: {
+                    align: 'center',
+                    x: 35
+                }
+            },
+        }
+    },
+    {
+        condition: {
+            maxWidth: 370,
+            minWidth: 331
+        },
+        chartOptions: {
+            rangeSelector: {
+                buttonPosition: {
+                    x: -15
+                },
+                inputPosition: {
+                    align: 'center',
+                    x: 35
+                }
+            },
+        }
+    },
+    {
+        condition: {
+            maxWidth: 410,
+            minWidth: 371
+        },
+        chartOptions: {
+            rangeSelector: {
+                buttonPosition: {
+                    x: 5
+                },
+                inputPosition: {
+                    align: 'center',
+                    x: 20
+                }
+            }
+        }
+    },
+    {
+        condition: {
+            maxWidth: 450,
+            minWidth: 411
+        },
+        chartOptions: {
+            rangeSelector: {
+                buttonPosition: {
+                    x: 20
+                },
+                inputPosition: {
+                    align: 'center',
+                    x: 15
+                }
+            }
+        }
+    },
+    {
+        condition: {
+            maxWidth: 490,
+            minWidth: 451
+        },
+        chartOptions: {
+            rangeSelector: {
+                buttonPosition: {
+                    x: 35
+                },
+                inputPosition: {
+                    align: 'center',
+                    x: 15
+                }
+            }
+        }
+    },
+    {
+        condition: {
+            maxWidth: 530,
+            minWidth: 491
+        },
+        chartOptions: {
+            rangeSelector: {
+                buttonPosition: {
+                    x: 45
+                },
+                inputPosition: {
+                    align: 'center',
+                    x: 5
+                }
+            }
+        }
+    },
+    {
+        condition: {
+            maxWidth: 570,
+            minWidth: 531
+        },
+        chartOptions: {
+            rangeSelector: {
+                buttonPosition: {
+                    x: 55
+                },
+                inputPosition: {
+                    align: 'center',
+                    x: -5
+                }
+            }
+        }
+    },
+    {
+        condition: {
+            maxWidth: 598,
+            minWidth: 570
+        },
+        chartOptions: {
+            rangeSelector: {
+                buttonPosition: {
+                    x: 65
+                },
+                inputPosition: {
+                    align: 'center',
+                    x: -20
+                }
+            },
+        }
+    }
+];


### PR DESCRIPTION
#### Contexto
Corrijo el alineamiento de los filtros de tiempo (selector de rangos y botones de selección) en los gráficos (tanto el componente exportable `Graphic` como el gráfico embebido en el _Detalle_ del `Explorer`), para que, según el ancho de los distintos viewports, se dispongan en una o dos filas (junto con el context menu para descargas). Para ello:
- Defino, en un archivo `responsiveFiltersAlignment.ts`, una constante con todas las reglas necesarias para que el componente de HighCharts sepa como actuar frente a distintos anchos de gráfico (tener en cuenta que el ancho del gráfico es siempre 30px menor que el del viewport).
- Defino reglas de alineamiento para **intervalos de a 30-40px** entre anchos de gráfico (ya que ese largo de intervalo es el umbral de máxima similitud entre viewports).
- El mínimo ancho de viewport posible considerado es de 320px (**290px** de gráfico), para el dispositivo `iPhone 5/SE` de las DevTools; por ende, el menor intervalo es de **0-300px** de gráfico.
- A partir de los 628px de viewport (**528px** de gráfico), hay suficiente espacio horizontal como para poner ambos filtros en una misma fila, uno a cada lado.
A su vez, agrego a los estilos del Explorer una regla para que los títulos muy largos de metadatos no se vean cortados al ser más largos que lo que un viewport pequeño permite.

#### Cómo probarlo
Abrir alguno de los archivos watcheables (por ejemplo `index.html` con `make watch` y probar que se visualicen bien dichos filtros de tiempo en los distitnos viewports de mobile posibles.

Closes #570