### PR TITLE
Agregar parametro ispercentage

### DIFF
--- a/src/components/exportable/CardExportable.tsx
+++ b/src/components/exportable/CardExportable.tsx
@@ -87,7 +87,8 @@ export default class CardExportable extends React.Component<ICardExportableProps
                 numbersAbbreviate: this.props.numbersAbbreviate,
                 source: this.props.source,
                 title: this.props.title,
-                units:this.props.units
+                units: this.props.units,
+                isPercentage: this.props.isPercentage 
             },
             downloadUrl: this.getDownloadUrl(),
             laps: this.state.laps,

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -37,7 +37,7 @@ export default (props: IFullCardProps) => {
         decimalsBillion: abbreviationProps.decimalsBillion,
         decimalsMillion: abbreviationProps.decimalsMillion,
         explicitSign: options.explicitSign,
-        isPercentage: props.cardOptions.isPercentage || props.serie.isPercentage,
+        isPercentage: props.cardOptions.isPercentage !== undefined ? props.cardOptions.isPercentage : props.serie.isPercentage,
         numbersAbbreviate: abbreviationProps.numbersAbbreviate
     }
     const formatter = new LocaleValueFormatter(formatterConfig);

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -37,7 +37,7 @@ export default (props: IFullCardProps) => {
         decimalsBillion: abbreviationProps.decimalsBillion,
         decimalsMillion: abbreviationProps.decimalsMillion,
         explicitSign: options.explicitSign,
-        isPercentage: props.serie.isPercentage,
+        isPercentage: props.cardOptions.isPercentage || props.serie.isPercentage,
         numbersAbbreviate: abbreviationProps.numbersAbbreviate
     }
     const formatter = new LocaleValueFormatter(formatterConfig);

--- a/src/indexCard.tsx
+++ b/src/indexCard.tsx
@@ -22,6 +22,7 @@ export interface ICardBaseConfig {
     numbersAbbreviate?: boolean;
     decimalsBillion?: number;
     decimalsMillion?: number;
+    isPercentage?: boolean;
 }
 
 export interface ICardExportableConfig extends ICardBaseConfig {
@@ -50,7 +51,8 @@ export function render(selector: string, config: ICardExportableConfig) {
                         decimals={config.decimals}
                         numbersAbbreviate={abbreviationProps.numbersAbbreviate}
                         decimalsBillion={abbreviationProps.decimalsBillion}
-                        decimalsMillion={abbreviationProps.decimalsMillion} />,
+                        decimalsMillion={abbreviationProps.decimalsMillion}
+                        isPercentage={config.isPercentage} />,
         document.getElementById(selector) as HTMLElement
     )
 


### PR DESCRIPTION
Se agrega el parametro isPercentage para la card, lo que hace que la card formatee el valor recibido por la api como porcentaje o no. En caso que no se envíe se usa el valor de la serie.

En este caso, el valor 0.1 = 10%, 10.0 = 1000%, y asi.

Para probarlo usar el comando `make components-watch` y probar poniendo o no este parametro en una card