### PR TITLE
514 - Nuevo componente Card de Previsualizacion

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -1,5 +1,36 @@
-/*---Roboto---*/
+/*---Fonts---*/
+
+/* Roboto */
 @import url("https://fonts.googleapis.com/css?family=Roboto:400,500,600&display=swap");
+/* Regular */
+@font-face {
+  font-family: 'Regular';
+  src: url('../fonts/roboto/Roboto-Regular.eot');
+  src: url('../fonts/roboto/Roboto-Regular.eot?#iefix') format('embedded-opentype'), url('../fonts/roboto/Roboto-Regular.woff') format('woff'), url('../fonts/roboto/Roboto-Regular.ttf') format('truetype'), url('../fonts/roboto/Roboto-Regular.svg#Roboto-Regular') format('svg');
+  font-weight: 300;
+  font-style: normal;
+  font-stretch: normal;
+}
+/* Medium */
+@font-face {
+  font-family: 'Medium';
+  src: url('../fonts/roboto/Roboto-Medium.eot');
+  src: url('../fonts/roboto/Roboto-Medium.eot?#iefix') format('embedded-opentype'), url('../fonts/roboto/Roboto-Medium.woff') format('woff'), url('../fonts/roboto/Roboto-Medium.ttf') format('truetype'), url('../fonts/roboto/Roboto-Medium.svg#Roboto-Medium') format('svg');
+  font-weight: 300;
+  font-style: normal;
+  font-stretch: normal;
+}
+/* Bold */
+@font-face {
+  font-family: 'Bold';
+  src: url('../fonts/roboto/Roboto-Bold.eot');
+  src: url('../fonts/roboto/Roboto-Bold.eot?#iefix') format('embedded-opentype'), url('../fonts/roboto/Roboto-Bold.woff') format('woff'), url('../fonts/roboto/Roboto-Bold.ttf') format('truetype'), url('../fonts/roboto/Roboto-Bold.svg#Roboto-Bold') format('svg');
+  font-weight: 300;
+  font-style: normal;
+  font-stretch: normal;
+}
+
+/*---Fin Fonts---*/
 
 /*---Graphic---*/
 
@@ -716,30 +747,171 @@ main a[href^="https://"][target^="_blank"]::after {
 
 /*---PreviewCard---*/
 
+.mg-lg-b {
+  margin-bottom: 30px;
+}
+
 .series-card {
-  animation-duration: 0.1s;
-  animation-iteration-count: 1;
+  animation-duration: .1s;
   animation-name: fadeInOpacity;
+  animation-iteration-count: 1;
   animation-timing-function: ease-in;
-  border-bottom-color: rgb(221, 221, 221);
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-image-outset: 0;
-  border-image-repeat: stretch;
-  border-image-slice: 100%;
-  border-image-source: none;
-  border-image-width: 1;
-  border-left-color: rgb(221, 221, 221);
-  border-left-style: solid;
-  border-left-width: 1px;
+  border: 1px solid #dddddd;
   border-radius: 5px;
-  border-right-color: rgb(153, 153, 153);
-  border-right-style: solid;
   border-right-width: 5px;
-  border-top-color: rgb(221, 221, 221);
-  border-top-style: solid;
-  border-top-width: 1px;
-  box-sizing: border-box;
+  border-right-style: solid;
+  border-right-color: #999999;
+  display: block;
+  font-family: "Regular", sans-serif;
+  height: 298px;
+  letter-spacing: normal;
+  line-height: 17.5px;
+  overflow: hidden;
+  padding: 22.5px;
+  position: relative;
+  text-align: left;
+  text-rendering: optimizeLegibility;
+  word-spacing: 0px;
+}
+
+.series-card:hover,
+.series-card:focus {
+  border-top-color: #999999;
+  border-bottom-color: #999999;
+  border-left-color: #999999;
+  cursor: pointer;
+}
+
+.series-card .row {
+  margin-left: -15px;
+  margin-right: -15px !important;
+  padding: 0;
+  width: 100%; 
+}
+
+.series-card .card-title,
+.series-card .card-desc {
+  margin-bottom: 7.5px;
+}
+
+.series-card .card-title {
+  color: #3e3e3e;
+  display: -webkit-box;
+  font-family: 'Medium';
+  font-size: 24px;
+  line-height: 30px;
+  margin-top: 0px;
+  padding: 0px;
+  -moz-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.series-card .card-desc {
+  display: -webkit-box;
+  height: auto;
+  overflow: hidden;
+  -moz-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.series-card .card-desc p {
+  color: #757575;
+  margin-bottom: 0;
+}
+
+.series-card .card-info {
+  color: rgb(153, 153, 153);
+  display: -webkit-box;
+  font-size: 12px;
+  letter-spacing: normal;
+  overflow: hidden;
+  -moz-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.series-card .card-info strong {
+  font-family: "Bold";
+  font-weight: 400;
+}
+
+.series-card .d3-line-chart {
+  float: right;
+  margin-top: 20px;
+}
+
+.series-card .d3-line-chart .units .date, 
+.series-card .d3-line-chart .units .value {
+  font-weight: 700;
+}
+
+.series-card .d3-line-chart .units .date {
+  color: rgb(104, 104, 104);
+  font-size: 12px;
+}
+
+.series-card .d3-line-chart .units .value {
+  color: rgb(26, 150, 210);
+  font-size: 18px;
+}
+
+.series-card .d3-line-chart svg {
+  overflow: hidden;
+}
+
+.series-card .d3-line-chart .frequency {
+  color: rgb(104, 104, 104);
+  font-size: 10px;
+}
+
+.series-card .card-section,
+.series-card .card-count {
+  display: block;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.series-card .card-section {
+  color: #999999;
+}
+
+.series-card .card-count,
+.series-card .card-source {
+  color: #aaaaaa;
+}
+
+.series-card.card-small {
+  padding: 15px 22.5px;
+}
+
+.series-card.card-has-check {
+  padding-right: 45px;
+}
+
+.series-card.card-has-check .card-check {
+  position: absolute;
+  z-index: 9;
+  top: 50%;
+  right: 15px;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  -o-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.series-card.card-has-check .card-check i {
+  font-size: 30px;
+  color: #0897D7;
+}
+
+@media (max-width: 767px) { /* Mobile viewport */
+  .series-card {
+    height: auto !important;
+  }
+  .series-card .card-title {
+    font-size: 18px;
+  }
 }
 
 /*---Fin PreviewCard---*/

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -714,6 +714,36 @@ main a[href^="https://"][target^="_blank"]::after {
 
 /*---Fin Card---*/
 
+/*---PreviewCard---*/
+
+.series-card {
+  animation-duration: 0.1s;
+  animation-iteration-count: 1;
+  animation-name: fadeInOpacity;
+  animation-timing-function: ease-in;
+  border-bottom-color: rgb(221, 221, 221);
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-image-outset: 0;
+  border-image-repeat: stretch;
+  border-image-slice: 100%;
+  border-image-source: none;
+  border-image-width: 1;
+  border-left-color: rgb(221, 221, 221);
+  border-left-style: solid;
+  border-left-width: 1px;
+  border-radius: 5px;
+  border-right-color: rgb(153, 153, 153);
+  border-right-style: solid;
+  border-right-width: 5px;
+  border-top-color: rgb(221, 221, 221);
+  border-top-style: solid;
+  border-top-width: 1px;
+  box-sizing: border-box;
+}
+
+/*---Fin PreviewCard---*/
+
 /*---Iconos---*/
 
 .fa-angle-up, .fa-link, .caret {

--- a/src/components/d3_charts/D3SeriesChart.tsx
+++ b/src/components/d3_charts/D3SeriesChart.tsx
@@ -125,5 +125,5 @@ function mapStateToProps(state: IStore) {
     };
 }
 
-
-export default connect(mapStateToProps)(D3SeriesChart);
+export const UnconnectedD3SeriesChart = D3SeriesChart;
+export const ConnectedD3SeriesChart = connect(mapStateToProps)(D3SeriesChart);

--- a/src/components/exportable/PreviewCardExportable.tsx
+++ b/src/components/exportable/PreviewCardExportable.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { ApiClient } from "../../api/ApiClient";
+import QueryParams from "../../api/QueryParams";
+import { ISerie } from "../../api/Serie";
+import SerieApi, { METADATA } from "../../api/SerieApi";
+import { IPreviewCardExportableConfig } from "../../indexPreviewCard";
+import PreviewCardContainer from "../style/ExportablePreviewCard/PreviewCardContainer";
+import SerieCardWithChart from "../style/Card/Serie/SerieCardWithChart";
+
+// import FullCardValue from "../style/exportable_card/FullCardValue";
+
+type IPreviewCardExportableProps = IPreviewCardExportableConfig;
+
+interface IPreviewCardExportableState {
+    serie: ISerie | null;
+}
+
+export default class PreviewCardExportable extends React.Component<IPreviewCardExportableProps, IPreviewCardExportableState> {
+
+    private seriesApi: SerieApi;
+
+    public constructor(props: any) {
+        super(props);
+
+        this.seriesApi = new SerieApi(new ApiClient(props.apiBaseUrl || getAPIDefaultURI(), 'ts-components-preview'));
+
+        this.state = {
+            serie: null
+        }
+    }
+
+    public componentDidMount() {
+        const params = new QueryParams([this.props.serieId]);
+        params.setLast(5000);
+        params.setMetadata(METADATA.FULL);
+        this.fetchSeries(params);
+    }
+
+    public render() {
+
+        if (!this.state.serie) { return null }
+        return(
+            <PreviewCardContainer clickTarget={getClickTarget(this.props)}>
+                <SerieCardWithChart serie={this.state.serie}
+                                    locale="AR"
+                                    maxDecimals={2}
+                                    numbersAbbreviate={true}
+                                    decimalsBillion={2}
+                                    decimalsMillion={2} />
+            </PreviewCardContainer>
+        );
+        /* <SerieCardWithChart serie={this.state.serie}
+                                    locale="AR"
+                                    maxDecimals={2}
+                                    numbersAbbreviate={true}
+                                    decimalsBillion={2}
+                                    decimalsMillion={2} /> */
+
+    }
+
+    private fetchSeries(params: QueryParams) {
+        this.seriesApi.fetchSeries(params)
+            .then((series: ISerie[]) => {
+                this.setState({
+                    serie: series[0]
+                })
+            })
+    }
+
+}
+
+function getAPIDefaultURI(): string {
+    return `https://apis.datos.gob.ar/series/api`
+}
+
+const SERIES_EXPLORER_DEFAULT_URL = "https://datos.gob.ar/series/api/series";
+
+export function getClickTarget(config: IPreviewCardExportableConfig): string {
+
+    const baseUrl: string = config.explorerUrl || config.apiBaseUrl || SERIES_EXPLORER_DEFAULT_URL;
+    return `${baseUrl}/?ids=${config.serieId}`;
+
+}

--- a/src/components/exportable/PreviewCardExportable.tsx
+++ b/src/components/exportable/PreviewCardExportable.tsx
@@ -46,7 +46,8 @@ export default class PreviewCardExportable extends React.Component<IPreviewCardE
                                     maxDecimals={2}
                                     numbersAbbreviate={true}
                                     decimalsBillion={2}
-                                    decimalsMillion={2} />
+                                    decimalsMillion={2}
+                                    connectedChart={false} />
             </PreviewCardContainer>
         );
         /* <SerieCardWithChart serie={this.state.serie}

--- a/src/components/exportable/PreviewCardExportable.tsx
+++ b/src/components/exportable/PreviewCardExportable.tsx
@@ -1,19 +1,22 @@
 import * as React from "react";
 import { ApiClient } from "../../api/ApiClient";
 import QueryParams from "../../api/QueryParams";
-import { ISerie } from "../../api/Serie";
+import { DEFAULT_SIGNIFICANT_FIGURES, ISerie } from "../../api/Serie";
 import SerieApi, { METADATA } from "../../api/SerieApi";
+import { buildAbbreviationProps } from "../../helpers/common/numberAbbreviation";
 import { IPreviewCardExportableConfig } from "../../indexPreviewCard";
-import PreviewCardContainer from "../style/ExportablePreviewCard/PreviewCardContainer";
 import SerieCardWithChart from "../style/Card/Serie/SerieCardWithChart";
+import PreviewCardContainer from "../style/ExportablePreviewCard/PreviewCardContainer";
+import { getAPIDefaultURI, getClickTarget } from "../../helpers/previewCard/linkGenerators";
 
-// import FullCardValue from "../style/exportable_card/FullCardValue";
 
 type IPreviewCardExportableProps = IPreviewCardExportableConfig;
 
 interface IPreviewCardExportableState {
     serie: ISerie | null;
 }
+
+const DEFAULT_PREVIEW_CARD_WIDTH = "100%";
 
 export default class PreviewCardExportable extends React.Component<IPreviewCardExportableProps, IPreviewCardExportableState> {
 
@@ -38,24 +41,20 @@ export default class PreviewCardExportable extends React.Component<IPreviewCardE
 
     public render() {
 
-        if (!this.state.serie) { return null }
+        if (!this.state.serie) { return null; }
+
+        const abbreviationProps = buildAbbreviationProps(this.props.numbersAbbreviate, this.props.decimalsBillion, this.props.decimalsMillion);
         return(
-            <PreviewCardContainer clickTarget={getClickTarget(this.props)}>
+            <PreviewCardContainer clickTarget={getClickTarget(this.props)} width={this.props.width || DEFAULT_PREVIEW_CARD_WIDTH }>
                 <SerieCardWithChart serie={this.state.serie}
                                     locale="AR"
-                                    maxDecimals={2}
-                                    numbersAbbreviate={true}
-                                    decimalsBillion={2}
-                                    decimalsMillion={2}
+                                    maxDecimals={this.props.maxDecimals || DEFAULT_SIGNIFICANT_FIGURES}
+                                    numbersAbbreviate={abbreviationProps.numbersAbbreviate}
+                                    decimalsBillion={abbreviationProps.decimalsBillion}
+                                    decimalsMillion={abbreviationProps.decimalsMillion}
                                     connectedChart={false} />
             </PreviewCardContainer>
         );
-        /* <SerieCardWithChart serie={this.state.serie}
-                                    locale="AR"
-                                    maxDecimals={2}
-                                    numbersAbbreviate={true}
-                                    decimalsBillion={2}
-                                    decimalsMillion={2} /> */
 
     }
 
@@ -67,18 +66,5 @@ export default class PreviewCardExportable extends React.Component<IPreviewCardE
                 })
             })
     }
-
-}
-
-function getAPIDefaultURI(): string {
-    return `https://apis.datos.gob.ar/series/api`
-}
-
-const SERIES_EXPLORER_DEFAULT_URL = "https://datos.gob.ar/series/api/series";
-
-export function getClickTarget(config: IPreviewCardExportableConfig): string {
-
-    const baseUrl: string = config.explorerUrl || config.apiBaseUrl || SERIES_EXPLORER_DEFAULT_URL;
-    return `${baseUrl}/?ids=${config.serieId}`;
 
 }

--- a/src/components/style/Card/Serie/LinkedSerieCardWithChart.tsx
+++ b/src/components/style/Card/Serie/LinkedSerieCardWithChart.tsx
@@ -8,5 +8,6 @@ import SerieCardWithChart from "./SerieCardWithChart";
 export default (props: ISerieCardProps) =>
 
     <Link to={`/series/?ids=${props.serie.id}`}>
-        <SerieCardWithChart {...props}/>
+        <SerieCardWithChart {...props}
+                            connectedChart={true}/>
     </Link>

--- a/src/components/style/Card/Serie/SerieCardWithChart.tsx
+++ b/src/components/style/Card/Serie/SerieCardWithChart.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { formattedHits90Days } from '../../../../helpers/common/LocaleValueFormatter';
 import { IAbbreviationProps } from '../../../../helpers/common/numberAbbreviation';
-import D3SeriesChart from "../../../d3_charts/D3SeriesChart";
+import { ConnectedD3SeriesChart, UnconnectedD3SeriesChart } from "../../../d3_charts/D3SeriesChart";
 import Row from "../../Common/Row";
 import Card from "../Card";
 import CardBody from "../CardBody";
@@ -9,8 +9,11 @@ import CardSubtitle from "../CardSubtitle";
 import CardTitle from "../CardTitle";
 import { ISerieCardProps } from "./SerieCard";
 
+interface ISerieCardWithChartProps extends ISerieCardProps {
+    connectedChart: boolean;
+}
 
-export default (props: ISerieCardProps) => {
+export default (props: ISerieCardWithChartProps) => {
 
     const abbreviateProps: IAbbreviationProps = {
         decimalsBillion: props.decimalsBillion,
@@ -18,6 +21,35 @@ export default (props: ISerieCardProps) => {
         numbersAbbreviate: props.numbersAbbreviate
     }
     const hits90Days = formattedHits90Days(props.locale, abbreviateProps, props.serie.hits90Days);
+
+    let D3SeriesChart = props.connectedChart ? ConnectedD3SeriesChart : UnconnectedD3SeriesChart;
+    const seriesChartProps = {
+        decimalsBillion: props.decimalsBillion,
+        decimalsMillion: props.decimalsMillion,
+        frequency: props.serie.accrualPeriodicity,
+        laps: {
+            Anual: 10,
+            Diaria: 90,
+            Mensual: 24,
+            Semestral: 10,
+            Trimestral: 20,
+        },
+        locale: props.locale,
+        maxDecimals: props.maxDecimals,
+        numbersAbbreviate: props.numbersAbbreviate,
+        serie: props.serie
+    };
+    if (!props.connectedChart) {
+        D3SeriesChart = UnconnectedD3SeriesChart;
+        seriesChartProps.laps = {
+            Anual: 10,
+            Diaria: 90,
+            Mensual: 24,
+            Semestral: 10,
+            Trimestral: 20,
+        }
+    }
+
 
     return(
         <Card title={props.serie.title} {...props}>
@@ -39,12 +71,7 @@ export default (props: ISerieCardProps) => {
             </div>
 
             <div className="col-sm-4 col-xs-12 d3-line-chart-container">
-                <D3SeriesChart serie={props.serie}
-                               frequency={props.serie.accrualPeriodicity} 
-                               maxDecimals={props.maxDecimals} 
-                               numbersAbbreviate={props.numbersAbbreviate} 
-                               decimalsBillion={props.decimalsBillion} 
-                               decimalsMillion={props.decimalsMillion} />
+                <D3SeriesChart {...seriesChartProps} />
             </div>
         </Row>
     </Card>

--- a/src/components/style/ExportablePreviewCard/PreviewCardContainer.tsx
+++ b/src/components/style/ExportablePreviewCard/PreviewCardContainer.tsx
@@ -3,6 +3,11 @@ import * as React from 'react';
 
 export interface IPreviewCardContainerProps extends React.HTMLProps<HTMLDivElement> {
     clickTarget: string;
+    width: string;
+}
+
+interface IPreviewCardContainerStyle {
+    width: string;
 }
 
 export default class PreviewCardContainer extends React.Component<IPreviewCardContainerProps> {
@@ -15,11 +20,17 @@ export default class PreviewCardContainer extends React.Component<IPreviewCardCo
     }
 
     public render() {
+
+        const containerStyle: IPreviewCardContainerStyle = {
+            width: this.props.width
+        }
+
         return (
-            <div className="p-container" onClick={this.clickHandling}>
+            <div className="p-container" onClick={this.clickHandling} style={containerStyle}>
                 {this.props.children}
             </div>
         );
+
     }
 
     public clickHandling() {

--- a/src/components/style/ExportablePreviewCard/PreviewCardContainer.tsx
+++ b/src/components/style/ExportablePreviewCard/PreviewCardContainer.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+
+export interface IPreviewCardContainerProps extends React.HTMLProps<HTMLDivElement> {
+    clickTarget: string;
+}
+
+export default class PreviewCardContainer extends React.Component<IPreviewCardContainerProps> {
+  
+    constructor(props: IPreviewCardContainerProps) {
+
+        super(props);
+        this.clickHandling = this.clickHandling.bind(this);
+
+    }
+
+    public render() {
+        return (
+            <div className="p-container" onClick={this.clickHandling}>
+                <p>Holis</p>
+                {this.props.children}
+            </div>
+        );
+    }
+
+    public clickHandling() {
+        window.open(this.props.clickTarget, '_blank');
+    }
+
+}

--- a/src/components/style/ExportablePreviewCard/PreviewCardContainer.tsx
+++ b/src/components/style/ExportablePreviewCard/PreviewCardContainer.tsx
@@ -17,7 +17,6 @@ export default class PreviewCardContainer extends React.Component<IPreviewCardCo
     public render() {
         return (
             <div className="p-container" onClick={this.clickHandling}>
-                <p>Holis</p>
                 {this.props.children}
             </div>
         );

--- a/src/helpers/previewCard/linkGenerators.ts
+++ b/src/helpers/previewCard/linkGenerators.ts
@@ -1,0 +1,19 @@
+import { IPreviewCardExportableConfig } from "../../indexPreviewCard";
+
+export function getAPIDefaultURI(): string {
+    return `https://apis.datos.gob.ar/series/api`
+}
+
+const SERIES_EXPLORER_DEFAULT_URL = "https://datos.gob.ar/series/api/series";
+
+export function getClickTarget(config: IPreviewCardExportableConfig): string {
+
+    if (config.explorerUrl) {
+        return `${config.explorerUrl}/?ids=${config.serieId}`;
+    }
+    if (config.apiBaseUrl) {
+        return `${config.apiBaseUrl}/series/?metadata=full&ids=${config.serieId}&last=5000`;
+    }
+    return `${SERIES_EXPLORER_DEFAULT_URL}/?ids=${config.serieId}`;;
+
+}

--- a/src/indexComponents.tsx
+++ b/src/indexComponents.tsx
@@ -1,6 +1,8 @@
 import * as Card from './indexCard';
 import * as Graphic from './indexGraphic';
+import * as PreviewCard from './indexPreviewCard';
 
 
 export { Graphic };
 export { Card };
+export { PreviewCard };

--- a/src/indexPreviewCard.tsx
+++ b/src/indexPreviewCard.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import PreviewCardExportable from "./components/exportable/PreviewCardExportable";
+
+export interface IPreviewCardExportableConfig {
+    apiBaseUrl?: string;
+    explorerUrl?: string;
+    serieId: string;
+}
+
+export function render(selector: string, config: IPreviewCardExportableConfig) {
+
+    ReactDOM.render(
+        <PreviewCardExportable serieId={config.serieId}
+                               apiBaseUrl={config.apiBaseUrl}
+                               explorerUrl={config.explorerUrl} />,
+        document.getElementById(selector) as HTMLElement
+    )
+
+}

--- a/src/indexPreviewCard.tsx
+++ b/src/indexPreviewCard.tsx
@@ -4,8 +4,13 @@ import PreviewCardExportable from "./components/exportable/PreviewCardExportable
 
 export interface IPreviewCardExportableConfig {
     apiBaseUrl?: string;
+    decimalsBillion?: number;
+    decimalsMillion?: number;
     explorerUrl?: string;
+    maxDecimals?: number;
+    numbersAbbreviate?: boolean;
     serieId: string;
+    width?: string;
 }
 
 export function render(selector: string, config: IPreviewCardExportableConfig) {
@@ -13,7 +18,12 @@ export function render(selector: string, config: IPreviewCardExportableConfig) {
     ReactDOM.render(
         <PreviewCardExportable serieId={config.serieId}
                                apiBaseUrl={config.apiBaseUrl}
-                               explorerUrl={config.explorerUrl} />,
+                               explorerUrl={config.explorerUrl}
+                               maxDecimals={config.maxDecimals}
+                               numbersAbbreviate={config.numbersAbbreviate}
+                               decimalsBillion={config.decimalsBillion}
+                               decimalsMillion={config.decimalsMillion}
+                               width={config.width} />,
         document.getElementById(selector) as HTMLElement
     )
 

--- a/src/tests/components/helpers/PreviewCardLinkGenerators.test.ts
+++ b/src/tests/components/helpers/PreviewCardLinkGenerators.test.ts
@@ -1,0 +1,37 @@
+import { IPreviewCardExportableConfig } from "../../../indexPreviewCard";
+import { getClickTarget } from "../../../helpers/previewCard/linkGenerators";
+
+describe("Tests for generation of the target URL to open when clicking on the PreviewCard", () => {
+
+    let config: IPreviewCardExportableConfig ;
+    let clickTarget: string;
+
+    beforeEach(() => {
+        config = {
+            serieId: "103.1_I2N_2016_M_15"
+        }
+    })
+
+    it("If no URL for the Explorer is defined, the default one is used as prefix", () => {
+        clickTarget = getClickTarget(config);
+        expect(clickTarget).toEqual("https://datos.gob.ar/series/api/series/?ids=103.1_I2N_2016_M_15");
+    });
+    it("If only a Base URL for the API is defined, it is used as a prefix", () => {
+        config.apiBaseUrl = "https://my.api.com";
+        clickTarget = getClickTarget(config);
+        expect(clickTarget).toEqual("https://my.api.com/series/?metadata=full&ids=103.1_I2N_2016_M_15&last=5000");
+    });
+    it("If only a URL for the Explorer is defined, it is used as a prefix", () => {
+        config.explorerUrl = "https://custom.series.explorer.com";
+        clickTarget = getClickTarget(config);
+        expect(clickTarget).toEqual("https://custom.series.explorer.com/?ids=103.1_I2N_2016_M_15"); 
+    });
+    it("If both URLs are defined as params, the Explorer one is used as prefix", () => {
+        config.apiBaseUrl = "https://base.api.com";
+        config.explorerUrl = "https://explorer.net";
+        clickTarget = getClickTarget(config);
+        expect(clickTarget).toEqual("https://explorer.net/?ids=103.1_I2N_2016_M_15"); 
+    })
+    
+
+})


### PR DESCRIPTION
#### Contexto
Agrego un nuevo componente exportable, `PreviewCard`, el cual es equivalente a las tarjetas de previsualización de series usadas en las secciones de _Destacados_, _Búsqueda_ y _Agregar Series_ del `Explorer`. El mismo posee varios parámetros, los cuales son `serieId` (el único obligatorio, el ID de la serie a representar), `maxDecimals`, `numbersAbbreviate`, `decimalsMillion`, `decimalsBillion` (análogos a los del `Explorer`), `apiBaseUrl` (para especificar la URL de la API a la cual pedir los datos), `explorerUrl` (la URL de la instancia del Explorer donde visualizar la serie), y `width` (para elegir el ancho del componente, ya sea en pixeles o un porcentaje del `div` contenedor). La tarjeta es clickeable y, al hacerlo, abre otra pestaña:
- Si se especificó `explorerUrl`, va a la visualización en esa URL de la serie representada.
- Si no se especificó URL del Explorer pero sí `apiBaseURL`, se va a la API Response de dicha API para la serie representada, en formato JSON.
- Si no se especificó ninguna de las dos, va a datos.gob.ar, en la visualización de la serie representada.

A su vez, agregué sus estilos CSS al `components.css`, ya que las versiones del componente irán de la mano con las releases de los componentes del repo.
Para reutilizar los componentes `D3SeriesWithChart` y `SeriesCardWithChart` que ya estaban siendo usados en el `Explorer`, creo una versión no conectada al store de Redux del primero, distinguiéndola de la ya existente (conectada).

#### Cómo probarlo
Ejecutando el watcheable, en el `components.html` agregar algún `div` que en el tag de `script` inferior renderee un `TSComponents.PreviewCard`, probando el uso de sus distintos parámetros y los sitios abiertos al clickear. 

Closes #514 