### PR TITLE
473 - Reubico input de rango cronologico del Graphic exportable

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -199,6 +199,12 @@ div.highcharts-tooltip-box span table tbody tr td span.tooltip-value {
   overflow: hidden;
 }
 
+.highcharts-range-selector:focus {
+  top: 75px !important;
+  width: 95px !important;
+  height: 25px !important;
+}
+
 /*---Fin Graphic---*/
 
 


### PR DESCRIPTION
#### Contexto
Agrego estilos al `components.css` para que el input del rango cronológico del componente exportable `Graphic` se ubique correctamente, y no sobre el label de dicho rango.

#### Cómo probarlo
Con el `components.html` watcheable mediante `make components-watch`, clickear en el rango cronológico del `Graphic`, y verificar que el input editable se posicione sobre el gráfico y no sobre el rango en sí.

Closes #473 
