### PR TITLE
294 - Selectores para GraphicExportable

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -199,6 +199,12 @@ div.highcharts-tooltip-box span table tbody tr td span.tooltip-value {
   overflow: hidden;
 }
 
+div.g-pickers-container {
+  margin-top: 20px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
 /*---Fin Graphic---*/
 
 

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -38,7 +38,7 @@
   width: 100%;
 }
 
-.exportable-graph div { /* Force highcharts to set the height from container */
+.exportable-graph div:not(.g-pickers-container, [data-highcharts-chart]) { /* Force highcharts to set the height from container */
   height: 100%;
 }
 

--- a/public/components.html
+++ b/public/components.html
@@ -33,7 +33,46 @@ body {
 </style>
 
 <body>
-    
+    <div class="row">
+        <div class="title">
+            <h3>Card: default</h3></div>
+        <div id='ipc-card' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='exportaciones-card' class="col-xs-12 col-sm-6 col-md-3"> </div>
+        <div id='superavit-card' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='desempleo-card' class="col-xs-12 col-sm-6 col-md-3"></div>
+    </div>
+    <div class="row">
+        <div class="title">
+            <h3>Card: menos links</h3></div>
+        <div id='ipc-card-links2' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='exportaciones-card-links2' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='superavit-card-links2' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='desempleo-card-links2' class="col-xs-12 col-sm-6 col-md-3"></div>
+    </div>
+    <div class="row">
+        <div class="title">
+            <h3>Card: sin links</h3></div>
+        <div id='ipc-card-med' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='exportaciones-card-med' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='superavit-card-med' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='desempleo-card-med' class="col-xs-12 col-sm-6 col-md-3"></div>
+    </div>
+    <div class="row">
+        <div class="title">
+            <h3>Card: mínima</h3></div>
+        <div id='ipc-card-min' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='exportaciones-card-min' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='superavit-card-min' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='desempleo-card-min' class="col-xs-12 col-sm-6 col-md-3"></div>
+    </div>
+    <div class="row">
+        <div class="title">
+            <h3>Card: mínima (eliminando elementos)</h3></div>
+        <div id='ipc-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='exportaciones-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='superavit-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
+        <div id='desempleo-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
+    </div>
     <div class="row row-graphic">
         <div class="title">
             <h3>Graphic: full</h3></div>
@@ -55,6 +94,145 @@ body {
     <script>
     window.onload = function() {
         // componentes de series de tiempo
+
+        TSComponents.Card.render('ipc-card', {
+            serieId: '116.4_TCRZE_2015_D_36_4',
+            color: '#F9A822',
+            hasChart: 'small',
+            title: "Indice de Precios al Consumidor Nacional"
+        })
+        TSComponents.Card.render('exportaciones-card', {
+            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+            explicitSign: true,
+            hasChart: 'small',
+            title: "Exportaciones"
+        })
+        TSComponents.Card.render('superavit-card', {
+            serieId: '372.6_SUPERAVIT_017__23_67',
+            hasChart: 'small',
+            title: "Resultado Primario del Sector Público No Fin."
+        })
+        TSComponents.Card.render('desempleo-card', {
+            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            color: '#EC407A',
+            hasChart: 'small',
+            title: "Desocupación"
+        })
+        TSComponents.Card.render('ipc-card-links2', {
+            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+            color: '#F9A822',
+            hasChart: 'small',
+            links: "small",
+            title: "Indice de Precios al Consumidor Nacional"
+        })
+        TSComponents.Card.render('exportaciones-card-links2', {
+            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+            explicitSign: true,
+            hasChart: 'small',
+            links: "small",
+            title: "Exportaciones"
+        })
+        TSComponents.Card.render('superavit-card-links2', {
+            serieId: '372.6_SUPERAVIT_017__23_67',
+            hasChart: 'small',
+            links: "small",
+            title: "Resultado Primario del Sector Público No Fin."
+        })
+        TSComponents.Card.render('desempleo-card-links2', {
+            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            color: '#EC407A',
+            hasChart: 'small',
+            links: "small",
+            title: "Desocupación"
+        })
+        TSComponents.Card.render('ipc-card-med', {
+            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+            color: '#F9A822',
+            hasChart: 'small',
+            links: "none",
+            title: "Indice de Precios al Consumidor Nacional"
+        })
+        TSComponents.Card.render('exportaciones-card-med', {
+            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+            explicitSign: true,
+            hasChart: 'small',
+            links: "none",
+            title: "Exportaciones"
+        })
+        TSComponents.Card.render('superavit-card-med', {
+            serieId: '372.6_SUPERAVIT_017__23_67',
+            hasChart: 'small',
+            links: "none",
+            title: "Resultado Primario del Sector Público No Fin."
+        })
+        TSComponents.Card.render('desempleo-card-med', {
+            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            color: '#EC407A',
+            hasChart: 'small',
+            links: "none",
+            title: "Desocupación"
+        })
+        TSComponents.Card.render('ipc-card-min', {
+            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+            color: '#F9A822',
+            links: 'none',
+            hasChart: "none",
+            title: "Indice de Precios al Consumidor Nacional"
+        })
+        TSComponents.Card.render('exportaciones-card-min', {
+            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+            explicitSign: true,
+            links: 'none',
+            hasChart: "none",
+            title: "Exportaciones"
+        })
+        TSComponents.Card.render('superavit-card-min', {
+            serieId: '372.6_SUPERAVIT_017__23_67',
+            links: 'none',
+            hasChart: "none",
+            title: "Resultado Primario del Sector Público No Fin."
+        })
+        TSComponents.Card.render('desempleo-card-min', {
+            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            color: '#EC407A',
+            links: 'none',
+            hasChart: "none",
+            title: "Desocupación"
+        })
+        TSComponents.Card.render('ipc-card-min-xtreme', {
+            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+            links: 'none',
+            hasChart: "none",
+            title: "",
+            units: "",
+            source: ""
+        })
+        TSComponents.Card.render('exportaciones-card-min-xtreme', {
+            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+            explicitSign: true,
+            links: 'none',
+            hasChart: "none",
+            title: "",
+            units: "",
+            source: ""
+        })
+        TSComponents.Card.render('superavit-card-min-xtreme', {
+            serieId: '372.6_SUPERAVIT_017__23_67',
+            links: 'none',
+            hasChart: "none",
+            title: "",
+            units: "",
+            source: ""
+        })
+        TSComponents.Card.render('desempleo-card-min-xtreme', {
+            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            color: '#EC407A',
+            links: 'none',
+            hasChart: "none",
+            title: "",
+            units: "",
+            source: ""
+        })
 
         TSComponents.Graphic.render('tcrm-graphic', {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=143.3_NO_PR_2004_A_21:percent_change_a_year_ago,116.4_TCRZE_2015_D_36_4&limit=1000&start=0',
@@ -93,13 +271,21 @@ body {
             navigator: false,
             datePickerEnabled: false,
             title: "Inflación interanual (nivel general)",
+            chartTypeSelector: false,
+            unitsSelector: false,
+            aggregationSelector: false,
+            frequencySelector: false
         })
 
         TSComponents.Graphic.render('rem-graphic-min', {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=430.1_MEDIANA_IP_12_M_0_0_27_96',
             navigator: false,
             datePickerEnabled: false,
-            title: "REM mediana de expectativas de inflación a 12 meses"
+            title: "REM mediana de expectativas de inflación a 12 meses",
+            chartTypeSelector: false,
+            unitsSelector: false,
+            aggregationSelector: false,
+            frequencySelector: false
         })
 
         TSComponents.Graphic.render('tcbna-graphic-min', {
@@ -108,7 +294,9 @@ body {
             datePickerEnabled: false,
             title: "Tipo de Cambio Vendedor (BNA)",
             chartTypeSelector: false,
-            unitsSelector: false
+            unitsSelector: false,
+            aggregationSelector: false,
+            frequencySelector: false
         })
 
 

--- a/public/components.html
+++ b/public/components.html
@@ -33,7 +33,7 @@ body {
 </style>
 
 <body>
-    <!-- <div class="row">
+    <div class="row">
         <div class="title">
             <h3>Card: default</h3></div>
         <div id='ipc-card' class="col-xs-12 col-sm-6 col-md-3"></div>
@@ -72,13 +72,13 @@ body {
         <div id='exportaciones-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
         <div id='superavit-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
         <div id='desempleo-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
-    </div> -->
+    </div>
     <div class="row row-graphic">
         <div class="title">
             <h3>Graphic: full</h3></div>
         <div id='tcrm-graphic' style="height: 800px;"></div>
     </div>
-    <!-- <div class="row row-graphic">
+    <div class="row row-graphic">
         <div class="title">
             <h3>Graphic: sin filtros de tiempo</h3></div>
         <div id='emae-graphic-without-filters' class="col-xs-12 col-sm-6 col-md-6" style="height: 700px;"></div>
@@ -90,216 +90,210 @@ body {
         <div id='ipc-graphic-min' class="col-xs-12 col-sm-6 col-md-4" style="height: 400px;"></div>
         <div id='rem-graphic-min' class="col-xs-12 col-sm-6 col-md-4" style="height: 400px;"></div>
         <div id='tcbna-graphic-min' class="col-xs-12 col-sm-6 col-md-4" style="height: 400px;"></div>
-    </div> -->
+    </div>
     <script>
     window.onload = function() {
         // componentes de series de tiempo
 
-        // TSComponents.Card.render('ipc-card', {
-        //     serieId: '116.4_TCRZE_2015_D_36_4',
-        //     color: '#F9A822',
-        //     hasChart: 'small',
-        //     title: "Indice de Precios al Consumidor Nacional"
-        // })
-        // TSComponents.Card.render('exportaciones-card', {
-        //     serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-        //     explicitSign: true,
-        //     hasChart: 'small',
-        //     title: "Exportaciones"
-        // })
-        // TSComponents.Card.render('superavit-card', {
-        //     serieId: '372.6_SUPERAVIT_017__23_67',
-        //     hasChart: 'small',
-        //     title: "Resultado Primario del Sector Público No Fin."
-        // })
-        // TSComponents.Card.render('desempleo-card', {
-        //     serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-        //     color: '#EC407A',
-        //     hasChart: 'small',
-        //     title: "Desocupación"
-        // })
-        // TSComponents.Card.render('ipc-card-links2', {
-        //     serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-        //     color: '#F9A822',
-        //     hasChart: 'small',
-        //     links: "small",
-        //     title: "Indice de Precios al Consumidor Nacional"
-        // })
-        // TSComponents.Card.render('exportaciones-card-links2', {
-        //     serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-        //     explicitSign: true,
-        //     hasChart: 'small',
-        //     links: "small",
-        //     title: "Exportaciones"
-        // })
-        // TSComponents.Card.render('superavit-card-links2', {
-        //     serieId: '372.6_SUPERAVIT_017__23_67',
-        //     hasChart: 'small',
-        //     links: "small",
-        //     title: "Resultado Primario del Sector Público No Fin."
-        // })
-        // TSComponents.Card.render('desempleo-card-links2', {
-        //     serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-        //     color: '#EC407A',
-        //     hasChart: 'small',
-        //     links: "small",
-        //     title: "Desocupación"
-        // })
-        // TSComponents.Card.render('ipc-card-med', {
-        //     serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-        //     color: '#F9A822',
-        //     hasChart: 'small',
-        //     links: "none",
-        //     title: "Indice de Precios al Consumidor Nacional"
-        // })
-        // TSComponents.Card.render('exportaciones-card-med', {
-        //     serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-        //     explicitSign: true,
-        //     hasChart: 'small',
-        //     links: "none",
-        //     title: "Exportaciones"
-        // })
-        // TSComponents.Card.render('superavit-card-med', {
-        //     serieId: '372.6_SUPERAVIT_017__23_67',
-        //     hasChart: 'small',
-        //     links: "none",
-        //     title: "Resultado Primario del Sector Público No Fin."
-        // })
-        // TSComponents.Card.render('desempleo-card-med', {
-        //     serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-        //     color: '#EC407A',
-        //     hasChart: 'small',
-        //     links: "none",
-        //     title: "Desocupación"
-        // })
-        // TSComponents.Card.render('ipc-card-min', {
-        //     serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-        //     color: '#F9A822',
-        //     links: 'none',
-        //     hasChart: "none",
-        //     title: "Indice de Precios al Consumidor Nacional"
-        // })
-        // TSComponents.Card.render('exportaciones-card-min', {
-        //     serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-        //     explicitSign: true,
-        //     links: 'none',
-        //     hasChart: "none",
-        //     title: "Exportaciones"
-        // })
-        // TSComponents.Card.render('superavit-card-min', {
-        //     serieId: '372.6_SUPERAVIT_017__23_67',
-        //     links: 'none',
-        //     hasChart: "none",
-        //     title: "Resultado Primario del Sector Público No Fin."
-        // })
-        // TSComponents.Card.render('desempleo-card-min', {
-        //     serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-        //     color: '#EC407A',
-        //     links: 'none',
-        //     hasChart: "none",
-        //     title: "Desocupación"
-        // })
-        // TSComponents.Card.render('ipc-card-min-xtreme', {
-        //     serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-        //     links: 'none',
-        //     hasChart: "none",
-        //     title: "",
-        //     units: "",
-        //     source: ""
-        // })
-        // TSComponents.Card.render('exportaciones-card-min-xtreme', {
-        //     serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-        //     explicitSign: true,
-        //     links: 'none',
-        //     hasChart: "none",
-        //     title: "",
-        //     units: "",
-        //     source: ""
-        // })
-        // TSComponents.Card.render('superavit-card-min-xtreme', {
-        //     serieId: '372.6_SUPERAVIT_017__23_67',
-        //     links: 'none',
-        //     hasChart: "none",
-        //     title: "",
-        //     units: "",
-        //     source: ""
-        // })
-        // TSComponents.Card.render('desempleo-card-min-xtreme', {
-        //     serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-        //     color: '#EC407A',
-        //     links: 'none',
-        //     hasChart: "none",
-        //     title: "",
-        //     units: "",
-        //     source: ""
-        // })
+        TSComponents.Card.render('ipc-card', {
+            serieId: '116.4_TCRZE_2015_D_36_4',
+            color: '#F9A822',
+            hasChart: 'small',
+            title: "Indice de Precios al Consumidor Nacional"
+        })
+        TSComponents.Card.render('exportaciones-card', {
+            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+            explicitSign: true,
+            hasChart: 'small',
+            title: "Exportaciones"
+        })
+        TSComponents.Card.render('superavit-card', {
+            serieId: '372.6_SUPERAVIT_017__23_67',
+            hasChart: 'small',
+            title: "Resultado Primario del Sector Público No Fin."
+        })
+        TSComponents.Card.render('desempleo-card', {
+            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            color: '#EC407A',
+            hasChart: 'small',
+            title: "Desocupación"
+        })
+        TSComponents.Card.render('ipc-card-links2', {
+            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+            color: '#F9A822',
+            hasChart: 'small',
+            links: "small",
+            title: "Indice de Precios al Consumidor Nacional"
+        })
+        TSComponents.Card.render('exportaciones-card-links2', {
+            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+            explicitSign: true,
+            hasChart: 'small',
+            links: "small",
+            title: "Exportaciones"
+        })
+        TSComponents.Card.render('superavit-card-links2', {
+            serieId: '372.6_SUPERAVIT_017__23_67',
+            hasChart: 'small',
+            links: "small",
+            title: "Resultado Primario del Sector Público No Fin."
+        })
+        TSComponents.Card.render('desempleo-card-links2', {
+            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            color: '#EC407A',
+            hasChart: 'small',
+            links: "small",
+            title: "Desocupación"
+        })
+        TSComponents.Card.render('ipc-card-med', {
+            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+            color: '#F9A822',
+            hasChart: 'small',
+            links: "none",
+            title: "Indice de Precios al Consumidor Nacional"
+        })
+        TSComponents.Card.render('exportaciones-card-med', {
+            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+            explicitSign: true,
+            hasChart: 'small',
+            links: "none",
+            title: "Exportaciones"
+        })
+        TSComponents.Card.render('superavit-card-med', {
+            serieId: '372.6_SUPERAVIT_017__23_67',
+            hasChart: 'small',
+            links: "none",
+            title: "Resultado Primario del Sector Público No Fin."
+        })
+        TSComponents.Card.render('desempleo-card-med', {
+            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            color: '#EC407A',
+            hasChart: 'small',
+            links: "none",
+            title: "Desocupación"
+        })
+        TSComponents.Card.render('ipc-card-min', {
+            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+            color: '#F9A822',
+            links: 'none',
+            hasChart: "none",
+            title: "Indice de Precios al Consumidor Nacional"
+        })
+        TSComponents.Card.render('exportaciones-card-min', {
+            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+            explicitSign: true,
+            links: 'none',
+            hasChart: "none",
+            title: "Exportaciones"
+        })
+        TSComponents.Card.render('superavit-card-min', {
+            serieId: '372.6_SUPERAVIT_017__23_67',
+            links: 'none',
+            hasChart: "none",
+            title: "Resultado Primario del Sector Público No Fin."
+        })
+        TSComponents.Card.render('desempleo-card-min', {
+            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            color: '#EC407A',
+            links: 'none',
+            hasChart: "none",
+            title: "Desocupación"
+        })
+        TSComponents.Card.render('ipc-card-min-xtreme', {
+            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+            links: 'none',
+            hasChart: "none",
+            title: "",
+            units: "",
+            source: ""
+        })
+        TSComponents.Card.render('exportaciones-card-min-xtreme', {
+            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+            explicitSign: true,
+            links: 'none',
+            hasChart: "none",
+            title: "",
+            units: "",
+            source: ""
+        })
+        TSComponents.Card.render('superavit-card-min-xtreme', {
+            serieId: '372.6_SUPERAVIT_017__23_67',
+            links: 'none',
+            hasChart: "none",
+            title: "",
+            units: "",
+            source: ""
+        })
+        TSComponents.Card.render('desempleo-card-min-xtreme', {
+            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+            color: '#EC407A',
+            links: 'none',
+            hasChart: "none",
+            title: "",
+            units: "",
+            source: ""
+        })
 
         TSComponents.Graphic.render('tcrm-graphic', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=tmi_arg,tmi_26:change&limit=1000&start=0',
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=143.3_NO_PR_2004_A_21:percent_change_a_year_ago,116.4_TCRZE_2015_D_36_4&limit=1000&start=0',
             title: "Nivel de actividad y tipo de cambio real",
             source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
-            // chartTypes: { '143.3_NO_PR_2004_A_21:percent_change_a_year_ago': 'column' },
-            chartTypes: { 'tmi_26:change': 'column' },
-            // chartType: 'area',
+            chartTypes: { '143.3_NO_PR_2004_A_21:percent_change_a_year_ago': 'column' },
             navigator: true,
             decimalTooltip: 3
         })
+        TSComponents.Graphic.render('emae-graphic-without-filters', {
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=defensa_FAA_0006,99.3_IR_2008_0_9&limit=1000&start=0&format=json',
+            chartOptions: { // Override highstock configs. See https://api.highcharts.com/highstock/
+            },
+            source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
+            datePickerEnabled: false,
+            navigator: false,
+            title: "Estimador Mensual de Actividad Económica (EMAE)",
+            chartTypes: { 'defensa_FAA_0006': 'area', '99.3_IR_2008_0_9': 'area' },
+            legendLabel: { 'defensa_FAA_0006': "Fuerza Aérea", '99.3_IR_2008_0_9': "IPC" },
+            seriesAxis: { 'defensa_FAA_0006': 'left', '99.3_IR_2008_0_9': 'right' }
+        })
+        TSComponents.Graphic.render('ica-graphic-without-filters', {
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=74.3_IET_0_M_16,74.3_IIT_0_M_25,74.3_ISC_0_M_19,307.2_SERVICIOS_IOS_0_T_51_87&collapse=year&collapse_aggregation=sum',
+            chartTypes: { '74.3_IET_0_M_16': 'line', '74.3_IIT_0_M_25': 'line', '74.3_ISC_0_M_19': 'column', '307.2_SERVICIOS_IOS_0_T_51_87': 'line' },
+            title: "Intercambio Comercial Argentino (ICA)",
+            navigator: false,
+            datePickerEnabled: false,
+            source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
+            seriesAxis: { '74.3_IET_0_M_16': 'left', '74.3_IIT_0_M_25': 'left', '74.3_ISC_0_M_19': 'right', '307.2_SERVICIOS_IOS_0_T_51_87': 'right'}
+        })
+        TSComponents.Graphic.render('ipc-graphic-min', {
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change_a_year_ago',
+            navigator: false,
+            datePickerEnabled: false,
+            title: "Inflación interanual (nivel general)",
+            chartTypeSelector: false,
+            unitsSelector: false,
+            frequencySelector: false,
+            aggregationSelector: false
+        })
+        TSComponents.Graphic.render('rem-graphic-min', {
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=430.1_MEDIANA_IP_12_M_0_0_27_96',
+            navigator: false,
+            datePickerEnabled: false,
+            title: "REM mediana de expectativas de inflación a 12 meses",
+            chartTypeSelector: false,
+            unitsSelector: false,
+            frequencySelector: false,
+            aggregationSelector: false
+        })
+        TSComponents.Graphic.render('tcbna-graphic-min', {
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=168.1_T_CAMBIOR_D_0_0_26',
+            navigator: false,
+            datePickerEnabled: false,
+            title: "Tipo de Cambio Vendedor (BNA)",
+            chartTypeSelector: false,
+            unitsSelector: false,
+            frequencySelector: false,
+            aggregationSelector: false
+        })
 
-        // TSComponents.Graphic.render('emae-graphic-without-filters', {
-        //     graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=defensa_FAA_0006,99.3_IR_2008_0_9&limit=1000&start=0&format=json',
-        //     chartOptions: { // Override highstock configs. See https://api.highcharts.com/highstock/
-        //     },
-        //     source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
-        //     datePickerEnabled: false,
-        //     navigator: false,
-        //     title: "Estimador Mensual de Actividad Económica (EMAE)",
-        //     chartTypes: { 'defensa_FAA_0006': 'area', '99.3_IR_2008_0_9': 'area' },
-        //     legendLabel: { 'defensa_FAA_0006': "Fuerza Aérea", '99.3_IR_2008_0_9': "IPC" },
-        //     seriesAxis: { 'defensa_FAA_0006': 'left', '99.3_IR_2008_0_9': 'right' }
-        // })
-
-        // TSComponents.Graphic.render('ica-graphic-without-filters', {
-        //     graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=74.3_IET_0_M_16,74.3_IIT_0_M_25,74.3_ISC_0_M_19,307.2_SERVICIOS_IOS_0_T_51_87&collapse=year&collapse_aggregation=sum',
-        //     chartTypes: { '74.3_IET_0_M_16': 'line', '74.3_IIT_0_M_25': 'line', '74.3_ISC_0_M_19': 'column', '307.2_SERVICIOS_IOS_0_T_51_87': 'line' },
-        //     title: "Intercambio Comercial Argentino (ICA)",
-        //     navigator: false,
-        //     datePickerEnabled: false,
-        //     source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
-        //     seriesAxis: { '74.3_IET_0_M_16': 'left', '74.3_IIT_0_M_25': 'left', '74.3_ISC_0_M_19': 'right', '307.2_SERVICIOS_IOS_0_T_51_87': 'right'}
-        // })
-
-        // TSComponents.Graphic.render('ipc-graphic-min', {
-        //     graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change_a_year_ago',
-        //     navigator: false,
-        //     datePickerEnabled: false,
-        //     title: "Inflación interanual (nivel general)",
-        //     chartTypeSelector: false,
-        //     unitsSelector: false,
-        //     aggregationSelector: false,
-        //     frequencySelector: false
-        // })
-
-        // TSComponents.Graphic.render('rem-graphic-min', {
-        //     graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=430.1_MEDIANA_IP_12_M_0_0_27_96',
-        //     navigator: false,
-        //     datePickerEnabled: false,
-        //     title: "REM mediana de expectativas de inflación a 12 meses",
-        //     chartTypeSelector: false,
-        //     unitsSelector: false,
-        //     aggregationSelector: false,
-        //     frequencySelector: false
-        // })
-
-        // TSComponents.Graphic.render('tcbna-graphic-min', {
-        //     graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=168.1_T_CAMBIOR_D_0_0_26',
-        //     navigator: false,
-        //     datePickerEnabled: false,
-        //     title: "Tipo de Cambio Vendedor (BNA)",
-        //     chartTypeSelector: false,
-        //     unitsSelector: false,
-        //     aggregationSelector: false,
-        //     frequencySelector: false
-        // })
 
 
     }

--- a/public/components.html
+++ b/public/components.html
@@ -33,7 +33,7 @@ body {
 </style>
 
 <body>
-    <div class="row">
+    <!-- <div class="row">
         <div class="title">
             <h3>Card: default</h3></div>
         <div id='ipc-card' class="col-xs-12 col-sm-6 col-md-3"></div>
@@ -72,13 +72,13 @@ body {
         <div id='exportaciones-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
         <div id='superavit-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
         <div id='desempleo-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
-    </div>
+    </div> -->
     <div class="row row-graphic">
         <div class="title">
             <h3>Graphic: full</h3></div>
         <div id='tcrm-graphic' style="height: 800px;"></div>
     </div>
-    <div class="row row-graphic">
+    <!-- <div class="row row-graphic">
         <div class="title">
             <h3>Graphic: sin filtros de tiempo</h3></div>
         <div id='emae-graphic-without-filters' class="col-xs-12 col-sm-6 col-md-6" style="height: 700px;"></div>
@@ -90,214 +90,216 @@ body {
         <div id='ipc-graphic-min' class="col-xs-12 col-sm-6 col-md-4" style="height: 400px;"></div>
         <div id='rem-graphic-min' class="col-xs-12 col-sm-6 col-md-4" style="height: 400px;"></div>
         <div id='tcbna-graphic-min' class="col-xs-12 col-sm-6 col-md-4" style="height: 400px;"></div>
-    </div>
+    </div> -->
     <script>
     window.onload = function() {
         // componentes de series de tiempo
 
-        TSComponents.Card.render('ipc-card', {
-            serieId: '116.4_TCRZE_2015_D_36_4',
-            color: '#F9A822',
-            hasChart: 'small',
-            title: "Indice de Precios al Consumidor Nacional"
-        })
-        TSComponents.Card.render('exportaciones-card', {
-            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-            explicitSign: true,
-            hasChart: 'small',
-            title: "Exportaciones"
-        })
-        TSComponents.Card.render('superavit-card', {
-            serieId: '372.6_SUPERAVIT_017__23_67',
-            hasChart: 'small',
-            title: "Resultado Primario del Sector Público No Fin."
-        })
-        TSComponents.Card.render('desempleo-card', {
-            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-            color: '#EC407A',
-            hasChart: 'small',
-            title: "Desocupación"
-        })
-        TSComponents.Card.render('ipc-card-links2', {
-            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-            color: '#F9A822',
-            hasChart: 'small',
-            links: "small",
-            title: "Indice de Precios al Consumidor Nacional"
-        })
-        TSComponents.Card.render('exportaciones-card-links2', {
-            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-            explicitSign: true,
-            hasChart: 'small',
-            links: "small",
-            title: "Exportaciones"
-        })
-        TSComponents.Card.render('superavit-card-links2', {
-            serieId: '372.6_SUPERAVIT_017__23_67',
-            hasChart: 'small',
-            links: "small",
-            title: "Resultado Primario del Sector Público No Fin."
-        })
-        TSComponents.Card.render('desempleo-card-links2', {
-            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-            color: '#EC407A',
-            hasChart: 'small',
-            links: "small",
-            title: "Desocupación"
-        })
-        TSComponents.Card.render('ipc-card-med', {
-            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-            color: '#F9A822',
-            hasChart: 'small',
-            links: "none",
-            title: "Indice de Precios al Consumidor Nacional"
-        })
-        TSComponents.Card.render('exportaciones-card-med', {
-            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-            explicitSign: true,
-            hasChart: 'small',
-            links: "none",
-            title: "Exportaciones"
-        })
-        TSComponents.Card.render('superavit-card-med', {
-            serieId: '372.6_SUPERAVIT_017__23_67',
-            hasChart: 'small',
-            links: "none",
-            title: "Resultado Primario del Sector Público No Fin."
-        })
-        TSComponents.Card.render('desempleo-card-med', {
-            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-            color: '#EC407A',
-            hasChart: 'small',
-            links: "none",
-            title: "Desocupación"
-        })
-        TSComponents.Card.render('ipc-card-min', {
-            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-            color: '#F9A822',
-            links: 'none',
-            hasChart: "none",
-            title: "Indice de Precios al Consumidor Nacional"
-        })
-        TSComponents.Card.render('exportaciones-card-min', {
-            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-            explicitSign: true,
-            links: 'none',
-            hasChart: "none",
-            title: "Exportaciones"
-        })
-        TSComponents.Card.render('superavit-card-min', {
-            serieId: '372.6_SUPERAVIT_017__23_67',
-            links: 'none',
-            hasChart: "none",
-            title: "Resultado Primario del Sector Público No Fin."
-        })
-        TSComponents.Card.render('desempleo-card-min', {
-            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-            color: '#EC407A',
-            links: 'none',
-            hasChart: "none",
-            title: "Desocupación"
-        })
-        TSComponents.Card.render('ipc-card-min-xtreme', {
-            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-            links: 'none',
-            hasChart: "none",
-            title: "",
-            units: "",
-            source: ""
-        })
-        TSComponents.Card.render('exportaciones-card-min-xtreme', {
-            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-            explicitSign: true,
-            links: 'none',
-            hasChart: "none",
-            title: "",
-            units: "",
-            source: ""
-        })
-        TSComponents.Card.render('superavit-card-min-xtreme', {
-            serieId: '372.6_SUPERAVIT_017__23_67',
-            links: 'none',
-            hasChart: "none",
-            title: "",
-            units: "",
-            source: ""
-        })
-        TSComponents.Card.render('desempleo-card-min-xtreme', {
-            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-            color: '#EC407A',
-            links: 'none',
-            hasChart: "none",
-            title: "",
-            units: "",
-            source: ""
-        })
+        // TSComponents.Card.render('ipc-card', {
+        //     serieId: '116.4_TCRZE_2015_D_36_4',
+        //     color: '#F9A822',
+        //     hasChart: 'small',
+        //     title: "Indice de Precios al Consumidor Nacional"
+        // })
+        // TSComponents.Card.render('exportaciones-card', {
+        //     serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+        //     explicitSign: true,
+        //     hasChart: 'small',
+        //     title: "Exportaciones"
+        // })
+        // TSComponents.Card.render('superavit-card', {
+        //     serieId: '372.6_SUPERAVIT_017__23_67',
+        //     hasChart: 'small',
+        //     title: "Resultado Primario del Sector Público No Fin."
+        // })
+        // TSComponents.Card.render('desempleo-card', {
+        //     serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+        //     color: '#EC407A',
+        //     hasChart: 'small',
+        //     title: "Desocupación"
+        // })
+        // TSComponents.Card.render('ipc-card-links2', {
+        //     serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+        //     color: '#F9A822',
+        //     hasChart: 'small',
+        //     links: "small",
+        //     title: "Indice de Precios al Consumidor Nacional"
+        // })
+        // TSComponents.Card.render('exportaciones-card-links2', {
+        //     serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+        //     explicitSign: true,
+        //     hasChart: 'small',
+        //     links: "small",
+        //     title: "Exportaciones"
+        // })
+        // TSComponents.Card.render('superavit-card-links2', {
+        //     serieId: '372.6_SUPERAVIT_017__23_67',
+        //     hasChart: 'small',
+        //     links: "small",
+        //     title: "Resultado Primario del Sector Público No Fin."
+        // })
+        // TSComponents.Card.render('desempleo-card-links2', {
+        //     serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+        //     color: '#EC407A',
+        //     hasChart: 'small',
+        //     links: "small",
+        //     title: "Desocupación"
+        // })
+        // TSComponents.Card.render('ipc-card-med', {
+        //     serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+        //     color: '#F9A822',
+        //     hasChart: 'small',
+        //     links: "none",
+        //     title: "Indice de Precios al Consumidor Nacional"
+        // })
+        // TSComponents.Card.render('exportaciones-card-med', {
+        //     serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+        //     explicitSign: true,
+        //     hasChart: 'small',
+        //     links: "none",
+        //     title: "Exportaciones"
+        // })
+        // TSComponents.Card.render('superavit-card-med', {
+        //     serieId: '372.6_SUPERAVIT_017__23_67',
+        //     hasChart: 'small',
+        //     links: "none",
+        //     title: "Resultado Primario del Sector Público No Fin."
+        // })
+        // TSComponents.Card.render('desempleo-card-med', {
+        //     serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+        //     color: '#EC407A',
+        //     hasChart: 'small',
+        //     links: "none",
+        //     title: "Desocupación"
+        // })
+        // TSComponents.Card.render('ipc-card-min', {
+        //     serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+        //     color: '#F9A822',
+        //     links: 'none',
+        //     hasChart: "none",
+        //     title: "Indice de Precios al Consumidor Nacional"
+        // })
+        // TSComponents.Card.render('exportaciones-card-min', {
+        //     serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+        //     explicitSign: true,
+        //     links: 'none',
+        //     hasChart: "none",
+        //     title: "Exportaciones"
+        // })
+        // TSComponents.Card.render('superavit-card-min', {
+        //     serieId: '372.6_SUPERAVIT_017__23_67',
+        //     links: 'none',
+        //     hasChart: "none",
+        //     title: "Resultado Primario del Sector Público No Fin."
+        // })
+        // TSComponents.Card.render('desempleo-card-min', {
+        //     serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+        //     color: '#EC407A',
+        //     links: 'none',
+        //     hasChart: "none",
+        //     title: "Desocupación"
+        // })
+        // TSComponents.Card.render('ipc-card-min-xtreme', {
+        //     serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
+        //     links: 'none',
+        //     hasChart: "none",
+        //     title: "",
+        //     units: "",
+        //     source: ""
+        // })
+        // TSComponents.Card.render('exportaciones-card-min-xtreme', {
+        //     serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
+        //     explicitSign: true,
+        //     links: 'none',
+        //     hasChart: "none",
+        //     title: "",
+        //     units: "",
+        //     source: ""
+        // })
+        // TSComponents.Card.render('superavit-card-min-xtreme', {
+        //     serieId: '372.6_SUPERAVIT_017__23_67',
+        //     links: 'none',
+        //     hasChart: "none",
+        //     title: "",
+        //     units: "",
+        //     source: ""
+        // })
+        // TSComponents.Card.render('desempleo-card-min-xtreme', {
+        //     serieId: '42.3_EPH_PUNTUATAL_0_M_30',
+        //     color: '#EC407A',
+        //     links: 'none',
+        //     hasChart: "none",
+        //     title: "",
+        //     units: "",
+        //     source: ""
+        // })
 
         TSComponents.Graphic.render('tcrm-graphic', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=143.3_NO_PR_2004_A_21:percent_change_a_year_ago,116.4_TCRZE_2015_D_36_4&limit=1000&start=0',
+            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=tmi_arg,tmi_26:change&limit=1000&start=0',
             title: "Nivel de actividad y tipo de cambio real",
             source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
-            chartTypes: { '143.3_NO_PR_2004_A_21:percent_change_a_year_ago': 'column' },
+            // chartTypes: { '143.3_NO_PR_2004_A_21:percent_change_a_year_ago': 'column' },
+            chartTypes: { 'tmi_26:change': 'column' },
+            // chartType: 'area',
             navigator: true,
             decimalTooltip: 3
         })
 
-        TSComponents.Graphic.render('emae-graphic-without-filters', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=defensa_FAA_0006,99.3_IR_2008_0_9&limit=1000&start=0&format=json',
-            chartOptions: { // Override highstock configs. See https://api.highcharts.com/highstock/
-            },
-            source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
-            datePickerEnabled: false,
-            navigator: false,
-            title: "Estimador Mensual de Actividad Económica (EMAE)",
-            chartTypes: { 'defensa_FAA_0006': 'area', '99.3_IR_2008_0_9': 'area' },
-            legendLabel: { 'defensa_FAA_0006': "Fuerza Aérea", '99.3_IR_2008_0_9': "IPC" },
-            seriesAxis: { 'defensa_FAA_0006': 'left', '99.3_IR_2008_0_9': 'right' }
-        })
+        // TSComponents.Graphic.render('emae-graphic-without-filters', {
+        //     graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=defensa_FAA_0006,99.3_IR_2008_0_9&limit=1000&start=0&format=json',
+        //     chartOptions: { // Override highstock configs. See https://api.highcharts.com/highstock/
+        //     },
+        //     source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
+        //     datePickerEnabled: false,
+        //     navigator: false,
+        //     title: "Estimador Mensual de Actividad Económica (EMAE)",
+        //     chartTypes: { 'defensa_FAA_0006': 'area', '99.3_IR_2008_0_9': 'area' },
+        //     legendLabel: { 'defensa_FAA_0006': "Fuerza Aérea", '99.3_IR_2008_0_9': "IPC" },
+        //     seriesAxis: { 'defensa_FAA_0006': 'left', '99.3_IR_2008_0_9': 'right' }
+        // })
 
-        TSComponents.Graphic.render('ica-graphic-without-filters', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=74.3_IET_0_M_16,74.3_IIT_0_M_25,74.3_ISC_0_M_19,307.2_SERVICIOS_IOS_0_T_51_87&collapse=year&collapse_aggregation=sum',
-            chartTypes: { '74.3_IET_0_M_16': 'line', '74.3_IIT_0_M_25': 'line', '74.3_ISC_0_M_19': 'column', '307.2_SERVICIOS_IOS_0_T_51_87': 'line' },
-            title: "Intercambio Comercial Argentino (ICA)",
-            navigator: false,
-            datePickerEnabled: false,
-            source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
-            seriesAxis: { '74.3_IET_0_M_16': 'left', '74.3_IIT_0_M_25': 'left', '74.3_ISC_0_M_19': 'right', '307.2_SERVICIOS_IOS_0_T_51_87': 'right'}
-        })
+        // TSComponents.Graphic.render('ica-graphic-without-filters', {
+        //     graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=74.3_IET_0_M_16,74.3_IIT_0_M_25,74.3_ISC_0_M_19,307.2_SERVICIOS_IOS_0_T_51_87&collapse=year&collapse_aggregation=sum',
+        //     chartTypes: { '74.3_IET_0_M_16': 'line', '74.3_IIT_0_M_25': 'line', '74.3_ISC_0_M_19': 'column', '307.2_SERVICIOS_IOS_0_T_51_87': 'line' },
+        //     title: "Intercambio Comercial Argentino (ICA)",
+        //     navigator: false,
+        //     datePickerEnabled: false,
+        //     source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
+        //     seriesAxis: { '74.3_IET_0_M_16': 'left', '74.3_IIT_0_M_25': 'left', '74.3_ISC_0_M_19': 'right', '307.2_SERVICIOS_IOS_0_T_51_87': 'right'}
+        // })
 
-        TSComponents.Graphic.render('ipc-graphic-min', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change_a_year_ago',
-            navigator: false,
-            datePickerEnabled: false,
-            title: "Inflación interanual (nivel general)",
-            chartTypeSelector: false,
-            unitsSelector: false,
-            aggregationSelector: false,
-            frequencySelector: false
-        })
+        // TSComponents.Graphic.render('ipc-graphic-min', {
+        //     graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change_a_year_ago',
+        //     navigator: false,
+        //     datePickerEnabled: false,
+        //     title: "Inflación interanual (nivel general)",
+        //     chartTypeSelector: false,
+        //     unitsSelector: false,
+        //     aggregationSelector: false,
+        //     frequencySelector: false
+        // })
 
-        TSComponents.Graphic.render('rem-graphic-min', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=430.1_MEDIANA_IP_12_M_0_0_27_96',
-            navigator: false,
-            datePickerEnabled: false,
-            title: "REM mediana de expectativas de inflación a 12 meses",
-            chartTypeSelector: false,
-            unitsSelector: false,
-            aggregationSelector: false,
-            frequencySelector: false
-        })
+        // TSComponents.Graphic.render('rem-graphic-min', {
+        //     graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=430.1_MEDIANA_IP_12_M_0_0_27_96',
+        //     navigator: false,
+        //     datePickerEnabled: false,
+        //     title: "REM mediana de expectativas de inflación a 12 meses",
+        //     chartTypeSelector: false,
+        //     unitsSelector: false,
+        //     aggregationSelector: false,
+        //     frequencySelector: false
+        // })
 
-        TSComponents.Graphic.render('tcbna-graphic-min', {
-            graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=168.1_T_CAMBIOR_D_0_0_26',
-            navigator: false,
-            datePickerEnabled: false,
-            title: "Tipo de Cambio Vendedor (BNA)",
-            chartTypeSelector: false,
-            unitsSelector: false,
-            aggregationSelector: false,
-            frequencySelector: false
-        })
+        // TSComponents.Graphic.render('tcbna-graphic-min', {
+        //     graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=168.1_T_CAMBIOR_D_0_0_26',
+        //     navigator: false,
+        //     datePickerEnabled: false,
+        //     title: "Tipo de Cambio Vendedor (BNA)",
+        //     chartTypeSelector: false,
+        //     unitsSelector: false,
+        //     aggregationSelector: false,
+        //     frequencySelector: false
+        // })
 
 
     }

--- a/public/components.html
+++ b/public/components.html
@@ -16,12 +16,10 @@
 }
 
 .row-graphic {
-    height: 80%;
     padding: 40px;
 }
 
 .row-graphic-min {
-    height: 50%;
     padding: 50px;
 }
 
@@ -35,225 +33,28 @@ body {
 </style>
 
 <body>
-    <div class="row">
-        <div class="title">
-            <h3>Card: default</h3></div>
-        <div id='ipc-card' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='exportaciones-card' class="col-xs-12 col-sm-6 col-md-3"> </div>
-        <div id='superavit-card' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='desempleo-card' class="col-xs-12 col-sm-6 col-md-3"></div>
-    </div>
-    <div class="row">
-        <div class="title">
-            <h3>Card: menos links</h3></div>
-        <div id='ipc-card-links2' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='exportaciones-card-links2' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='superavit-card-links2' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='desempleo-card-links2' class="col-xs-12 col-sm-6 col-md-3"></div>
-    </div>
-    <div class="row">
-        <div class="title">
-            <h3>Card: sin links</h3></div>
-        <div id='ipc-card-med' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='exportaciones-card-med' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='superavit-card-med' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='desempleo-card-med' class="col-xs-12 col-sm-6 col-md-3"></div>
-    </div>
-    <div class="row">
-        <div class="title">
-            <h3>Card: mínima</h3></div>
-        <div id='ipc-card-min' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='exportaciones-card-min' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='superavit-card-min' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='desempleo-card-min' class="col-xs-12 col-sm-6 col-md-3"></div>
-    </div>
-    <div class="row">
-        <div class="title">
-            <h3>Card: mínima (eliminando elementos)</h3></div>
-        <div id='ipc-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='exportaciones-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='superavit-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
-        <div id='desempleo-card-min-xtreme' class="col-xs-12 col-sm-6 col-md-3"></div>
-    </div>
+    
     <div class="row row-graphic">
         <div class="title">
             <h3>Graphic: full</h3></div>
-        <div id='tcrm-graphic'></div>
+        <div id='tcrm-graphic' style="height: 800px;"></div>
     </div>
     <div class="row row-graphic">
         <div class="title">
             <h3>Graphic: sin filtros de tiempo</h3></div>
-        <div id='emae-graphic-without-filters' class="col-xs-12 col-sm-6 col-md-6"></div>
-        <div id='ica-graphic-without-filters' class="col-xs-12 col-sm-6 col-md-6"></div>
+        <div id='emae-graphic-without-filters' class="col-xs-12 col-sm-6 col-md-6" style="height: 700px;"></div>
+        <div id='ica-graphic-without-filters' class="col-xs-12 col-sm-6 col-md-6" style="height: 700px;"></div>
     </div>
     <div class="row row-graphic-min">
         <div class="title">
             <h3>Graphic: mínimo</h3></div>
-        <div id='ipc-graphic-min' class="col-xs-12 col-sm-6 col-md-4"></div>
-        <div id='rem-graphic-min' class="col-xs-12 col-sm-6 col-md-4"></div>
-        <div id='tcbna-graphic-min' class="col-xs-12 col-sm-6 col-md-4"></div>
+        <div id='ipc-graphic-min' class="col-xs-12 col-sm-6 col-md-4" style="height: 400px;"></div>
+        <div id='rem-graphic-min' class="col-xs-12 col-sm-6 col-md-4" style="height: 400px;"></div>
+        <div id='tcbna-graphic-min' class="col-xs-12 col-sm-6 col-md-4" style="height: 400px;"></div>
     </div>
     <script>
     window.onload = function() {
         // componentes de series de tiempo
-
-        TSComponents.Card.render('ipc-card', {
-            serieId: '116.4_TCRZE_2015_D_36_4',
-            color: '#F9A822',
-            hasChart: 'small',
-            title: "Indice de Precios al Consumidor Nacional"
-        })
-
-        TSComponents.Card.render('exportaciones-card', {
-            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-            explicitSign: true,
-            hasChart: 'small',
-            title: "Exportaciones"
-        })
-
-        TSComponents.Card.render('superavit-card', {
-            serieId: '372.6_SUPERAVIT_017__23_67',
-            hasChart: 'small',
-            title: "Resultado Primario del Sector Público No Fin."
-        })
-
-        TSComponents.Card.render('desempleo-card', {
-            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-            color: '#EC407A',
-            hasChart: 'small',
-            title: "Desocupación"
-        })
-
-        TSComponents.Card.render('ipc-card-links2', {
-            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-            color: '#F9A822',
-            hasChart: 'small',
-            links: "small",
-            title: "Indice de Precios al Consumidor Nacional"
-        })
-
-        TSComponents.Card.render('exportaciones-card-links2', {
-            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-            explicitSign: true,
-            hasChart: 'small',
-            links: "small",
-            title: "Exportaciones"
-        })
-
-        TSComponents.Card.render('superavit-card-links2', {
-            serieId: '372.6_SUPERAVIT_017__23_67',
-            hasChart: 'small',
-            links: "small",
-            title: "Resultado Primario del Sector Público No Fin."
-        })
-
-        TSComponents.Card.render('desempleo-card-links2', {
-            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-            color: '#EC407A',
-            hasChart: 'small',
-            links: "small",
-            title: "Desocupación"
-        })
-
-        TSComponents.Card.render('ipc-card-med', {
-            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-            color: '#F9A822',
-            hasChart: 'small',
-            links: "none",
-            title: "Indice de Precios al Consumidor Nacional"
-        })
-
-        TSComponents.Card.render('exportaciones-card-med', {
-            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-            explicitSign: true,
-            hasChart: 'small',
-            links: "none",
-            title: "Exportaciones"
-        })
-
-        TSComponents.Card.render('superavit-card-med', {
-            serieId: '372.6_SUPERAVIT_017__23_67',
-            hasChart: 'small',
-            links: "none",
-            title: "Resultado Primario del Sector Público No Fin."
-        })
-
-        TSComponents.Card.render('desempleo-card-med', {
-            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-            color: '#EC407A',
-            hasChart: 'small',
-            links: "none",
-            title: "Desocupación"
-        })
-
-        TSComponents.Card.render('ipc-card-min', {
-            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-            color: '#F9A822',
-            links: 'none',
-            hasChart: "none",
-            title: "Indice de Precios al Consumidor Nacional"
-        })
-
-        TSComponents.Card.render('exportaciones-card-min', {
-            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-            explicitSign: true,
-            links: 'none',
-            hasChart: "none",
-            title: "Exportaciones"
-        })
-
-        TSComponents.Card.render('superavit-card-min', {
-            serieId: '372.6_SUPERAVIT_017__23_67',
-            links: 'none',
-            hasChart: "none",
-            title: "Resultado Primario del Sector Público No Fin."
-        })
-
-        TSComponents.Card.render('desempleo-card-min', {
-            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-            color: '#EC407A',
-            links: 'none',
-            hasChart: "none",
-            title: "Desocupación"
-        })
-
-        TSComponents.Card.render('ipc-card-min-xtreme', {
-            serieId: '148.3_INIVELNAL_DICI_M_26:percent_change',
-            links: 'none',
-            hasChart: "none",
-            title: "",
-            units: "",
-            source: ""
-        })
-
-        TSComponents.Card.render('exportaciones-card-min-xtreme', {
-            serieId: '74.3_IET_0_M_16:percent_change_a_year_ago',
-            explicitSign: true,
-            links: 'none',
-            hasChart: "none",
-            title: "",
-            units: "",
-            source: ""
-        })
-
-        TSComponents.Card.render('superavit-card-min-xtreme', {
-            serieId: '372.6_SUPERAVIT_017__23_67',
-            links: 'none',
-            hasChart: "none",
-            title: "",
-            units: "",
-            source: ""
-        })
-
-        TSComponents.Card.render('desempleo-card-min-xtreme', {
-            serieId: '42.3_EPH_PUNTUATAL_0_M_30',
-            color: '#EC407A',
-            links: 'none',
-            hasChart: "none",
-            title: "",
-            units: "",
-            source: ""
-        })
 
         TSComponents.Graphic.render('tcrm-graphic', {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=143.3_NO_PR_2004_A_21:percent_change_a_year_ago,116.4_TCRZE_2015_D_36_4&limit=1000&start=0',
@@ -291,7 +92,7 @@ body {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change_a_year_ago',
             navigator: false,
             datePickerEnabled: false,
-            title: "Inflación interanual (nivel general)"
+            title: "Inflación interanual (nivel general)",
         })
 
         TSComponents.Graphic.render('rem-graphic-min', {
@@ -305,7 +106,9 @@ body {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=168.1_T_CAMBIOR_D_0_0_26',
             navigator: false,
             datePickerEnabled: false,
-            title: "Tipo de Cambio Vendedor (BNA)"
+            title: "Tipo de Cambio Vendedor (BNA)",
+            chartTypeSelector: false,
+            unitsSelector: false
         })
 
 

--- a/public/components.html
+++ b/public/components.html
@@ -240,7 +240,11 @@ body {
             source: "Fuente: Instituto Nacional de Estadística y Censos (INDEC)",
             chartTypes: { '143.3_NO_PR_2004_A_21:percent_change_a_year_ago': 'column' },
             navigator: true,
-            decimalTooltip: 3
+            decimalTooltip: 3,
+            chartTypeSelector: true,
+            unitsSelector: true,
+            frequencySelector: true,
+            aggregationSelector: true
         })
         TSComponents.Graphic.render('emae-graphic-without-filters', {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?metadata=full&ids=defensa_FAA_0006,99.3_IR_2008_0_9&limit=1000&start=0&format=json',
@@ -252,7 +256,9 @@ body {
             title: "Estimador Mensual de Actividad Económica (EMAE)",
             chartTypes: { 'defensa_FAA_0006': 'area', '99.3_IR_2008_0_9': 'area' },
             legendLabel: { 'defensa_FAA_0006': "Fuerza Aérea", '99.3_IR_2008_0_9': "IPC" },
-            seriesAxis: { 'defensa_FAA_0006': 'left', '99.3_IR_2008_0_9': 'right' }
+            seriesAxis: { 'defensa_FAA_0006': 'left', '99.3_IR_2008_0_9': 'right' },
+            chartTypeSelector: true,
+            frequencySelector: true,
         })
         TSComponents.Graphic.render('ica-graphic-without-filters', {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=74.3_IET_0_M_16,74.3_IIT_0_M_25,74.3_ISC_0_M_19,307.2_SERVICIOS_IOS_0_T_51_87&collapse=year&collapse_aggregation=sum',
@@ -267,31 +273,19 @@ body {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=148.3_INIVELNAL_DICI_M_26:percent_change_a_year_ago',
             navigator: false,
             datePickerEnabled: false,
-            title: "Inflación interanual (nivel general)",
-            chartTypeSelector: false,
-            unitsSelector: false,
-            frequencySelector: false,
-            aggregationSelector: false
+            title: "Inflación interanual (nivel general)"
         })
         TSComponents.Graphic.render('rem-graphic-min', {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=430.1_MEDIANA_IP_12_M_0_0_27_96',
             navigator: false,
             datePickerEnabled: false,
-            title: "REM mediana de expectativas de inflación a 12 meses",
-            chartTypeSelector: false,
-            unitsSelector: false,
-            frequencySelector: false,
-            aggregationSelector: false
+            title: "REM mediana de expectativas de inflación a 12 meses"
         })
         TSComponents.Graphic.render('tcbna-graphic-min', {
             graphicUrl: 'https://apis.datos.gob.ar/series/api/series/?ids=168.1_T_CAMBIOR_D_0_0_26',
             navigator: false,
             datePickerEnabled: false,
-            title: "Tipo de Cambio Vendedor (BNA)",
-            chartTypeSelector: false,
-            unitsSelector: false,
-            frequencySelector: false,
-            aggregationSelector: false
+            title: "Tipo de Cambio Vendedor (BNA)"
         })
 
 

--- a/src/api/ChartTypeSelector.ts
+++ b/src/api/ChartTypeSelector.ts
@@ -61,29 +61,3 @@ function chartTypesFromString(types: string|null): IChartTypeProps {
 function isValidChartType(type: string|null): boolean {
     return VALID_TYPES.indexOf(type || '') !== -1;
 }
-
-export function getSelectedChartType(chartTypes: IChartTypeProps, chartType?: string) {
-
-    if(chartType !== undefined) { return chartType; }
-
-    const types: string[] = (Object as any).values(chartTypes);
-    if (types.length > 0) {
-        return types[0];
-    }
-
-    return DEFAULT_CHART_TYPE;
-
-}
-
-export function cloneChartTypes(original: IChartTypeProps): IChartTypeProps {
-
-    const involvedIDs = Object.keys(original);
-    const newTypes: IChartTypeProps = {}
-
-    for (const id of involvedIDs) {
-        newTypes[id] = original[id];
-    }
-
-    return newTypes;
-
-}

--- a/src/api/ChartTypeSelector.ts
+++ b/src/api/ChartTypeSelector.ts
@@ -3,8 +3,8 @@ import { ISerie } from "./Serie";
 import { getFullSerieId } from "../helpers/common/fullSerieID";
 
 
-const DEFAULT_TYPE = "line";
-const VALID_TYPES = [DEFAULT_TYPE, "column", "area"];
+export const DEFAULT_CHART_TYPE = "line";
+const VALID_TYPES = [DEFAULT_CHART_TYPE, "column", "area"];
 
 
 export default class ChartTypeSelector {
@@ -37,9 +37,9 @@ export default class ChartTypeSelector {
 }
 
 function getValidChartType(type: string|null): string {
-    type = type || DEFAULT_TYPE;
+    type = type || DEFAULT_CHART_TYPE;
     if (!isValidChartType(type) || type === "default") {
-        type = DEFAULT_TYPE;
+        type = DEFAULT_CHART_TYPE;
     }
 
     return type;
@@ -60,4 +60,30 @@ function chartTypesFromString(types: string|null): IChartTypeProps {
 
 function isValidChartType(type: string|null): boolean {
     return VALID_TYPES.indexOf(type || '') !== -1;
+}
+
+export function getSelectedChartType(chartTypes: IChartTypeProps, chartType?: string) {
+
+    if(chartType !== undefined) { return chartType; }
+
+    const types: string[] = (Object as any).values(chartTypes);
+    if (types.length > 0) {
+        return types[0];
+    }
+
+    return DEFAULT_CHART_TYPE;
+
+}
+
+export function cloneChartTypes(original: IChartTypeProps): IChartTypeProps {
+
+    const involvedIDs = Object.keys(original);
+    const newTypes: IChartTypeProps = {}
+
+    for (const id of involvedIDs) {
+        newTypes[id] = original[id];
+    }
+
+    return newTypes;
+
 }

--- a/src/api/QueryParams.ts
+++ b/src/api/QueryParams.ts
@@ -113,12 +113,10 @@ export default class QueryParams {
         this.chartType = chartType;
     }
 
-    public addParamsFrom(params: any, addRepMode: boolean) {
+    public addParamsFrom(params: any) {
         this.setCollapse(params.get('collapse') || '');
         this.setCollapseAggregation(params.get('collapse_aggregation') || '');
-        if (addRepMode) {
-            this.setRepresentationMode(params.get('representation_mode') || '');
-        }
+        this.setRepresentationMode(params.get('representation_mode') || '');
         this.setLast(params.get('last') || '');
     }
 

--- a/src/api/QueryParams.ts
+++ b/src/api/QueryParams.ts
@@ -113,10 +113,12 @@ export default class QueryParams {
         this.chartType = chartType;
     }
 
-    public addParamsFrom(params: any) {
+    public addParamsFrom(params: any, addRepMode: boolean) {
         this.setCollapse(params.get('collapse') || '');
         this.setCollapseAggregation(params.get('collapse_aggregation') || '');
-        this.setRepresentationMode(params.get('representation_mode') || '');
+        if (addRepMode) {
+            this.setRepresentationMode(params.get('representation_mode') || '');
+        }
         this.setLast(params.get('last') || '');
     }
 

--- a/src/api/utils/periodicityManager.ts
+++ b/src/api/utils/periodicityManager.ts
@@ -47,12 +47,12 @@ export class PeriodicityManager {
 
  }
 
-// returns if `higher` is higher than `newFrequency`
-export function isHigherFrequency(higher: string, newFrequency: string): boolean {
-    return (higher === 'Anual') ||
-        (higher === 'Semestral' && newFrequency !== 'Anual') ||
-        ((higher === 'Trimestral') && ((newFrequency !== 'Anual') && newFrequency !== 'Semestral')) ||
-        (higher === 'Mensual' && ((newFrequency !== 'Anual') && (newFrequency !== 'Semestral') && (newFrequency !== 'Trimestral')))
+// returns if `lower` is lower (less frequent) than `newFrequency`
+export function isLowerFrequency(lower: string, newFrequency: string): boolean {
+    return (lower === 'Anual') ||
+        (lower === 'Semestral' && newFrequency !== 'Anual') ||
+        ((lower === 'Trimestral') && ((newFrequency !== 'Anual') && newFrequency !== 'Semestral')) ||
+        (lower === 'Mensual' && ((newFrequency !== 'Anual') && (newFrequency !== 'Semestral') && (newFrequency !== 'Trimestral')))
 }
 
 export function i18nFrequency(frequency: string): string {

--- a/src/components/exportable/GraphicExportable.tsx
+++ b/src/components/exportable/GraphicExportable.tsx
@@ -206,20 +206,24 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
                                           unitsSelector={unitsSelector}
                                           aggregationSelector={aggregationSelector}
                                           frequencySelector={frequencySelector}
+                                          presentSelectorsAmount={this.presentSelectorsAmount()}
                                           parentWidth={this.divWidth} />
             </ExportableGraphicContainer>
         )
     }
 
     private afterRender(chart: any) {
-        const chartHeight = chart.container.parentElement.clientHeight;
+
+        this.divWidth = chart.container.parentElement.clientWidth;
+        const pickersHeight = this.divWidth < 1500 ? this.presentSelectorsAmount() * 74 : 74;   // Height of the pickers' container
+        const rootDivHeight = chart.container.parentElement.parentElement.parentElement.clientHeight;
+        
+        const chartHeight = rootDivHeight - chart.subtitle.element.clientHeight - pickersHeight;
         const zoomEnabled = this.props.zoom || (this.props.zoom === undefined && chart.chartWidth >= 620);
         const navigatorEnabled = this.props.navigator || (this.props.navigator === undefined && chartHeight >= 500);
         const datepickerEnabled = this.props.datePickerEnabled || (this.props.datePickerEnabled === undefined && chart.chartWidth >= 400);
         const smallChart = chart.chartWidth <= 700;
         const displayUnits = this.props.displayUnits || (this.props.displayUnits === undefined && chart.chartWidth > 450);
-
-        this.divWidth = chart.container.parentElement.clientWidth;
 
         chart.update({
             chart: {
@@ -283,6 +287,19 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
         for (const id of orderedSeriesIDs) {
             delete this.props.chartTypes[id];
         }
+
+    }
+
+    private presentSelectorsAmount(): number {
+
+        let amount = 0;
+
+        if (this.props.chartTypeSelector !== false) { amount++; }
+        if (this.props.aggregationSelector !== false) { amount++; }
+        if (this.props.unitsSelector !== false) { amount++; }
+        if (this.props.frequencySelector !== false) { amount++; }
+
+        return amount;
 
     }
 

--- a/src/components/exportable/GraphicExportable.tsx
+++ b/src/components/exportable/GraphicExportable.tsx
@@ -201,10 +201,10 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
         const chartOptions = buildChartOptions(this.props.chartOptions, this.props);
         const abbreviationProps = buildAbbreviationProps(this.props.numbersAbbreviate, this.props.decimalsBillion, this.props.decimalsMillion);
 
-        const chartTypeSelector = this.props.chartTypeSelector  !== undefined ? this.props.chartTypeSelector : true;
-        const unitsSelector = this.props.unitsSelector  !== undefined ? this.props.unitsSelector : true;
-        const aggregationSelector = this.props.aggregationSelector  !== undefined ? this.props.aggregationSelector : true;
-        const frequencySelector = this.props.frequencySelector  !== undefined ? this.props.frequencySelector : true;
+        const chartTypeSelector = this.props.chartTypeSelector ? this.props.chartTypeSelector : false;
+        const unitsSelector = this.props.unitsSelector ? this.props.unitsSelector : false;
+        const aggregationSelector = this.props.aggregationSelector ? this.props.aggregationSelector : false;
+        const frequencySelector = this.props.frequencySelector ? this.props.frequencySelector : false;
 
         return (
             <ExportableGraphicContainer>
@@ -336,10 +336,10 @@ export default class GraphicExportable extends React.Component<IGraphicExportabl
 
         let amount = 0;
 
-        if (this.props.chartTypeSelector !== false) { amount++; }
-        if (this.props.aggregationSelector !== false) { amount++; }
-        if (this.props.unitsSelector !== false) { amount++; }
-        if (this.props.frequencySelector !== false) { amount++; }
+        if (this.props.chartTypeSelector) { amount++; }
+        if (this.props.aggregationSelector) { amount++; }
+        if (this.props.unitsSelector) { amount++; }
+        if (this.props.frequencySelector) { amount++; }
 
         return amount;
 

--- a/src/components/style/Graphic/ExportableGraphicContainer.tsx
+++ b/src/components/style/Graphic/ExportableGraphicContainer.tsx
@@ -1,4 +1,4 @@
 import * as React from 'react';
 
 export default (props: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>) =>
-    <div className="exportable-graph mg-xlg-b" {...props} style={{height: '100%'}}/>
+    <div className="exportable-graph mg-xlg-b" {...props} />

--- a/src/components/style/Graphic/ExportableGraphicPickers.tsx
+++ b/src/components/style/Graphic/ExportableGraphicPickers.tsx
@@ -17,6 +17,7 @@ export interface IExportableGraphicPickersProps {
     aggregationSelector: boolean;
     unitsSelector: boolean;
     frequencySelector: boolean;
+    presentSelectorsAmount: number;
     parentWidth: number;
 }
 
@@ -120,14 +121,8 @@ export default class ExportableGraphicPickers extends React.Component<IExportabl
             }
         }
 
-        let presentSelectors = 0;
-        if (this.props.chartTypeSelector) { presentSelectors++; }
-        if (this.props.aggregationSelector) { presentSelectors++; }
-        if (this.props.unitsSelector) { presentSelectors++; }
-        if (this.props.frequencySelector) { presentSelectors++; }
-
         return {
-            width: WIDTHS_PER_PRESENT_SELECTORS[presentSelectors]
+            width: WIDTHS_PER_PRESENT_SELECTORS[this.props.presentSelectorsAmount]
         }
 
     }

--- a/src/components/style/Graphic/ExportableGraphicPickers.tsx
+++ b/src/components/style/Graphic/ExportableGraphicPickers.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ISerie } from "../../../api/Serie";
-import { CHART_TYPE_OPTIONS, AGGREGATION_OPTIONS, UNIT_OPTIONS, frequencyOptions, appropiatedFrequency } from "../../../helpers/graphic/optionPickers";
+import { CHART_TYPE_OPTIONS, AGGREGATION_OPTIONS, UNIT_OPTIONS, frequencyOptions, appropiatedFrequency } from "../../../helpers/graphic/optionSelectors";
 import OptionsPicker from "../../common/picker/OptionsPicker";
 
 export interface IExportableGraphicPickersProps {
@@ -51,20 +51,12 @@ export default class ExportableGraphicPickers extends React.Component<IExportabl
 
         return (
             <div className="g-pickers-container" style={containerStyle}>
-                { this.props.chartTypeSelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
-                                                                 onChangeOption={this.props.handleChangeChartType}
-                                                                 selected={this.props.selectedChartType}
-                                                                 availableOptions={CHART_TYPE_OPTIONS}
-                                                                 label="Tipo de Gráfico"
+                { this.props.frequencySelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
+                                                                 onChangeOption={this.props.handleChangeFrequency}
+                                                                 selected={initialFrequency}
+                                                                 availableOptions={frequencyOptions(this.props.series)}
+                                                                 label="Frecuencia"
                                                                  style={pickerStyle} />)
-                                               : emptyDiv 
-                }
-                { this.props.aggregationSelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
-                                                                   onChangeOption={this.props.handleChangeAggregation}
-                                                                   selected={this.props.selectedAggregation}
-                                                                   availableOptions={AGGREGATION_OPTIONS}
-                                                                   label="Agregación"
-                                                                   style={pickerStyle} />)
                                                  : emptyDiv 
                 }
                 { this.props.unitsSelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
@@ -75,13 +67,21 @@ export default class ExportableGraphicPickers extends React.Component<IExportabl
                                                              style={pickerStyle} />)
                                                  : emptyDiv 
                 }
-                { this.props.frequencySelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
-                                                                 onChangeOption={this.props.handleChangeFrequency}
-                                                                 selected={initialFrequency}
-                                                                 availableOptions={frequencyOptions(this.props.series)}
-                                                                 label="Frecuencia"
-                                                                 style={pickerStyle} />)
+                { this.props.aggregationSelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
+                                                                   onChangeOption={this.props.handleChangeAggregation}
+                                                                   selected={this.props.selectedAggregation}
+                                                                   availableOptions={AGGREGATION_OPTIONS}
+                                                                   label="Agregación"
+                                                                   style={pickerStyle} />)
                                                  : emptyDiv 
+                }
+                { this.props.chartTypeSelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
+                                                                 onChangeOption={this.props.handleChangeChartType}
+                                                                 selected={this.props.selectedChartType}
+                                                                 availableOptions={CHART_TYPE_OPTIONS}
+                                                                 label="Tipo de Gráfico"
+                                                                 style={pickerStyle} />)
+                                               : emptyDiv 
                 }
             </div>
         )

--- a/src/components/style/Graphic/ExportableGraphicPickers.tsx
+++ b/src/components/style/Graphic/ExportableGraphicPickers.tsx
@@ -1,0 +1,143 @@
+import OptionsPicker, { IPickerOptionsProps } from "../../common/picker/OptionsPicker";
+import * as React from "react";
+import { ISerie } from "../../../api/Serie";
+import { isHigherFrequency } from "../../../api/utils/periodicityManager";
+
+export interface IExportableGraphicPickersProps {
+    series: ISerie[];
+    handleChangeFrequency: (value: string) => void;
+    handleChangeUnits: (value: string) => void;
+    handleChangeAggregation: (value: string) => void;
+    handleChangeChartType: (value: string) => void;
+    selectedFrequency: string;
+    selectedUnits: string;
+    selectedAggregation: string;
+    selectedChartType: string;
+    chartTypeSelector: boolean;
+    aggregationSelector: boolean;
+    unitsSelector: boolean;
+    frequencySelector: boolean;
+}
+
+const FREQUENCY_MAPPING = {
+    "Diaria": "day",
+    "Mensual": "month",
+    "Trimestral": "quarter",
+    "Semestral": "semester",
+    "Anual": "year"
+}
+
+export default class ExportableGraphicPickers extends React.Component<IExportableGraphicPickersProps, any> {
+
+    public render() {
+
+        if(this.props.series.length === 0) {
+            return null;
+        }
+
+        const initialFrequency = this.props.selectedFrequency === '' ? this.highestFrequency() : this.props.selectedFrequency;
+        const emptyDiv = <div className="col-xs-12 col-md-3 col-lg-3"/>;
+
+        return (
+            <div className="g-pickers-container">
+                { this.props.chartTypeSelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
+                                                                 onChangeOption={this.props.handleChangeChartType}
+                                                                 selected={this.props.selectedChartType}
+                                                                 availableOptions={this.chartTypeOptions()}
+                                                                 label="Tipo de Gráfico" />)
+                                               : emptyDiv 
+                }
+                { this.props.aggregationSelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
+                                                                   onChangeOption={this.props.handleChangeAggregation}
+                                                                   selected={this.props.selectedAggregation}
+                                                                   availableOptions={this.aggregationOptions()}
+                                                                   label="Agregación" />)
+                                                 : emptyDiv 
+                }
+                { this.props.unitsSelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
+                                                             onChangeOption={this.props.handleChangeUnits}
+                                                             selected={this.props.selectedUnits}
+                                                             availableOptions={this.unitOptions()}
+                                                             label="Unidades" />)
+                                                 : emptyDiv 
+                }
+                { this.props.frequencySelector ? (<OptionsPicker className="col-xs-12 col-md-3 col-lg-3 g-picker"
+                                                                 onChangeOption={this.props.handleChangeFrequency}
+                                                                 selected={initialFrequency}
+                                                                 availableOptions={this.frequencyOptions()}
+                                                                 label="Frecuencia" />)
+                                                 : emptyDiv 
+                }
+            </div>
+        )
+
+    }
+
+    public chartTypeOptions(): IPickerOptionsProps[] {
+        return [
+            { value: "line", title: "Líneas", available: true },
+            { value: "column", title: "Columnas", available: true },
+            { value: "area", title: "Áreas", available: true }
+        ];
+    }
+
+    public unitOptions(): IPickerOptionsProps[] {
+        return [
+            { value: "value", title: "Unidades originales", available: true },
+            { value: "change", title: "Variación", available: true },
+            { value: "change_a_year_ago", title: "Variación interanual", available: true },
+            { value: "change_since_beginning_of_year", title: "Variación acumulada anual", available: true },
+            { value: "percent_change", title: "Variación porcentual", available: true },
+            { value: "percent_change_a_year_ago", title: "Variación porcentual interanual", available: true },
+            { value: "percent_change_since_beginning_of_year", title: "Variación porcentual acumulada anual", available: true }
+        ];
+    }
+
+    public aggregationOptions(): IPickerOptionsProps[] {
+        return [
+            { value: "avg", title: "Promedio", available: true },
+            { value: "sum", title: "Suma", available: true },
+            { value: "min", title: "Mínimo", available: true },
+            { value: "max", title: "Máximo", available: true },
+            { value: "end_of_period", title: "Último valor del período", available: true }
+        ];
+    }
+
+    public frequencyOptions(): IPickerOptionsProps[] {
+        const accrualPeriodicity = this.appropiatedFrequency();
+        // noinspection TsLint
+        const options = [
+            { value: 'year',     title: 'Anual',      available: false },
+            { value: 'semester', title: 'Semestral',  available: false },
+            { value: 'quarter',  title: 'Trimestral', available: false },
+            { value: 'month',    title: 'Mensual',    available: false },
+            { value: 'day',      title: 'Diaria',     available: false },
+        ];
+
+        const optionIndex = options.findIndex((option: IPickerOptionsProps) => option.title === accrualPeriodicity);
+        options.forEach((option: IPickerOptionsProps) => {
+            option.available = options.indexOf(option) <= optionIndex;
+        });
+
+        return options;
+    }
+
+    private appropiatedFrequency(): string {
+        let higherFrequency = this.props.series[0].accrualPeriodicity;
+        this.props.series.forEach((serie: ISerie) => {
+            if (isHigherFrequency(serie.accrualPeriodicity, higherFrequency)) {
+                higherFrequency = serie.accrualPeriodicity;
+            }
+        });
+
+        return higherFrequency;
+    }
+
+    private highestFrequency(): string {
+
+        const frequencyTitle = this.appropiatedFrequency();
+        return FREQUENCY_MAPPING[frequencyTitle];
+
+    }
+
+}

--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -192,7 +192,7 @@ export class ViewPage extends React.Component<IViewPageProps, IViewPageState> {
 
     private setParamsAndFetch(ids: string[], location: Location) {
         const queryParams = new QueryParams(ids);
-        queryParams.addParamsFrom(getQueryParams(location));
+        queryParams.addParamsFrom(getQueryParams(location), true);
 
         this.fetchSeries(queryParams);
     }

--- a/src/components/viewpage/ViewPage.tsx
+++ b/src/components/viewpage/ViewPage.tsx
@@ -192,7 +192,7 @@ export class ViewPage extends React.Component<IViewPageProps, IViewPageState> {
 
     private setParamsAndFetch(ids: string[], location: Location) {
         const queryParams = new QueryParams(ids);
-        queryParams.addParamsFrom(getQueryParams(location), true);
+        queryParams.addParamsFrom(getQueryParams(location));
 
         this.fetchSeries(queryParams);
     }

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -119,22 +119,9 @@ export default class Graphic extends React.Component<IGraphicProps> {
 
     public shouldComponentUpdate(nextProps: IGraphicProps) {
 
-        /*if (this.props.chartTypes !== nextProps.chartTypes) {
-            return true;
+        if (JSON.stringify(this.props) === JSON.stringify(nextProps)) {
+            return false;
         }
-
-        /const types = (Object as any).values(this.props.chartTypes);
-        if (types.any((chartType: string) => chartType !== 'line')) {
-            return true;
-        }
-
-        if (this.props.series !== nextProps.series) {
-            return true;
-        }
-
-        return this.props.series.every((serie1: ISerie) => {
-            return nextProps.series.every((serie2: ISerie) => serie1.id !== serie2.id)
-        });*/
 
         return true;
 

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -119,13 +119,24 @@ export default class Graphic extends React.Component<IGraphicProps> {
 
     public shouldComponentUpdate(nextProps: IGraphicProps) {
 
-        if (this.props.chartTypes !== nextProps.chartTypes) {
+        /*if (this.props.chartTypes !== nextProps.chartTypes) {
+            return true;
+        }
+
+        /const types = (Object as any).values(this.props.chartTypes);
+        if (types.any((chartType: string) => chartType !== 'line')) {
+            return true;
+        }
+
+        if (this.props.series !== nextProps.series) {
             return true;
         }
 
         return this.props.series.every((serie1: ISerie) => {
             return nextProps.series.every((serie2: ISerie) => serie1.id !== serie2.id)
-        });
+        });*/
+
+        return true;
 
     }
 

--- a/src/components/viewpage/graphic/Graphic.tsx
+++ b/src/components/viewpage/graphic/Graphic.tsx
@@ -38,6 +38,8 @@ export interface IGraphicProps {
     numbersAbbreviate: boolean;
     decimalsBillion: number;
     decimalsMillion: number;
+    originalChartTypes?: IChartTypeProps;
+    waitForSeriesFetch?: boolean;
 }
 
 export interface IStringPropsPerId {
@@ -76,12 +78,17 @@ export default class Graphic extends React.Component<IGraphicProps> {
 
     private myRef: RefObject<any>;
     private yAxisBySeries: IYAxisConf;
+    private originalChartTypes: IChartTypeProps | undefined;
 
     constructor(props: IGraphicProps) {
 
         super(props);
         this.myRef = React.createRef();       
         setHighchartsGlobalConfig(props.locale);
+
+        if (this.props.originalChartTypes !== undefined) {
+            this.originalChartTypes = this.originalChartTypes = JSON.parse(JSON.stringify(this.props.originalChartTypes)) as IChartTypeProps;
+        }
 
     }
 
@@ -119,11 +126,19 @@ export default class Graphic extends React.Component<IGraphicProps> {
 
     public shouldComponentUpdate(nextProps: IGraphicProps) {
 
-        if (JSON.stringify(this.props) === JSON.stringify(nextProps)) {
-            return false;
+        if (JSON.stringify(this.props.series) !== JSON.stringify(nextProps.series)) {
+            return true;
         }
-
-        return true;
+        if (JSON.stringify(this.props.chartTypes) !== JSON.stringify(nextProps.chartTypes)) {
+            return true;
+        }
+        if (this.originalChartTypes !== undefined && 
+            JSON.stringify(nextProps.chartTypes) !== JSON.stringify(this.originalChartTypes) &&
+            nextProps.waitForSeriesFetch === false) {
+            return true;
+        }
+        
+        return false;
 
     }
 

--- a/src/components/viewpage/graphic/GraphicAndShare.tsx
+++ b/src/components/viewpage/graphic/GraphicAndShare.tsx
@@ -16,10 +16,9 @@ import { getQueryParams } from '../ViewPage';
 import Graphic, { IChartExtremeProps } from "./Graphic";
 import GraphicComplements from "./GraphicComplements";
 import { chartExtremes } from '../../../helpers/graphic/chartExtremes';
+import { DEFAULT_REPRESENTATION_MODE } from '../../../helpers/common/URLExtractors';
+import { DEFAULT_CHART_TYPE } from '../../../api/ChartTypeSelector';
 
-
-const DEFAULT_CHART_TYPE: string = 'line';
-const DEFAULT_REPRESENTATION_MODE: string = 'value';
 
 export interface IGraphicAndShareProps {
     series: ISerie[];
@@ -153,7 +152,7 @@ class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
         const endDate = getQueryParams(location).get('end_date') || '';
 
         const queryParams = new QueryParams(ids);
-        queryParams.addParamsFrom(getQueryParams(location), true);
+        queryParams.addParamsFrom(getQueryParams(location));
         queryParams.setChartType(getQueryParams(location).get('chartType')||'line');
         if (this.validStartDateFilter(startDate)) { queryParams.setStartDate(startDate) }
         if (this.validEndDateFilter(endDate)) { queryParams.setEndDate(endDate) }

--- a/src/components/viewpage/graphic/GraphicAndShare.tsx
+++ b/src/components/viewpage/graphic/GraphicAndShare.tsx
@@ -153,7 +153,7 @@ class GraphicAndShare extends React.Component<IGraphicAndShareProps, any> {
         const endDate = getQueryParams(location).get('end_date') || '';
 
         const queryParams = new QueryParams(ids);
-        queryParams.addParamsFrom(getQueryParams(location));
+        queryParams.addParamsFrom(getQueryParams(location), true);
         queryParams.setChartType(getQueryParams(location).get('chartType')||'line');
         if (this.validStartDateFilter(startDate)) { queryParams.setStartDate(startDate) }
         if (this.validEndDateFilter(endDate)) { queryParams.setEndDate(endDate) }

--- a/src/components/viewpage/graphic/GraphicComplements.tsx
+++ b/src/components/viewpage/graphic/GraphicComplements.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ISerie } from "../../../api/Serie";
 import OptionsPicker, { IPickerStyle } from '../../common/picker/OptionsPicker';
 import ShareLinks from '../ShareLinks';
-import { CHART_TYPE_OPTIONS, AGGREGATION_OPTIONS, UNIT_OPTIONS, frequencyOptions } from '../../../helpers/graphic/optionPickers';
+import { CHART_TYPE_OPTIONS, AGGREGATION_OPTIONS, UNIT_OPTIONS, frequencyOptions } from '../../../helpers/graphic/optionSelectors';
 
 
 export interface IGraphicComplementsProps {

--- a/src/helpers/common/URLExtractors.ts
+++ b/src/helpers/common/URLExtractors.ts
@@ -1,14 +1,19 @@
 import { IDateRange } from "../../api/DateSerie";
 
+export interface ICollapseParams {
+    collapse: string;
+    collapseAggregation: string;
+}
+
 export class IDsExtractor {
 
     private idsParam: string;
     private repModeParam: string;
 
-    constructor(url: string) {
+    constructor(url: string, representationMode?: string) {
         const params = new URLSearchParams(url.split('?')[1]);
         this.idsParam = params.get('ids') || '';
-        this.repModeParam = params.get('representation_mode') || '';
+        this.repModeParam = representationMode || params.get('representation_mode') || '';
     }
 
     public getIDsAsTheyAre(): string[] {
@@ -67,6 +72,33 @@ export function getDateFromUrl(url: string): IDateRange {
     const end = params.get('end_date') || '';
 
     return { start, end };
+
+}
+
+export function getRepresentationModeFromUrl(url: string): string {
+
+    const params = new URLSearchParams(url);
+    let repMode = params.get('representation_mode') || '';
+
+    const series = params.getAll('ids');
+    if (series.length === 1) {
+        if (series[0].indexOf(':') !== -1) {
+            repMode = series[0].split(':')[1];
+        }
+    }
+
+    return repMode;
+
+}
+
+export function getCollapseParamsFromUrl(url: string): ICollapseParams {
+
+    const params = new URLSearchParams(url);
+
+    const collapse = params.get('collapse') || '';
+    const collapseAggregation = params.get('collapse_aggregation') || '';
+
+    return { collapse, collapseAggregation };
 
 }
 

--- a/src/helpers/common/URLExtractors.ts
+++ b/src/helpers/common/URLExtractors.ts
@@ -81,29 +81,54 @@ export function getDateFromUrl(url: string): IDateRange {
 
 export function getRepresentationModeFromUrl(url: string): string {
 
-    const params = new URLSearchParams(url);
+    const searchQuery = new URL(url).search;
+    const params = new URLSearchParams(searchQuery);
     const repMode = params.get('representation_mode') || '';
 
     if (repMode !== '') { return repMode; }
 
     const IDsQueryParam = params.get('ids');
+    const specificRepModes = [];
 
     if (IDsQueryParam !== null) {
         const seriesIDs = IDsQueryParam.split(',');
         for (const id of seriesIDs) {
             if (id.indexOf(':') !== -1) {
-                return id.split(':')[1];
+                specificRepModes.push(id.split(':')[1]);
+            }
+            else {
+                specificRepModes.push(DEFAULT_REPRESENTATION_MODE);
             }
         }
+    }
+
+    specificRepModes.sort();
+    if (specificRepModes[0] === specificRepModes[specificRepModes.length - 1]) {
+        return specificRepModes[0];
     }
 
     return DEFAULT_REPRESENTATION_MODE;
 
 }
 
+export function getUpdatedRepModeURL(originalURL: string, newRepMode: string): string {
+
+    if (originalURL.indexOf('representation_mode=') !== -1) {
+        const originalRepMode = originalURL.split('representation_mode=')[1].split('&')[0];
+        return originalURL.replace(originalRepMode, newRepMode);
+    }
+
+    if (newRepMode !== DEFAULT_REPRESENTATION_MODE) {
+        return `${originalURL}&representation_mode=${newRepMode}`;
+    }
+    return originalURL;    
+
+}
+
 export function getCollapseParamsFromUrl(url: string): ICollapseParams {
 
-    const params = new URLSearchParams(url);
+    const searchQuery = new URL(url).search;
+    const params = new URLSearchParams(searchQuery);
 
     const collapse = params.get('collapse') || '';
     const collapseAggregation = params.get('collapse_aggregation') || DEFAULT_COLLAPSE_AGGREGATION;

--- a/src/helpers/common/URLExtractors.ts
+++ b/src/helpers/common/URLExtractors.ts
@@ -1,5 +1,9 @@
 import { IDateRange } from "../../api/DateSerie";
 
+
+export const DEFAULT_REPRESENTATION_MODE: string = 'value';
+const DEFAULT_COLLAPSE_AGGREGATION: string = 'avg'
+
 export interface ICollapseParams {
     collapse: string;
     collapseAggregation: string;
@@ -10,10 +14,10 @@ export class IDsExtractor {
     private idsParam: string;
     private repModeParam: string;
 
-    constructor(url: string, representationMode?: string) {
+    constructor(url: string) {
         const params = new URLSearchParams(url.split('?')[1]);
         this.idsParam = params.get('ids') || '';
-        this.repModeParam = representationMode || params.get('representation_mode') || '';
+        this.repModeParam = params.get('representation_mode') || '';
     }
 
     public getIDsAsTheyAre(): string[] {
@@ -78,16 +82,22 @@ export function getDateFromUrl(url: string): IDateRange {
 export function getRepresentationModeFromUrl(url: string): string {
 
     const params = new URLSearchParams(url);
-    let repMode = params.get('representation_mode') || '';
+    const repMode = params.get('representation_mode') || '';
 
-    const series = params.getAll('ids');
-    if (series.length === 1) {
-        if (series[0].indexOf(':') !== -1) {
-            repMode = series[0].split(':')[1];
+    if (repMode !== '') { return repMode; }
+
+    const IDsQueryParam = params.get('ids');
+
+    if (IDsQueryParam !== null) {
+        const seriesIDs = IDsQueryParam.split(',');
+        for (const id of seriesIDs) {
+            if (id.indexOf(':') !== -1) {
+                return id.split(':')[1];
+            }
         }
     }
 
-    return repMode;
+    return DEFAULT_REPRESENTATION_MODE;
 
 }
 
@@ -96,7 +106,7 @@ export function getCollapseParamsFromUrl(url: string): ICollapseParams {
     const params = new URLSearchParams(url);
 
     const collapse = params.get('collapse') || '';
-    const collapseAggregation = params.get('collapse_aggregation') || '';
+    const collapseAggregation = params.get('collapse_aggregation') || DEFAULT_COLLAPSE_AGGREGATION;
 
     return { collapse, collapseAggregation };
 

--- a/src/helpers/common/chartTypeHandling.ts
+++ b/src/helpers/common/chartTypeHandling.ts
@@ -1,0 +1,48 @@
+import { IChartTypeProps } from "../../components/viewpage/graphic/Graphic";
+import { ISerie } from "../../api/Serie";
+import { ISerieFullID, getFullSerieId } from "./fullSerieID";
+import { DEFAULT_CHART_TYPE } from "../../api/ChartTypeSelector";
+
+export function getChartType(serie: ISerie, types?: IChartTypeProps): string {
+
+    if (!types) { return 'line' }
+
+    const serieFullID: ISerieFullID = {
+        id: serie.id,
+        representationMode: serie.representationMode
+    }
+    return types[getFullSerieId(serieFullID)];
+
+}
+
+export function hasSpecifiedChartType(id: string, chartTypes: IChartTypeProps): boolean {
+
+    const pureID = id.split(':')[0];
+    if (chartTypes[id] !== undefined || chartTypes[pureID] !== undefined) {
+        return true;
+    }
+
+    return false;
+
+}
+
+export function getSelectedChartType(chartTypes: IChartTypeProps, ids: string[], chartType?: string): string {
+
+    if(chartType !== undefined) { return chartType; }
+
+    const types: string[] = (Object as any).values(chartTypes);
+    if (types.every((type: string) => type === DEFAULT_CHART_TYPE)) {
+        return DEFAULT_CHART_TYPE;
+    }
+
+    // If every serie has a specified chartType and they're all the same, that's the selected type
+    if (ids.every((id: string) => hasSpecifiedChartType(id, chartTypes))) { 
+        types.sort();
+        if (types[0] === types[types.length - 1]) {
+            return types[0];
+        }
+    }
+
+    return DEFAULT_CHART_TYPE;
+
+}

--- a/src/helpers/common/fullSerieID.ts
+++ b/src/helpers/common/fullSerieID.ts
@@ -1,6 +1,4 @@
-import { ISerie } from "../../api/Serie";
 import SerieConfig from "../../api/SerieConfig";
-import { IChartTypeProps } from "../../components/viewpage/graphic/Graphic";
 
 export interface ISerieFullID {
     id: string;
@@ -15,16 +13,4 @@ export function getFullSerieId(serie: ISerieFullID): string {
 
 export function findSerieConfig(configs: SerieConfig[], serieId: string) {
     return configs.find((config: SerieConfig) => config.getFullSerieId() === serieId);
-}
-
-export function getChartType(serie: ISerie, types?: IChartTypeProps): string {
-
-    if (!types) { return 'line' }
-
-    const serieFullID: ISerieFullID = {
-        id: serie.id,
-        representationMode: serie.representationMode
-    }
-    return types[getFullSerieId(serieFullID)];
-
 }

--- a/src/helpers/graphic/fetchParamsBuilder.ts
+++ b/src/helpers/graphic/fetchParamsBuilder.ts
@@ -1,0 +1,40 @@
+import QueryParams from "../../api/QueryParams";
+
+export interface IFetchParamsBuildingConfig {
+    collapse: string,
+    collapseAggregation: string,
+    ids: string[],
+    representationMode?: string
+}
+
+export default class FetchParamsBuilder {
+
+    private startDate: string;
+    private endDate: string;
+
+    public constructor(graphicUrl: string) {
+
+        const url = new URLSearchParams(graphicUrl);
+        this.startDate = url.get('start_date') || '';
+        this.endDate = url.get('end_date') || '';
+
+    }
+
+    public getParams(config: IFetchParamsBuildingConfig): QueryParams {
+
+        const params = new QueryParams(config.ids);
+        params.setStartDate(this.startDate);
+        params.setEndDate(this.endDate);
+        
+        params.setCollapse(config.collapse);
+        params.setCollapseAggregation(config.collapseAggregation);
+        if(config.representationMode !== undefined) {
+            params.setRepresentationMode(config.representationMode);
+        }
+
+        return params;
+
+    }
+
+
+}

--- a/src/helpers/graphic/hcSerieFromISerie.ts
+++ b/src/helpers/graphic/hcSerieFromISerie.ts
@@ -1,4 +1,4 @@
-import { getChartType, getFullSerieId } from "../common/fullSerieID";
+import { getFullSerieId } from "../common/fullSerieID";
 import { timestamp } from "../common/dateFunctions";
 import { ISerie } from "../../api/Serie";
 import { IYAxis, IYAxisConf, ILegendLabel, IChartTypeProps } from "../../components/viewpage/graphic/Graphic";
@@ -6,6 +6,7 @@ import { IHCSerie } from "../../components/viewpage/graphic/highcharts";
 import { DEFAULT_HC_SERIES_CONFIG } from "./hcConfiguration";
 import { getSerieColor, Color } from "../../components/style/Colors/Color";
 import { valuesFromObject } from "../common/commonFunctions";
+import { getChartType } from "../common/chartTypeHandling";
 
 export interface IHighchartsSerieBuilderOptions {
     chartTypes?: IChartTypeProps,

--- a/src/helpers/graphic/optionSelectors.ts
+++ b/src/helpers/graphic/optionSelectors.ts
@@ -1,6 +1,6 @@
 import { IPickerOptionsProps } from "../../components/common/picker/OptionsPicker";
 import { ISerie } from "../../api/Serie";
-import { isHigherFrequency } from "../../api/utils/periodicityManager";
+import { isLowerFrequency } from "../../api/utils/periodicityManager";
 
 export const CHART_TYPE_OPTIONS: IPickerOptionsProps[] = [
     { value: "line", title: "Líneas", available: true },
@@ -30,7 +30,7 @@ export function appropiatedFrequency(series: ISerie[]): string {
 
     let higherFrequency = series[0].accrualPeriodicity;
     series.forEach((serie: ISerie) => {
-        if (isHigherFrequency(serie.accrualPeriodicity, higherFrequency)) {
+        if (isLowerFrequency(serie.accrualPeriodicity, higherFrequency)) {
             higherFrequency = serie.accrualPeriodicity;
         }
     });
@@ -42,20 +42,20 @@ export function appropiatedFrequency(series: ISerie[]): string {
 export function frequencyOptions(series: ISerie[]): IPickerOptionsProps[] {
 
     const accrualPeriodicity = appropiatedFrequency(series);
-        // noinspection TsLint
-        const options = [
-            { value: 'year',     title: 'Anual',      available: false },
-            { value: 'semester', title: 'Semestral',  available: false },
-            { value: 'quarter',  title: 'Trimestral', available: false },
-            { value: 'month',    title: 'Mensual',    available: false },
-            { value: 'day',      title: 'Diaria',     available: false },
-        ];
+    // noinspection TsLint
+    const options = [
+        { value: 'year',     title: 'Anual',      available: false },
+        { value: 'semester', title: 'Semestral',  available: false },
+        { value: 'quarter',  title: 'Trimestral', available: false },
+        { value: 'month',    title: 'Mensual',    available: false },
+        { value: 'day',      title: 'Diaria',     available: false },
+    ];
 
-        const optionIndex = options.findIndex((option: IPickerOptionsProps) => option.title === accrualPeriodicity);
-        options.forEach((option: IPickerOptionsProps) => {
-            option.available = options.indexOf(option) <= optionIndex;
-        });
+    const optionIndex = options.findIndex((option: IPickerOptionsProps) => option.title === accrualPeriodicity);
+    options.forEach((option: IPickerOptionsProps) => {
+        option.available = options.indexOf(option) <= optionIndex;
+    });
 
-        return options;
+    return options;
 
 }

--- a/src/indexGraphic.tsx
+++ b/src/indexGraphic.tsx
@@ -9,7 +9,7 @@ export function render(selector: string, config: IGraphicExportableProps) {
     const abbreviationProps = buildAbbreviationProps(config.numbersAbbreviate, config.decimalsBillion, config.decimalsMillion);
 
     ReactDOM.render(
-        <GraphicExportable graphicUrl={config.graphicUrl}
+        <GraphicExportable graphicUrl={config.graphicUrl} 
                            chartOptions={config.chartOptions || {}}
                            navigator={config.navigator}
                            locale={config.locale}
@@ -35,7 +35,11 @@ export function render(selector: string, config: IGraphicExportableProps) {
                            last={config.last} 
                            numbersAbbreviate={abbreviationProps.numbersAbbreviate}
                            decimalsBillion={abbreviationProps.decimalsBillion}
-                           decimalsMillion={abbreviationProps.decimalsMillion} />,
+                           decimalsMillion={abbreviationProps.decimalsMillion}
+                           chartTypeSelector={config.chartTypeSelector}
+                           aggregationSelector={config.aggregationSelector}
+                           unitsSelector={config.unitsSelector}
+                           frequencySelector={config.frequencySelector} />,
         document.getElementById(selector) as HTMLElement
     )
 

--- a/src/tests/components/helpers/ChartType.test.ts
+++ b/src/tests/components/helpers/ChartType.test.ts
@@ -1,7 +1,7 @@
 import { IChartTypeProps } from "../../../components/viewpage/graphic/Graphic";
 import { ISerie } from "../../../api/Serie";
 import { generateCommonMockSerieEMAE, generateCommonMockSerieMotos, generatePercentageMockSerie, generatePercentageYearMockSerie } from "../../support/mockers/seriesMockers";
-import { getChartType } from "../../../helpers/common/fullSerieID";
+import { getChartType } from "../../../helpers/common/chartTypeHandling";
 
 describe("Chart Type settings between different series", () => {
 

--- a/src/tests/components/helpers/ChartTypeHandling.test.ts
+++ b/src/tests/components/helpers/ChartTypeHandling.test.ts
@@ -1,0 +1,89 @@
+import { IChartTypeProps } from "../../../components/viewpage/graphic/Graphic"
+import { hasSpecifiedChartType, getSelectedChartType } from "../../../helpers/common/chartTypeHandling";
+import { DEFAULT_CHART_TYPE } from "../../../api/ChartTypeSelector";
+
+describe("Verification of a serie having a specific chartType assigned", () => {
+
+    let chartTypes: IChartTypeProps;
+    let serieID: string;
+
+    it("If the serie's ID is has an exact match on the types' keys, true is returned", () => {
+        serieID = "serieOne";
+        chartTypes = {
+            'serieOne': 'column',
+            'serieTwo': 'area'
+        };
+        expect(hasSpecifiedChartType(serieID, chartTypes)).toBe(true);
+    });
+    it("If the serie's ID is compose and at least its base is used as a key, true is returned", () => {
+        serieID = 'serieA:change';
+        chartTypes = {
+            'serieA': 'area'
+        };
+        expect(hasSpecifiedChartType(serieID, chartTypes)).toBe(true);
+    });
+    it("If nor the serie's full nor base ID are used as keys, false is returned", () => {
+        serieID = 'serieThree';
+        chartTypes = {
+            'serieFour': 'line',
+            'serieB': 'column'
+        };
+        expect(hasSpecifiedChartType(serieID, chartTypes)).toBe(false);
+    })
+
+})
+
+describe("Obtention of the initially selected chartType from a config", () => {
+
+    let chartTypesProp: IChartTypeProps;
+    let involvedIDs: string[];
+    let chartTypeProp: string;
+    let selectedChartType: string;
+
+    beforeAll(() => {
+        involvedIDs = ['serieOne', 'serieOne:change', 'serieTwo'];
+    })
+
+    it("If the chartType prop is employed, then it is the selected one", () => {
+        chartTypesProp = {
+            'serieOne': 'column'
+        };
+        chartTypeProp = 'area';
+        selectedChartType = getSelectedChartType(chartTypesProp, involvedIDs, chartTypeProp);
+        expect(selectedChartType).toEqual('area');
+    });
+
+    describe("Tests without using the chartType prop", () => {
+
+        it("If every specified type is the default one, such is the selected one", () => {
+            chartTypesProp = {
+                'serieOne:change': DEFAULT_CHART_TYPE
+            };
+            selectedChartType = getSelectedChartType(chartTypesProp, involvedIDs);
+            expect(selectedChartType).toEqual(DEFAULT_CHART_TYPE);
+        });
+        it("If every serie has a specified chartType and they're all the same, that's the selected one", () => {
+            chartTypesProp = {
+                'serieOne': 'column',
+                'serieTwo': 'column'
+            };
+            selectedChartType = getSelectedChartType(chartTypesProp, involvedIDs);
+            expect(selectedChartType).toEqual('column');
+        });
+        it("If every serie has a specified chartType but they're not all the same, the default is the selected one", () => {
+            chartTypesProp = {
+                'serieOne': 'line',
+                'serieTwo': 'column'
+            };
+            selectedChartType = getSelectedChartType(chartTypesProp, involvedIDs);
+            expect(selectedChartType).toEqual(DEFAULT_CHART_TYPE);
+        });
+        it("If neither the chartTypes prop is employed, the default type is the selected onde", () => {
+            chartTypesProp = {};
+            selectedChartType = getSelectedChartType(chartTypesProp, involvedIDs);
+            expect(selectedChartType).toEqual(DEFAULT_CHART_TYPE);
+        });
+
+    })
+
+})

--- a/src/tests/components/helpers/FetchParamsBuilder.test.ts
+++ b/src/tests/components/helpers/FetchParamsBuilder.test.ts
@@ -1,0 +1,60 @@
+import FetchParamsBuilder, { IFetchParamsBuildingConfig } from "../../../helpers/graphic/fetchParamsBuilder";
+import QueryParams from "../../../api/QueryParams";
+
+describe("Usage of a builder to obtain the params for fetching series at GraphicExportable", () => {
+
+    let url: string;
+    let builder: FetchParamsBuilder;
+    let config: IFetchParamsBuildingConfig;
+    let params: QueryParams;
+
+    beforeAll(() => {
+        url = 'https://apis.datos.gob.ar/series/api/series/?ids=122.2_CV_1999_0_12&start_date=2008-10-14&end_date=2014-05-09';
+        builder = new FetchParamsBuilder(url);
+    })
+
+    describe("Building params without specifying a representationMode", () => {
+
+        beforeAll(() => {
+            config = {
+                collapse: 'quarter',
+                collapseAggregation: 'sum',
+                ids: ['serieA:change', 'serieB', 'serieC']
+            };
+            params = builder.getParams(config);
+        });
+
+        it("The collapse param is copied as it is", () => {
+            expect(params.getCollapse()).toEqual('quarter');
+        });
+        it("The collapse aggregation param is copied as it is", () => {
+            expect(params.getCollapseAggregation()).toEqual('sum');
+        });
+        it("The ids are copied as they are and joined by ',' characters into a single string", () => {
+            expect(params.getIds()).toEqual('serieA:change,serieB,serieC');
+        });
+
+    })
+
+    describe("Building params specifying a representationMode", () => {
+
+        beforeAll(() => {
+            config = {
+                collapse: 'month',
+                collapseAggregation: 'min',
+                ids: ['serieA', 'serieB:change_since_beginning_of_year'],
+                representationMode: 'percent_change_a_year_ago'
+            };
+            params = builder.getParams(config);
+        });
+
+        it("The representation mode param is copied as it is", () => {
+            expect(params.getRepresentationMode()).toEqual('percent_change_a_year_ago');
+        });
+        it("The ids are copied as they are, despite the representationMode", () => {
+            expect(params.getIds()).toEqual('serieA,serieB:change_since_beginning_of_year');
+        });
+
+    })
+
+})

--- a/src/tests/components/helpers/OptionSelectors.test.ts
+++ b/src/tests/components/helpers/OptionSelectors.test.ts
@@ -1,0 +1,82 @@
+import { ISerie } from "../../../api/Serie"
+import { generateCommonMockSerieEMAE, generateCommonMockSerieMotos, generateYearlyFrequencySerie, generateDailyFrequencySerie } from "../../support/mockers/seriesMockers";
+import { appropiatedFrequency, frequencyOptions } from "../../../helpers/graphic/optionSelectors";
+import { IPickerOptionsProps } from "../../../components/common/picker/OptionsPicker";
+
+describe("Obtainment of the lowest common frequency between a group of series", () => {
+
+    let serieOne: ISerie;
+    let serieTwo: ISerie;
+    let serieThree: ISerie;
+    let series: ISerie[]; 
+    let lowestFrequency: string; 
+    
+    beforeAll(() => {
+        serieOne = generateCommonMockSerieEMAE();
+        serieTwo = generateCommonMockSerieMotos();
+        serieThree = generateYearlyFrequencySerie();
+    })
+
+    it("If there is only one serie, its frequency is the lowest", () => {
+        series = [serieOne];
+        lowestFrequency = appropiatedFrequency(series);
+        expect(lowestFrequency).toEqual(serieOne.accrualPeriodicity);
+    });
+    it("If both series have the same frequency, such is the lowest", () => {
+        series = [serieOne, serieTwo];
+        lowestFrequency = appropiatedFrequency(series);
+        expect(lowestFrequency).toEqual("Mensual");
+    });
+    it("The less frequent or smallest of the series' frequencies is considered the lowest one", () => {
+        series = [serieOne, serieTwo, serieThree];
+        lowestFrequency = appropiatedFrequency(series);
+        expect(lowestFrequency).toEqual("Anual");
+    });
+
+})
+
+describe("Obtainment of available options for a frequency selector", () => {
+
+    let serieOne: ISerie;
+    let serieTwo: ISerie;
+    let serieThree: ISerie;
+    let series: ISerie[]; 
+    let finalOptions: IPickerOptionsProps[];
+
+    function availableFrequencies(options: IPickerOptionsProps[]): string[] {
+
+        const available = [];
+
+        for (const option of options) {
+            if (option.available) {
+                available.push(option.title);
+            }
+        }
+
+        return available;
+
+    }
+
+    beforeAll(() => {
+        serieOne = generateCommonMockSerieEMAE();
+        serieTwo = generateYearlyFrequencySerie();
+        serieThree = generateDailyFrequencySerie();
+    })
+
+    it("Only the lowest common frequency and lower possible frequencies are available", () => {
+        series = [serieOne, serieThree];
+        finalOptions = frequencyOptions(series);
+        expect(availableFrequencies(finalOptions)).toEqual(["Anual", "Semestral", "Trimestral", "Mensual"]);
+    });
+    it("If the lowest common frequency is yearly, only such is available", () => {
+        series = [serieTwo, serieThree];
+        finalOptions = frequencyOptions(series);
+        expect(availableFrequencies(finalOptions)).toEqual(["Anual"]);
+    });
+    it("If the lowest common frequency is daily, every existing frequency is available", () => {
+        series = [serieThree];
+        finalOptions = frequencyOptions(series);
+        expect(availableFrequencies(finalOptions)).toEqual(["Anual", "Semestral", "Trimestral", "Mensual", "Diaria"]);
+    });
+
+})

--- a/src/tests/support/mockers/seriesMockers.ts
+++ b/src/tests/support/mockers/seriesMockers.ts
@@ -1,7 +1,7 @@
 export function generateCommonMockSerieEMAE() {
 
     return {
-        accrualPeriodicity: "R/P1M",
+        accrualPeriodicity: "Mensual",
         collapseAggregation: "CollapseAgregation",
         data: [{ date: "2018-07-01", value: 145.30019275372558 },
         { date: "2018-08-01", value: 145.96423636915267 },
@@ -48,7 +48,7 @@ export function generateCommonMockSerieEMAE() {
 export function generateCommonMockSerieMotos() {
 
     return {
-        accrualPeriodicity: "R/P1M",
+        accrualPeriodicity: "Mensual",
         collapseAggregation: "CollapseAgregation",
         data: [{ date: "2018-09-01", value: 33896 },
         { date: "2018-10-01", value: 35567 },
@@ -107,6 +107,18 @@ export function generatePercentageYearMockSerie() {
     serie.representationMode = "percent_change_a_year_ago";
     return serie;
 
+}
+
+export function generateYearlyFrequencySerie() {
+    const serie = generateCommonMockSerieEMAE();
+    serie.accrualPeriodicity = "Anual";
+    return serie;
+}
+
+export function generateDailyFrequencySerie() {
+    const serie = generateCommonMockSerieEMAE();
+    serie.accrualPeriodicity = "Diaria";
+    return serie;
 }
 
 export function generateEmptySerie() {


### PR DESCRIPTION
#### Contexto
Agrego, opcionalmente, cuatro selectores desplegables al componente exportable `Graphic`, análogos a los existentes en la sección de _Detalle_ del componente `Explorer`. La presencia o no de los mismos depende de cuatro parámetros, los cuales por defecto están seteados en `false`: 
- `chartTypeSelector`, el cual permite elegir el tipo de gráfico a dibujar para toda aquella serie que no tenga uno especificado en el parámetro `chartTypes`. Al ser utilizado, pisa el valor del parámetro opcional `chartType`, si lo hubiera.
- `unitsSelector`, el cual permite elegir las unidades a usar para todas aquellas series que no tengan un modificador de unidades explícito en su ID en la URL, ya que dicho modificador siempre prevalece. Reemplaza al valor del query param `representation_mode` en la URL.
- `frequencySelector`, el cual permite elegir la frecuencia de agregado de las series involucradas. Solo permite usar frecuencias menores o iguales a la frecuencia nativa más chica de las series presentes. Reemplaza al parámetro `collapse` en la URL.
- `aggregationSelector`, el cual permite elegir el criterio de agregado de las series involucradas. Reemplaza al parámetro `collapse_aggregation` en la URL.

Para lograr el comportamiento correcto, retoco varias partes del código y agrego funciones auxiliares, con sus correspondientes casos de prueba:
- Creo el subcomponente `ExportableGraphicPickers`, el cual engloba los selectores elegidos por parámetro y su contenedor. Utiliza callbacks para notificar al `GraphicExportable` que cambiaron los valores seleccionados, y depende de su ancho para disponer a los selecotres. Dichos selectores son el componente `OptionsPicker`, reutilizado.
- Agrego al estado del componente `GraphicExportable` los valores intrínsecos de cada una de sus opciones seleccionadas, los cuales son usados para re-renderear el componente y su `Graphic` interno, y para definir la URL de la API call en cada actualización.
- Agrego al componente `GraphicExportable` algunos atributos, donde guardar el ancho del gráfico, los ¨chartTypes¨ originales y un flag para saber si debe esperarse a que se traigan las series de la API para re-renderear (solo falso cuando se actualiza el tipo de gráfico), entre otros.
- Modifico los lifecycle hooks de `Graphic` y `GraphicExportable` que deciden cuándo re-renderearlos, de modo que hagan comparaciones de las props y los states, pero no como objetos Typescript (siempre distintos) sino propiedad a propiedad, para optimizar la cantidad de veces que se re-dibuja. El `Graphic` interno también depende del valor de un flag que indica si debe esperar un fetch de la API o no.
- Recalculo el alto del gráfico del `GraphicExportable` como el alto del `div` raíz que lo renderiza, menos el alto de la fuente, menos el alto acumulado entre selectores (si los hay).
- Agrego estilos de CSS para que no se usen altos relativos en los componentes de mayor nivel, sino que siempre quede todo `div` interno dentro del espacio asignado al `div` raíz. A su vez, así logro que los selectores siempre queden debajo de la fuente.
- Muevo funciones reutilizadas del módulo `GraphicComplements` y en común a los selectores de opciones, a un módulo `optionsSelectors.ts`.
- Creo la clase `fetchParamsBuilder`, que permite obtener los query params a usar al traer las series en una API call, en base a una URL y el estado del componente en cierto momento.
- Agrego funciones auxiliares para obtener parámetros de URLs, usados para determinar la opción elegida incialmente de cada selector del gráfico; así como funciones que determinan cuál es el tipo de gráfico elegido inicialmente según una prop y las ids involucradas.
- Altero el `components.html` para que las clases `row` no usen más altos relativos, sino que sean los mismos `div`s raíz los que setean su propia altura, mediante estilos inline.
- Cambio el nombre de la función `isHigherFrequency` a `isLowerFrequency`, ya que lo que se busca es la menor frecuencia común a todas las series involucradas, no la mayor.

#### Cómo probarlo
Ejecutar `make components-watch`, para poder así abrir el archivo `components.html` en el browser, e ir probando cómo se renderizan los selectores respecto al gráfico y su ancho (en base al ancho que tenga el `div` sobre el cual se renderice el componente exportable), así como también el comportamiento y re-rendereo del gráfico según se elijan las opciones. Emplear los nuevos parámetros opcionales, en combinación con los ya existentes.

Closes #294 