### PR TITLE
592 - Corrijo valores de parametro last menores a 1 

### DIFF
--- a/src/helpers/graphic/chartExtremes.ts
+++ b/src/helpers/graphic/chartExtremes.ts
@@ -2,6 +2,8 @@ import { IDataPoint } from "../../api/DataPoint";
 import { ISerie } from "../../api/Serie";
 import { IChartExtremeProps } from "../../components/viewpage/graphic/Graphic";
 
+const MIN_LAST_OFFSET = 1;
+
 export function chartExtremes(series: ISerie[], dateRange: { start: string; end: string; }, last?: number): IChartExtremeProps {
 
     if (series.length === 0) {
@@ -19,7 +21,8 @@ export function chartExtremes(series: ISerie[], dateRange: { start: string; end:
         maxDataIndex = firstSerieData.length - 1;
     }
     if (last !== undefined) {
-        minDataIndex = Math.max(minDataIndex, maxDataIndex - last + 1);
+        const lastOffset = Math.max(MIN_LAST_OFFSET, last)
+        minDataIndex = Math.max(minDataIndex, maxDataIndex - lastOffset + 1);
     }
 
     const min = new Date(firstSerieData[minDataIndex].date).getTime();

--- a/src/tests/components/helpers/ChartExtremes.test.ts
+++ b/src/tests/components/helpers/ChartExtremes.test.ts
@@ -92,6 +92,16 @@ describe("Tests for obtainment of a chart's time axis extremes", () => {
             last = 20;
             evaluateTimestamps(dateRange.start, dateRange.end, last);
         });
+        it("If the amount of last values asked for is only one, just the last value of the interval is returned", () => {
+            last = 1;
+            evaluateTimestamps(dateRange.end, dateRange.end, last);
+        });
+        it("Asking for a negative amount of last values is the same than asking for the last itself", () => {
+            const lastOneValueExtremes = chartExtremes(series, dateRange, 1);
+            const lastNegativeExtremes = chartExtremes(series, dateRange, -2)
+            expect(lastOneValueExtremes.min).toEqual(lastNegativeExtremes.min);
+            expect(lastOneValueExtremes.max).toEqual(lastNegativeExtremes.max);
+        })
         
     })
 


### PR DESCRIPTION
#### Contexto
Resuelvo el comportamiento erróneo que tenía el componente exportable `Graphic` cuando se seteaban valores menores a 1 en su parámetro opcional `last`, de modo que ahora el uso de esos valores implique que la región ampliada inicial del gráfico comprenda sólo el último valor (lo mismo que ocurriría al setear `last: 1`. Para ello:
- Cambio la lógica para conseguir los extremos de la región ampliada, usando el mayor valor entre 1 y `last` para descontar del extremo final.
- Creo casos de prueba para el valor de borde (1) y valores menores.

#### Cómo probarlo
Ejecutando `make components-watch` y tocando el `components.html` de `public/`, usar valores menores a 1 para el parámetro `last` del exportable `Graphic`, y verificar que el comportamiento sea igual a un `last: 1`: hacer zoom sólo en el último valor.

Closes #592 