### PR TITLE
473 - Agrego selectores CSS y formato de impresion para selector de fecha de graficos

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -38,6 +38,10 @@
   width: 100%;
 }
 
+.exportable-graph > div > div:first-child {
+  z-index: auto !important;
+}
+
 .exportable-graph div:not(.g-pickers-container, [data-highcharts-chart]) { /* Force highcharts to set the height from container */
   height: 100%;
 }
@@ -72,8 +76,8 @@
   font-size: 13px;
 }
 
-div.highcharts-container:hover {
-  z-index: 1 !important;
+div.highcharts-container {
+  z-index: auto !important;
 }
 
 /* Tooltip styles for iframing or third-party pages */
@@ -199,10 +203,31 @@ div.highcharts-tooltip-box span table tbody tr td span.tooltip-value {
   overflow: hidden;
 }
 
+.highcharts-label.highcharts-range-input {
+  color: rgb(104, 104, 104);
+  letter-spacing: normal;
+  text-rendering: optimizeLegibility;
+  word-spacing: 0px;
+  z-index: 1;
+}
+
+.highcharts-range-selector {
+  border-color: rgb(192, 192, 192);
+  color: rgb(104, 104, 104);
+  letter-spacing: normal;
+  line-height: 14px;
+  text-rendering: optimizeLegibility;
+  vertical-align: baseline;
+  word-spacing: 0px;
+}
+
 .highcharts-range-selector:focus {
-  top: 75px !important;
-  width: 95px !important;
-  height: 25px !important;
+  top: 12px !important;
+  width: 90px !important;
+  height: 20px !important;
+  margin-left: 2px;
+  border: 0px !important;
+  z-index: 2;
 }
 
 div.g-pickers-container {

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -289,7 +289,7 @@
 }
 
 .highcharts-range-selector:focus {
-  top: 75px !important;
+  top: 9px !important;
   width: 95px !important;
   height: 25px !important;
 }

--- a/src/helpers/graphic/chartConfigBuilder.ts
+++ b/src/helpers/graphic/chartConfigBuilder.ts
@@ -179,6 +179,7 @@ export class ChartConfigBuilder {
                 { count: 1, text: '1y', type: 'year' },
                 { text: 'Todo', type: 'all' }
             ],
+            inputDateFormat: dateFormatByPeriodicity(this.props.series),
             inputEditDateFormat: dateFormatByPeriodicity(this.props.series),
             inputDateParser: {}
         }


### PR DESCRIPTION
#### Contexto
Agrego a las hojas de estilos `components.css` y `main.css` los selectores y propiedades necesarios para que los inputs de los selectores de rango de fechas de los gráficos (tanto del exportable `Graphic` como del empleado en el `Explorer` se ubiquen correctamente y se superpongan al placeholder que tiene su valor actual.
A su vez, agrego el formato cronológico usado en los placeholder de rango de fechas para que se adecúe a la frecuencia de las series involucradas.

#### Cómo probarlo
Ejecutando `make watch`, o bien `make watch-components`, probar que la elección de rangos de fechas en los gráficos ande bien, respete los formatos y no tenga problemas de estilos.

Closes #473 