### PR TITLE
599 - Componente CardRow

### DIFF
--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -218,6 +218,11 @@ div.g-pickers-container div.g-picker {
 
 /*---Fin Graphic---*/
 
+div.r-row {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 40px;
+}
 
 /*---Card---*/
 

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -218,12 +218,6 @@ div.g-pickers-container div.g-picker {
 
 /*---Fin Graphic---*/
 
-div.r-row {
-  display: flex;
-  justify-content: space-around;
-  margin-bottom: 40px;
-}
-
 /*---Card---*/
 
 /*-General Styles-*/
@@ -965,6 +959,16 @@ main a[href^="https://"][target^="_blank"]::after {
 }
 
 /*---Fin PreviewCard---*/
+
+/*---CardRow---*/
+
+div.r-row {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 40px;
+}
+
+/*---Fin CardRow---*/
 
 /*---Iconos---*/
 

--- a/src/api/Serie.ts
+++ b/src/api/Serie.ts
@@ -224,6 +224,7 @@ export default class Serie implements ISerie {
             units: this.units,
         };
     }
+
 }
 
 function emptyDatasetThemes(): IDataSetTheme[] {

--- a/src/components/exportable/CardExportable.tsx
+++ b/src/components/exportable/CardExportable.tsx
@@ -71,7 +71,6 @@ export default class CardExportable extends React.Component<ICardExportableProps
 
         return {
             cardOptions: {
-                apiBaseUrl: this.props.apiBaseUrl,
                 chartType: this.props.chartType,
                 collapse: this.props.collapse,
                 color: this.props.color,

--- a/src/components/exportable/CardRowExportable.tsx
+++ b/src/components/exportable/CardRowExportable.tsx
@@ -4,7 +4,7 @@ import SerieApi, { METADATA } from "../../api/SerieApi";
 import { ApiClient } from "../../api/ApiClient";
 import { getAPIDefaultURI } from "../../helpers/previewCard/linkGenerators";
 import QueryParams from "../../api/QueryParams";
-import { getCardColor } from "../style/Colors/Color";
+import { getCardColor, DEFAULT_COLORS } from "../style/Colors/Color";
 import { DEFAULT_DECIMALS_BILLION, DEFAULT_DECIMALS_MILLION } from "../../helpers/common/LocaleValueFormatter";
 import { ICardRowExportableConfig } from "../../indexCardRow";
 import FullCard from "../exportable_card/FullCard";
@@ -140,10 +140,15 @@ export default class CardRowExportable extends React.Component<ICardRowExportabl
             }
             this.colors = this.props.color;
         }
-        else {
+        else if (this.props.color !== undefined) {
             const color = getCardColor(this.props.color);
             for (let step = 0; step < this.idsAmount; step++) {
                 this.colors.push(color);
+            }
+        }
+        else {
+            for (let step = 0; step < this.idsAmount; step++) {
+                this.colors.push(DEFAULT_COLORS[step % DEFAULT_COLORS.length].code)
             }
         }
 

--- a/src/components/exportable/CardRowExportable.tsx
+++ b/src/components/exportable/CardRowExportable.tsx
@@ -1,0 +1,245 @@
+import * as React from "react";
+import { ISerie } from "../../api/Serie";
+import SerieApi, { METADATA } from "../../api/SerieApi";
+import { ApiClient } from "../../api/ApiClient";
+import { getAPIDefaultURI } from "../../helpers/previewCard/linkGenerators";
+import QueryParams from "../../api/QueryParams";
+import { getCardColor } from "../style/Colors/Color";
+import { DEFAULT_DECIMALS_BILLION, DEFAULT_DECIMALS_MILLION } from "../../helpers/common/LocaleValueFormatter";
+import { ICardRowExportableConfig } from "../../indexCardRow";
+
+export type ICardRowExportableProps = ICardRowExportableConfig;
+
+interface ICardRowExportableState {
+    series: ISerie[] | null;
+}
+
+export default class CardRowExportable extends React.Component<ICardRowExportableProps, ICardRowExportableState> {
+
+    private seriesApi: SerieApi;
+    private idsAmount: number;
+
+    private colors: string[];
+    private decimals: number[];
+    private decimalsBillion: number[];
+    private decimalsMillion: number[];
+    private explicitSigns: boolean[];
+    private numbersAbbreviate: boolean[];
+    private sources: string[];
+    private titles: string[];
+    private units: string[];
+
+    public constructor(props: ICardRowExportableProps) {
+        super(props);
+
+        this.seriesApi = new SerieApi(new ApiClient(props.apiBaseUrl || getAPIDefaultURI(), 'ts-components-row'));
+        this.idsAmount = this.props.ids.length;
+
+        this.colors = [];
+        this.decimals = [];
+        this.decimalsBillion = [];
+        this.decimalsMillion = [];
+        this.explicitSigns = [];
+        this.numbersAbbreviate = [];
+        this.sources = [];
+        this.titles = [];
+        this.units = [];
+
+        this.checkColor();
+        this.checkDecimals();
+        this.checkDecimalsBillion();
+        this.checkDecimalsMillion();
+        this.checkExplicitSign();
+        this.checkNumbersAbbreviate();
+        this.checkSource();
+        this.checkTitle();
+        this.checkUnits();
+
+        this.state = {
+            series: null
+        }
+    }
+
+    public componentDidMount() {
+        const params = new QueryParams(this.props.ids);
+        if(this.props.collapse !== undefined) {
+            params.setCollapse(this.props.collapse);
+        }
+        params.setLast(5000);
+        params.setMetadata(METADATA.FULL);
+        this.fetchSeries(params);
+    }
+
+    public render() {
+
+        if (!this.state.series) { return null; }
+
+        return(
+            <div>
+                {for (let step = 0; step < this.idsAmount; step++) {
+                this.titles.push(this.props.title);
+                }}
+            </div>
+        );
+
+    }
+
+    private checkColor() {
+
+        if (Array.isArray(this.props.color)) {
+            if(this.props.color.length !== this.props.ids.length) {
+                throw new Error(`El parametro color debe ser un array de igual longitud al parametro ids, o bien un string solo`);
+            }
+            this.colors = this.props.color;
+        }
+        else {
+            const color = getCardColor(this.props.color);
+            for (let step = 0; step < this.idsAmount; step++) {
+                this.colors.push(color);
+            }
+        }
+
+    }
+
+    private checkDecimals() {
+
+        if (Array.isArray(this.props.decimals)) {
+            if(this.props.decimals.length !== this.props.ids.length) {
+                throw new Error(`El parametro decimals debe ser un array de igual longitud al parametro ids, o bien un numero solo`);
+            }
+            this.decimals = this.props.decimals;
+        }
+        else if (this.props.decimals !== undefined) {
+            for (let step = 0; step < this.idsAmount; step++) {
+                this.decimals.push(Math.max(this.props.decimals, 0));
+            }
+        }
+
+    }
+
+    private checkDecimalsBillion() {
+
+        if (Array.isArray(this.props.decimalsBillion)) {
+            if(this.props.decimalsBillion.length !== this.props.ids.length) {
+                throw new Error(`El parametro decimalsBillion debe ser un array de igual longitud al parametro ids, o bien un numero solo`);
+            }
+            this.decimalsBillion = this.props.decimalsBillion;
+        }
+        else if (this.props.decimalsBillion) {
+            const decimalsBillion = this.props.decimalsBillion !== undefined && this.props.decimalsBillion >= 0 ? this.props.decimalsBillion : DEFAULT_DECIMALS_BILLION;
+            for (let step = 0; step < this.idsAmount; step++) {
+                this.decimalsBillion.push(decimalsBillion);
+            }
+        }
+
+    }
+
+    private checkDecimalsMillion() {
+
+        if (Array.isArray(this.props.decimalsMillion)) {
+            if(this.props.decimalsMillion.length !== this.props.ids.length) {
+                throw new Error(`El parametro decimalsMillion debe ser un array de igual longitud al parametro ids, o bien un numero solo`);
+            }
+            this.decimalsMillion = this.props.decimalsMillion;
+        }
+        else if (this.props.decimalsMillion) {
+            const decimalsMillion = this.props.decimalsMillion !== undefined && this.props.decimalsMillion >= 0 ? this.props.decimalsMillion : DEFAULT_DECIMALS_MILLION;
+            for (let step = 0; step < this.idsAmount; step++) {
+                this.decimalsMillion.push(decimalsMillion);
+            }
+        }
+
+    }
+
+    private checkExplicitSign() {
+
+        if (Array.isArray(this.props.explicitSign)) {
+            if(this.props.explicitSign.length !== this.props.ids.length) {
+                throw new Error(`El parametro explicitSign debe ser un array de igual longitud al parametro ids, o bien un booleano solo`);
+            }
+            this.explicitSigns = this.props.explicitSign;
+        }
+        else {
+            const explicitSign = this.props.explicitSign !== undefined ? this.props.explicitSign : false;
+            for (let step = 0; step < this.idsAmount; step++) {
+                this.explicitSigns.push(explicitSign);
+            }
+        }
+
+    }
+
+    private checkNumbersAbbreviate() {
+
+        if (Array.isArray(this.props.numbersAbbreviate)) {
+            if(this.props.numbersAbbreviate.length !== this.props.ids.length) {
+                throw new Error(`El parametro numbersAbbreviate debe ser un array de igual longitud al parametro ids, o bien un booleano solo`);
+            }
+            this.numbersAbbreviate = this.props.numbersAbbreviate;
+        }
+        else {
+            const numbersAbbreviate = this.props.numbersAbbreviate !== undefined ? this.props.numbersAbbreviate : true;
+            for (let step = 0; step < this.idsAmount; step++) {
+                this.numbersAbbreviate.push(numbersAbbreviate);
+            }
+        }
+
+    }
+
+    private checkSource() {
+
+        if (Array.isArray(this.props.source)) {
+            if(this.props.source.length !== this.props.ids.length) {
+                throw new Error(`El parametro source debe ser un array de igual longitud al parametro ids, o bien un string solo`);
+            }
+            this.sources = this.props.source;
+        }
+        else {
+            for (let step = 0; step < this.idsAmount; step++) {
+                this.sources.push(this.props.source);
+            }
+        }
+
+    }
+
+    private checkTitle() {
+
+        if (Array.isArray(this.props.title)) {
+            if(this.props.title.length !== this.props.ids.length) {
+                throw new Error(`El parametro title debe ser un array de igual longitud al parametro ids, o bien un string solo`);
+            }
+            this.titles = this.props.title;
+        }
+        else {
+            for (let step = 0; step < this.idsAmount; step++) {
+                this.titles.push(this.props.title);
+            }
+        }
+
+    }
+
+    private checkUnits() {
+
+        if (Array.isArray(this.props.units)) {
+            if(this.props.units.length !== this.props.ids.length) {
+                throw new Error(`El parametro units debe ser un array de igual longitud al parametro ids, o bien un string solo`);
+            }
+            this.units = this.props.units;
+        }
+        else {
+            for (let step = 0; step < this.idsAmount; step++) {
+                this.units.push(this.props.units);
+            }
+        }
+
+    }
+
+    private fetchSeries(params: QueryParams) {
+        this.seriesApi.fetchSeries(params)
+            .then((series: ISerie[]) => {
+                this.setState({
+                    series
+                })
+            })
+    }
+
+}

--- a/src/components/exportable_card/FullCard.tsx
+++ b/src/components/exportable_card/FullCard.tsx
@@ -13,6 +13,7 @@ import FullCardValue from '../style/exportable_card/FullCardValue';
 import FullCardChart from './FullCardChart';
 import FullCardLinks from './FullCardLinks';
 import { buildAbbreviationProps } from '../../helpers/common/numberAbbreviation';
+import { lastNonNullPoint } from '../../helpers/common/serieDataHandling';
 
 
 interface IFullCardProps {
@@ -29,7 +30,7 @@ export default (props: IFullCardProps) => {
         downloadUrl: props.downloadUrl,
         serieId: getFullSerieId(props.serie)
     };
-    const value = props.serie.data[props.serie.data.length-1].value;
+    const value = lastNonNullPoint(props.serie.data).value;
     const abbreviationProps = buildAbbreviationProps(options.numbersAbbreviate, options.decimalsBillion, options.decimalsMillion);
     const formatterConfig: ILocaleValueFormatterConfig = {
         code: options.locale,

--- a/src/components/style/Colors/Color.ts
+++ b/src/components/style/Colors/Color.ts
@@ -21,7 +21,7 @@ const COLORS = {
 const hexaColorRegex = /^#[0-9a-f]{6}$/i;
 
 export const DEFAULT_CARD_COLOR = "#0072BB";
-const DEFAULT_COLORS = (Object as any).values(COLORS);
+export const DEFAULT_COLORS = (Object as any).values(COLORS);
 
 export default COLORS;
 

--- a/src/helpers/common/dateFunctions.ts
+++ b/src/helpers/common/dateFunctions.ts
@@ -3,6 +3,7 @@ import 'moment/locale/es';
 import { ISerie } from "../../api/Serie";
 import { PERIODICITY_LANG } from "../../api/utils/periodicityManager";
 import { capitalize } from "./commonFunctions";
+import { lastNonNullPoint } from "./serieDataHandling";
 
 export function timestamp(date: string): number {
     return new Date(date).getTime()
@@ -99,6 +100,6 @@ export function shortLocaleDate(format: string, dateString: string) {
 export function lastSerieDate(serie: ISerie): string {
 
     const langFrequency = serie.frequency !== undefined ? PERIODICITY_LANG[serie.frequency] : serie.accrualPeriodicity;
-    return fullLocaleDate(langFrequency, serie.data[serie.data.length-1].date);
+    return fullLocaleDate(langFrequency, lastNonNullPoint(serie.data).date);
 
 }

--- a/src/helpers/common/serieDataHandling.ts
+++ b/src/helpers/common/serieDataHandling.ts
@@ -1,0 +1,13 @@
+import { IDataPoint } from "../../api/DataPoint";
+
+export function lastNonNullPoint(datapoints: IDataPoint[]): IDataPoint {
+
+    const valuesAmount = datapoints.length;
+    for (let i = valuesAmount - 1; i >= 0; i--) {
+        if(datapoints[i].value !== null) {
+            return datapoints[i];
+        }
+    }
+    return datapoints[0];
+
+}

--- a/src/indexCardRow.tsx
+++ b/src/indexCardRow.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import CardRowExportable from "./components/exportable/CardRowExportable";
+
+export interface ICardRowExportableConfig {
+    apiBaseUrl?: string;
+    collapse?: string;
+    color: string[] | string;
+    decimals?: number[] | number;
+    decimalsBillion?: number[] | number;
+    decimalsMillion?: number[] | number;
+    explicitSign?: boolean[] | boolean;
+    hasChart?: string;
+    hasColorBar?: boolean;
+    hasFrame?: boolean;
+    ids: string[];
+    links?: string;
+    locale: string;
+    numbersAbbreviate?: boolean[] | boolean;
+    source: string[] | string;
+    title: string[] | string;
+    units: string[] | string;
+}
+
+export function render(selector: string, config: ICardRowExportableConfig) {
+
+    ReactDOM.render(
+        <CardRowExportable ids={config.ids}
+                           apiBaseUrl={config.apiBaseUrl}
+                           collapse={config.collapse}
+                           color={config.color}
+                           decimals={config.decimals}
+                           decimalsBillion={config.decimalsBillion}
+                           decimalsMillion={config.decimalsMillion}
+                           explicitSign={config.explicitSign}
+                           hasChart={config.hasChart}
+                           hasColorBar={config.hasColorBar}
+                           hasFrame={config.hasFrame}
+                           links={config.links}
+                           locale={config.locale}
+                           numbersAbbreviate={config.numbersAbbreviate}
+                           source={config.source}
+                           title={config.title}
+                           units={config.units} />,
+        document.getElementById(selector) as HTMLElement
+    )
+
+}

--- a/src/indexCardRow.tsx
+++ b/src/indexCardRow.tsx
@@ -5,16 +5,17 @@ import CardRowExportable from "./components/exportable/CardRowExportable";
 export interface ICardRowExportableConfig {
     apiBaseUrl?: string;
     collapse?: string;
-    color: string[] | string;
+    color?: string[] | string;
     decimals?: number[] | number;
     decimalsBillion?: number[] | number;
     decimalsMillion?: number[] | number;
     explicitSign?: boolean[] | boolean;
-    hasChart?: string;
+    hasChart: string;
     hasColorBar?: boolean;
     hasFrame?: boolean;
     ids: string[];
-    links?: string;
+    isPercentage?: boolean;
+    links: string;
     locale: string;
     numbersAbbreviate?: boolean[] | boolean;
     source: string[] | string;
@@ -33,11 +34,11 @@ export function render(selector: string, config: ICardRowExportableConfig) {
                            decimalsBillion={config.decimalsBillion}
                            decimalsMillion={config.decimalsMillion}
                            explicitSign={config.explicitSign}
-                           hasChart={config.hasChart}
+                           hasChart={config.hasChart || 'small'}
                            hasColorBar={config.hasColorBar}
                            hasFrame={config.hasFrame}
-                           links={config.links}
-                           locale={config.locale}
+                           links={config.links || 'full'}
+                           locale={config.locale || 'AR'}
                            numbersAbbreviate={config.numbersAbbreviate}
                            source={config.source}
                            title={config.title}

--- a/src/indexComponents.tsx
+++ b/src/indexComponents.tsx
@@ -1,8 +1,10 @@
 import * as Card from './indexCard';
 import * as Graphic from './indexGraphic';
 import * as PreviewCard from './indexPreviewCard';
+import * as CardRow from './indexCardRow';
 
 
 export { Graphic };
 export { Card };
 export { PreviewCard };
+export { CardRow };

--- a/src/tests/components/helpers/SerieDataHandling.test.ts
+++ b/src/tests/components/helpers/SerieDataHandling.test.ts
@@ -1,0 +1,46 @@
+import { IDataPoint } from "../../../api/DataPoint"
+import { lastNonNullPoint } from "../../../helpers/common/serieDataHandling";
+
+describe("Obtainment of the last non-null-valued DataPoint from an array", () => {
+
+    let points: IDataPoint[];
+    let desiredPoint: IDataPoint;
+    
+    it("If the very last point of the array has a non-null value, it is returned", () => {
+        points = [
+            { date: '2014-03-30', value: 2 },
+            { date: '2014-11-27', value: 1 },
+            { date: '2015-05-07', value: 1 },
+            { date: '2017-05-14', value: 3 },
+            { date: '2018-03-14', value: 2 },
+            { date: '2018-12-09', value: 3 },
+            { date: '2019-10-22', value: 2 }
+        ];
+        desiredPoint = lastNonNullPoint(points);
+        expect(desiredPoint.date).toEqual('2019-10-22');
+        expect(desiredPoint.value).toBe(2);
+    });
+    it("The non-null-valued point of the array with the greatest index will be returned", () => {
+        points = [
+            { date: '1988-10-01', value: null },
+            { date: '1988-11-01', value: 0 },
+            { date: '1988-12-01', value: 25 },
+            { date: '1989-01-01', value: null },
+            { date: '1989-02-01', value: null }
+        ];
+        desiredPoint = lastNonNullPoint(points);
+        expect(desiredPoint.date).toEqual('1988-12-01');
+        expect(desiredPoint.value).toBe(25);
+    });
+    it("If every point in the array is null-valued, the first one is returned", () => {
+        points = [
+            { date: '2004-01-01', value: null },
+            { date: '2005-01-01', value: null },
+            { date: '2006-01-01', value: null }
+        ];
+        desiredPoint = lastNonNullPoint(points);
+        expect(desiredPoint.date).toEqual('2004-01-01');
+        expect(desiredPoint.value).toBeNull();
+    });
+
+})


### PR DESCRIPTION
#### Contexto
Agrego un nuevo componente exportable `CardRow`, el cual permite instanciar una o varias filas de hasta cuatro `Card`s, según con cuantas series se quiera trabajar. El componente es un atajo para poder renderizar varias `Card` de una sola llamada a `TSComponents.render`, distribuyéndolas equiespaciadamente en varias filas, y haciendo uso de una única API call. Los parámetros del componente tienen funcionalidad análoga a los usados en el componente `Card`. Los parámetros de valor singular son:
- `apiBaseUrl`: La URL de la API a la cual pedirle los datos de las series.
- `collapse`: La frecuencia por la cual agregar los valores de todas las series involucradas (debe ser menor, es decir con mayor intervalo de tiempo entre sus puntos, a las nativas de todas ellas).
- `hasColorBar`: Un booleano que indica si debe mostrarse o no la pestaña de color en la parte superior de las tarjetas.
- `hasFrame`: Un booleano que indica si las tarjetas deben tener bordes y fondo, o no.
- `isPercentage`: Un booleano que indica si los valores empleados en las tarjetas, obtenidos en la API call, deben ser tratados como porcentajes o tal como los devuelve la API.
- `links`: Un string que permite elegir qué tipo de menú inferior de enlaces mostrar en las tarjetas: nada, todas las opciones, o sólo el desplegable de _Enlaces_.
- `locale`: Un string que permite elegir qué locale usar para los formateos de texto.

A su vez, los parámetros que pueden ser un valor singular o un array de valores son:
- `ids`: El único obligatorio, un array de strings con los ids (puros o compuestos) de las series a pedir a la API.
- `color`: Un string con un valor hexadecimal para usar como color de borde y número en todas las tarjetas; o bien un array de strings con tantos elementos como `ids`, que permite elegir un color para cada tarjeta, apareando por índice entre ambos arrays.
- `decimals`: Un numérico o array de numéricos, que permite elegir cuántos decimales usar en los valores de todas (o cada una de, apareando por índice) las tarjetas, para valores no abreviados.
- `decimalsBillion`: Un numérico o array de numéricos, que permite elegir cuántos decimales usar en los valores de todas (o cada una de, apareando por índice) las tarjetas, para valores abreviados del orden del billón.
- `decimalsMillion`: Un numérico o array de numéricos, que permite elegir cuántos decimales usar en los valores de todas (o cada una de, apareando por índice) las tarjetas, para valores abreviados del orden de las decenas de millones.
- `explicitSign`: Un booleano o array de booleanos, que permite elegir si forzar la presencia de un prefijo de signo en todas (o cada una de, apareando por índice) las tarjetas.
- `numbersAbbreviate`: Un booleano o array de booleanos, que permite elegir si abreviar los números muy grandes en todas (o cada una de, apareando por índice) las tarjetas.
- `source`: Un string o array de strings, que permite elegir el texto a mostrar como fuente en todas (o cada una de, apareando por índice) las tarjetas.
- `title`: Un string o array de strings, que permite elegir el texto a mostrar como título en todas (o cada una de, apareando por índice) las tarjetas.
- `units`: Un string o array de strings, que permite elegir el texto a mostrar como unidades en todas (o cada una de, apareando por índice) las tarjetas.

Internamente, el componente `CardRow` no es más que un wrapper que ejecuta una sóla API call (tal como lo hace el `CardExportable`), obtiene los datos de las series involucradas y la configuración de sus tarjetas representativas, y dispone tantas `Card`s como series en filas de hasta 4 tarjetas, equiespaciándolas. Al instanciarse, crea arrays de configuraciones para cada parámetro, usando los valores de los mismos (si fueron especificados en el HTML), o bien tomando valores por defecto; también, comprueba que dichos parámetros, en caso de ser arrays, tengan tantos valores como el array de `ids`.
A su vez, desarrollé una función `lastNonNullPoint` que permite obtener el `IDataPoint` de `value` no nulo y mayor índice y dentro de un array, para que toda `Card` (independiente o en un `CardRow`) muestre el último valor no nulo de su serie.

#### Cómo probarlo
Ejecutar `make components-watch` y editar el archivo watcheable `components.html`, rendereando componentes `CardRow` y jugando con los valores default de sus parámetros opcionales, o bien seteándolos como valores únicos y/o arrays de valores (en aquellos que lo permiten).

Closes #599 